### PR TITLE
Lint cleanup: prettier formatting + stale eslint-disable directives

### DIFF
--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -19,7 +19,7 @@ services:
     volumes:
       - pg_data:/var/lib/postgresql/data
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -42,7 +42,7 @@ services:
     depends_on:
       postgres: { condition: service_healthy }
     ports:
-      - '3000:3000'
+      - "3000:3000"
 
   worker:
     build: .

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,8 +15,7 @@ const noProcessEnv = {
     {
       object: "process",
       property: "env",
-      message:
-        "Read env via src/lib/server/config/env.ts (PITFALL P2 mitigation)",
+      message: "Read env via src/lib/server/config/env.ts (PITFALL P2 mitigation)",
     },
   ],
 };
@@ -85,12 +84,7 @@ export default [
   },
   // Tests legitimately read/manipulate process.env to drive env-config behavior.
   {
-    files: [
-      "tests/**/*.ts",
-      "tests/**/*.js",
-      "vitest.config.ts",
-      "tests/setup.ts",
-    ],
+    files: ["tests/**/*.ts", "tests/**/*.js", "vitest.config.ts", "tests/setup.ts"],
     rules: { "no-restricted-properties": "off" },
   },
   prettier,

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -6,7 +6,7 @@
 // global App namespace so every +page.server.ts and +layout.server.ts can
 // reference `locals.user` with full type safety.
 
-import type { UserDto, SessionDto } from '$lib/server/dto.js';
+import type { UserDto, SessionDto } from "$lib/server/dto.js";
 
 declare global {
   namespace App {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -10,9 +10,9 @@
 // access to the same call. Duplication is fine because Better Auth caches
 // the lookup per-request; the cost is one DB round-trip at most.
 
-import type { Handle } from '@sveltejs/kit';
-import { auth } from '$lib/auth.js';
-import { toUserDto, toSessionDto } from '$lib/server/dto.js';
+import type { Handle } from "@sveltejs/kit";
+import { auth } from "$lib/auth.js";
+import { toUserDto, toSessionDto } from "$lib/server/dto.js";
 
 export const handle: Handle = async ({ event, resolve }) => {
   const result = await auth.api.getSession({ headers: event.request.headers });
@@ -20,9 +20,7 @@ export const handle: Handle = async ({ event, resolve }) => {
     // toUserDto / toSessionDto strip secret-shaped fields and apply the
     // tenant-scope projection (Plan 05 / 07).
     event.locals.user = toUserDto(result.user as Parameters<typeof toUserDto>[0]);
-    event.locals.session = toSessionDto(
-      result.session as Parameters<typeof toSessionDto>[0],
-    );
+    event.locals.session = toSessionDto(result.session as Parameters<typeof toSessionDto>[0]);
   }
   return resolve(event);
 };

--- a/src/lib/server/audit.ts
+++ b/src/lib/server/audit.ts
@@ -50,9 +50,6 @@ export async function writeAudit(entry: AuditEntry): Promise<void> {
   } catch (err) {
     // Never let an audit failure break the user-facing request.
     // But log loudly — silent audit drops are a P19/P20 risk.
-    logger.error(
-      { err, action: entry.action, userId: entry.userId },
-      "audit write failed",
-    );
+    logger.error({ err, action: entry.action, userId: entry.userId }, "audit write failed");
   }
 }

--- a/src/lib/server/config/env.ts
+++ b/src/lib/server/config/env.ts
@@ -7,7 +7,6 @@
 // The `eslint-disable-next-line no-restricted-properties` comments below are
 // the ONLY approved exceptions to the project-wide ban on `process.env` access.
 
-// eslint-disable-next-line no-restricted-properties -- this module is the sole reader of process.env (D-24)
 import "dotenv/config";
 import { z } from "zod";
 
@@ -29,7 +28,6 @@ const RawSchema = z.object({
   KEK_CURRENT_VERSION: z.coerce.number().int().min(1).default(1),
 });
 
-// eslint-disable-next-line no-restricted-properties -- sole reader of process.env (D-24)
 const raw = RawSchema.parse(process.env);
 
 // Decode and length-validate every KEK version present in env.
@@ -40,9 +38,7 @@ const kekVersions = new Map<number, Buffer>();
 function decodeKek(b64: string, version: number): Buffer {
   const buf = Buffer.from(b64, "base64");
   if (buf.length !== 32) {
-    throw new Error(
-      `KEK v${version} must decode to 32 bytes (got ${buf.length})`,
-    );
+    throw new Error(`KEK v${version} must decode to 32 bytes (got ${buf.length})`);
   }
   return buf;
 }
@@ -51,7 +47,6 @@ kekVersions.set(1, decodeKek(raw.APP_KEK_BASE64, 1));
 
 // Optional rotation versions: APP_KEK_V2_BASE64 .. APP_KEK_V9_BASE64.
 for (let v = 2; v <= 9; v++) {
-  // eslint-disable-next-line no-restricted-properties -- sole reader of process.env (D-24)
   const b64 = process.env[`APP_KEK_V${v}_BASE64`];
   if (b64) kekVersions.set(v, decodeKek(b64, v));
 }
@@ -65,15 +60,12 @@ if (!kekVersions.has(raw.KEK_CURRENT_VERSION)) {
 // PITFALL P2 mitigation #4: scrub the original env vars after consumption so
 // the raw KEK material cannot leak via accidental console.log(process.env) or
 // debug dumps. The decoded buffers live in `kekVersions` Map only.
-// eslint-disable-next-line no-restricted-properties -- sole reader of process.env (D-24)
 delete process.env.APP_KEK_BASE64;
 for (let v = 2; v <= 9; v++) {
-  // eslint-disable-next-line no-restricted-properties -- sole reader of process.env (D-24)
   delete process.env[`APP_KEK_V${v}_BASE64`];
 }
 
-const TRUSTED_ORIGINS = raw.TRUSTED_ORIGINS
-  .split(",")
+const TRUSTED_ORIGINS = raw.TRUSTED_ORIGINS.split(",")
   .map((s) => s.trim())
   .filter(Boolean);
 

--- a/src/lib/server/crypto/envelope.ts
+++ b/src/lib/server/crypto/envelope.ts
@@ -19,10 +19,10 @@
 // on every call. The KEK is never cached at module scope — that would defeat
 // the env-scrub mitigation in env.ts and prevent rotation hot-swaps.
 
-import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
-import { env } from '../config/env.js';
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import { env } from "../config/env.js";
 
-const ALG = 'aes-256-gcm';
+const ALG = "aes-256-gcm";
 const NONCE_BYTES = 12;
 const TAG_BYTES = 16;
 const KEK_BYTES = 32;
@@ -58,9 +58,7 @@ function loadKek(version: number): Buffer {
     throw new Error(`KEK v${version} not loaded (env.KEK_VERSIONS missing)`);
   }
   if (kek.length !== KEK_BYTES) {
-    throw new Error(
-      `KEK v${version} must be ${KEK_BYTES} bytes (got ${kek.length})`,
-    );
+    throw new Error(`KEK v${version} must be ${KEK_BYTES} bytes (got ${kek.length})`);
   }
   return kek;
 }
@@ -83,10 +81,7 @@ export function encryptSecret(plaintext: string): EncryptedSecret {
     // 1. Encrypt the user secret with the DEK.
     const secretIv = randomBytes(NONCE_BYTES);
     const c1 = createCipheriv(ALG, dek, secretIv);
-    const secretCt = Buffer.concat([
-      c1.update(plaintext, 'utf8'),
-      c1.final(),
-    ]);
+    const secretCt = Buffer.concat([c1.update(plaintext, "utf8"), c1.final()]);
     const secretTag = c1.getAuthTag();
     if (secretTag.length !== TAG_BYTES) {
       throw new Error(`unexpected GCM tag length ${secretTag.length}`);
@@ -140,7 +135,7 @@ export function decryptSecret(s: EncryptedSecret): string {
     // 2. Decrypt the secret with the DEK.
     const d2 = createDecipheriv(ALG, dek, s.secretIv);
     d2.setAuthTag(s.secretTag);
-    return Buffer.concat([d2.update(s.secretCt), d2.final()]).toString('utf8');
+    return Buffer.concat([d2.update(s.secretCt), d2.final()]).toString("utf8");
   } finally {
     dek.fill(0);
   }
@@ -158,10 +153,7 @@ export function decryptSecret(s: EncryptedSecret): string {
  * Throws on auth-tag mismatch during unwrap (corrupted row) or unknown KEK
  * version (rotation rehearsal will surface the operator drill defect early).
  */
-export function rotateDek(
-  s: EncryptedSecret,
-  newKekVersion: number,
-): EncryptedSecret {
+export function rotateDek(s: EncryptedSecret, newKekVersion: number): EncryptedSecret {
   // Step 1: unwrap with old KEK.
   const oldKek = loadKek(s.kekVersion);
   const d = createDecipheriv(ALG, oldKek, s.dekIv);

--- a/src/lib/server/db/schema/audit-log.ts
+++ b/src/lib/server/db/schema/audit-log.ts
@@ -37,18 +37,13 @@ export const auditLog = pgTable(
     // Sanitized; never includes other tenants' identifiers (P19). See file
     // header for the convention contract.
     metadata: jsonb("metadata"),
-    createdAt: timestamp("created_at", { withTimezone: true })
-      .notNull()
-      .defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => ({
     // Tenant-relative cursor: `(user_id, created_at)` covers list-my-audit
     // pagination without ever needing a global index that could leak cross-
     // tenant ordering (PITFALL P19).
     userIdx: index("audit_log_user_id_idx").on(t.userId),
-    userCreatedIdx: index("audit_log_user_id_created_at_idx").on(
-      t.userId,
-      t.createdAt,
-    ),
+    userCreatedIdx: index("audit_log_user_id_created_at_idx").on(t.userId, t.createdAt),
   }),
 );

--- a/src/lib/server/db/schema/auth.ts
+++ b/src/lib/server/db/schema/auth.ts
@@ -20,12 +20,8 @@ export const user = pgTable("user", {
   emailVerified: boolean("email_verified").notNull().default(false),
   name: text("name").notNull(),
   image: text("image"),
-  createdAt: timestamp("created_at", { withTimezone: true })
-    .notNull()
-    .defaultNow(),
-  updatedAt: timestamp("updated_at", { withTimezone: true })
-    .notNull()
-    .defaultNow(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
 export const session = pgTable("session", {
@@ -39,12 +35,8 @@ export const session = pgTable("session", {
   expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
   ipAddress: text("ip_address"),
   userAgent: text("user_agent"),
-  createdAt: timestamp("created_at", { withTimezone: true })
-    .notNull()
-    .defaultNow(),
-  updatedAt: timestamp("updated_at", { withTimezone: true })
-    .notNull()
-    .defaultNow(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
 export const account = pgTable("account", {
@@ -71,12 +63,8 @@ export const account = pgTable("account", {
   // Unused — we only ship Google OAuth in MVP (no email/password). Better
   // Auth's core schema reserves the column; we keep it for adapter parity.
   password: text("password"),
-  createdAt: timestamp("created_at", { withTimezone: true })
-    .notNull()
-    .defaultNow(),
-  updatedAt: timestamp("updated_at", { withTimezone: true })
-    .notNull()
-    .defaultNow(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
 export const verification = pgTable("verification", {

--- a/src/lib/server/http/app.ts
+++ b/src/lib/server/http/app.ts
@@ -12,20 +12,20 @@
 // Plan 05's `auth.handler` is the Better Auth web-standard handler that
 // receives a Request (Hono's c.req.raw) and returns a Response.
 
-import { Hono } from 'hono';
-import { secureHeaders } from 'hono/secure-headers';
-import { proxyTrust } from './middleware/proxy-trust.js';
-import { tenantScope } from './middleware/tenant.js';
-import { meRoutes } from './routes/me.js';
-import { auth } from '../../auth.js';
-import { migrationsApplied } from '../db/migrate.js';
-import { pool } from '../db/client.js';
-import { logger } from '../logger.js';
+import { Hono } from "hono";
+import { secureHeaders } from "hono/secure-headers";
+import { proxyTrust } from "./middleware/proxy-trust.js";
+import { tenantScope } from "./middleware/tenant.js";
+import { meRoutes } from "./routes/me.js";
+import { auth } from "../../auth.js";
+import { migrationsApplied } from "../db/migrate.js";
+import { pool } from "../db/client.js";
+import { logger } from "../logger.js";
 
 export type AppContext = {
   Variables: {
     clientIp: string;
-    clientProto: 'http' | 'https';
+    clientProto: "http" | "https";
     userId?: string;
     sessionId?: string;
   };
@@ -35,19 +35,19 @@ export function createApp(): Hono<AppContext> {
   const app = new Hono<AppContext>();
 
   // First: resolve client IP behind any proxy (Plan 01-06 Task 1).
-  app.use('*', proxyTrust);
+  app.use("*", proxyTrust);
 
   // Defense-in-depth headers (Open Question Q5).
   app.use(
-    '*',
+    "*",
     secureHeaders({
-      strictTransportSecurity: 'max-age=63072000; includeSubDomains',
+      strictTransportSecurity: "max-age=63072000; includeSubDomains",
       // SvelteKit's adapter sets the page CSP — leave Hono's CSP off so we
       // don't double-emit conflicting policies.
       contentSecurityPolicy: undefined,
-      xFrameOptions: 'DENY',
-      xContentTypeOptions: 'nosniff',
-      referrerPolicy: 'strict-origin-when-cross-origin',
+      xFrameOptions: "DENY",
+      xContentTypeOptions: "nosniff",
+      referrerPolicy: "strict-origin-when-cross-origin",
     }),
   );
 
@@ -55,38 +55,35 @@ export function createApp(): Hono<AppContext> {
   // "Health/ready endpoint authn — `/healthz` and `/readyz` are unauthenticated
   // by design (PRIV-01 explicitly excludes them from 'every endpoint refuses
   // anonymous')").
-  app.get('/healthz', (c) => c.text('ok'));
+  app.get("/healthz", (c) => c.text("ok"));
 
-  app.get('/readyz', async (c) => {
+  app.get("/readyz", async (c) => {
     if (!migrationsApplied.current) {
-      return c.json(
-        { ok: false, reason: 'migrations not yet applied' },
-        503,
-      );
+      return c.json({ ok: false, reason: "migrations not yet applied" }, 503);
     }
     try {
-      await pool.query('SELECT 1');
+      await pool.query("SELECT 1");
       return c.json({ ok: true });
     } catch (err) {
-      logger.warn({ err }, 'readyz db ping failed');
-      return c.json({ ok: false, reason: 'db unreachable' }, 503);
+      logger.warn({ err }, "readyz db ping failed");
+      return c.json({ ok: false, reason: "db unreachable" }, 503);
     }
   });
 
   // Better Auth mount (Plan 05). Handles login / callback / signout / getSession.
   // MUST be mounted BEFORE the /api/* tenant-scope guard so OAuth callbacks
   // (which arrive anonymously by definition) are not blocked.
-  app.on(['GET', 'POST'], '/api/auth/*', (c) => auth.handler(c.req.raw));
+  app.on(["GET", "POST"], "/api/auth/*", (c) => auth.handler(c.req.raw));
 
   // Tenant scope (Plan 07): every /api/* (except /api/auth/* above) requires
   // a valid Better Auth session. Anonymous requests get 401 + {error:'unauthorized'};
   // authenticated requests land on the route handler with c.var.userId and
   // c.var.sessionId set. Pattern 3 (404 not 403) is enforced one layer deeper
   // by service functions (see src/lib/server/services/errors.ts).
-  app.use('/api/*', tenantScope);
+  app.use("/api/*", tenantScope);
 
   // /api routes (Phase 1: just /api/me; Phase 2 adds /api/games, etc.).
-  app.route('/api', meRoutes);
+  app.route("/api", meRoutes);
 
   return app;
 }

--- a/src/lib/server/http/middleware/proxy-trust.ts
+++ b/src/lib/server/http/middleware/proxy-trust.ts
@@ -17,26 +17,26 @@
 // PT6: trusted source + X-Forwarded-Proto → respected (HSTS-relevant);
 //      untrusted source falls back to socket scheme.
 
-import { parse, parseCIDR, type IPv4, type IPv6 } from 'ipaddr.js';
-import type { MiddlewareHandler } from 'hono';
-import { env } from '../../config/env.js';
+import { parse, parseCIDR, type IPv4, type IPv6 } from "ipaddr.js";
+import type { MiddlewareHandler } from "hono";
+import { env } from "../../config/env.js";
 
 export interface CidrEntry {
   network: IPv4 | IPv6;
   bits: number;
-  kind: 'ipv4' | 'ipv6';
+  kind: "ipv4" | "ipv6";
 }
 
 export function parseCidrList(csv: string): CidrEntry[] {
   if (!csv.trim()) return [];
   const result: CidrEntry[] = [];
   for (const raw of csv
-    .split(',')
+    .split(",")
     .map((s) => s.trim())
     .filter(Boolean)) {
     try {
       const [network, bits] = parseCIDR(raw);
-      result.push({ network, bits, kind: network.kind() as 'ipv4' | 'ipv6' });
+      result.push({ network, bits, kind: network.kind() as "ipv4" | "ipv6" });
     } catch {
       throw new Error(`TRUSTED_PROXY_CIDR contains invalid CIDR: ${raw}`);
     }
@@ -53,10 +53,7 @@ export function isTrusted(ip: string): boolean {
     parsed = parse(ip);
     // Normalize IPv6 IPv4-mapped (::ffff:1.2.3.4) → IPv4 so a connection from
     // an IPv6-stack TCP socket carrying an IPv4 client still matches IPv4 CIDRs.
-    if (
-      parsed.kind() === 'ipv6' &&
-      (parsed as IPv6).isIPv4MappedAddress()
-    ) {
+    if (parsed.kind() === "ipv6" && (parsed as IPv6).isIPv4MappedAddress()) {
       parsed = (parsed as IPv6).toIPv4Address();
     }
   } catch {
@@ -65,34 +62,32 @@ export function isTrusted(ip: string): boolean {
   const kind = parsed.kind();
   return TRUSTED.some((entry) => {
     if (entry.kind !== kind) return false;
-    return parsed.match([entry.network, entry.bits] as Parameters<
-      typeof parsed.match
-    >[0]);
+    return parsed.match([entry.network, entry.bits] as Parameters<typeof parsed.match>[0]);
   });
 }
 
 export const proxyTrust: MiddlewareHandler<{
-  Variables: { clientIp: string; clientProto: 'http' | 'https' };
+  Variables: { clientIp: string; clientProto: "http" | "https" };
 }> = async (c, next) => {
   // Hono's Node adapter exposes the underlying IncomingMessage on c.env.incoming.
   // For tests using app.request(...), tests pass a synthetic socket via the
   // third argument's `incoming.socket` field.
-  const incoming = (c.env as { incoming?: { socket?: { remoteAddress?: string; encrypted?: boolean } } } | undefined)?.incoming;
-  const socketIp = incoming?.socket?.remoteAddress ?? '';
+  const incoming = (
+    c.env as { incoming?: { socket?: { remoteAddress?: string; encrypted?: boolean } } } | undefined
+  )?.incoming;
+  const socketIp = incoming?.socket?.remoteAddress ?? "";
   let clientIp = socketIp;
-  let clientProto: 'http' | 'https' = incoming?.socket?.encrypted
-    ? 'https'
-    : 'http';
+  let clientProto: "http" | "https" = incoming?.socket?.encrypted ? "https" : "http";
 
   if (TRUSTED.length > 0 && isTrusted(socketIp)) {
     // CF-Connecting-IP takes precedence if proxy is Cloudflare (PT4).
-    const cf = c.req.header('cf-connecting-ip');
+    const cf = c.req.header("cf-connecting-ip");
     if (cf) {
       clientIp = cf;
     } else {
-      const xff = c.req.header('x-forwarded-for') ?? '';
+      const xff = c.req.header("x-forwarded-for") ?? "";
       const hops = xff
-        .split(',')
+        .split(",")
         .map((s) => s.trim())
         .filter(Boolean);
       // Walk from right: drop trusted hops, first untrusted is the real client (PT2).
@@ -104,8 +99,8 @@ export const proxyTrust: MiddlewareHandler<{
       }
     }
     // PT6: respect X-Forwarded-Proto from trusted source (HSTS-relevant).
-    const xfp = c.req.header('x-forwarded-proto');
-    if (xfp === 'https' || xfp === 'http') {
+    const xfp = c.req.header("x-forwarded-proto");
+    if (xfp === "https" || xfp === "http") {
       clientProto = xfp;
     }
   }
@@ -113,7 +108,7 @@ export const proxyTrust: MiddlewareHandler<{
   // X-Forwarded-Proto entirely (CVE-2026-27700; PT3, PT5 reject XFF/CF; PT6
   // falls back to socket scheme).
 
-  c.set('clientIp', clientIp);
-  c.set('clientProto', clientProto);
+  c.set("clientIp", clientIp);
+  c.set("clientProto", clientProto);
   return next();
 };

--- a/src/lib/server/http/middleware/tenant.ts
+++ b/src/lib/server/http/middleware/tenant.ts
@@ -19,22 +19,19 @@
 // established here by convention (every service function takes `userId` first;
 // the row is filtered by it; missing or other-tenant rows throw NotFoundError).
 
-import type { MiddlewareHandler } from 'hono';
-import { auth } from '../../../auth.js';
-import { logger } from '../../logger.js';
+import type { MiddlewareHandler } from "hono";
+import { auth } from "../../../auth.js";
+import { logger } from "../../logger.js";
 
 export const tenantScope: MiddlewareHandler<{
   Variables: { userId: string; sessionId: string };
 }> = async (c, next) => {
   const result = await auth.api.getSession({ headers: c.req.raw.headers });
   if (!result) {
-    return c.json({ error: 'unauthorized' }, 401);
+    return c.json({ error: "unauthorized" }, 401);
   }
-  c.set('userId', result.user.id);
-  c.set('sessionId', result.session.id);
-  logger.debug(
-    { userId: result.user.id, route: c.req.path },
-    'tenant-scope: authed',
-  );
+  c.set("userId", result.user.id);
+  c.set("sessionId", result.session.id);
+  logger.debug({ userId: result.user.id, route: c.req.path }, "tenant-scope: authed");
   return next();
 };

--- a/src/lib/server/http/routes/me.ts
+++ b/src/lib/server/http/routes/me.ts
@@ -29,10 +29,7 @@ meRoutes.get("/me", async (c) => {
       return c.json({ error: "not_found" }, 404);
     }
     if (err instanceof AppError) {
-      return c.json(
-        { error: err.code },
-        err.status as 400 | 401 | 403 | 404 | 500,
-      );
+      return c.json({ error: err.code }, err.status as 400 | 401 | 403 | 404 | 500);
     }
     logger.error({ err, userId }, "/api/me unhandled error");
     return c.json({ error: "internal_server_error" }, 500);

--- a/src/lib/server/queue-client.ts
+++ b/src/lib/server/queue-client.ts
@@ -18,10 +18,10 @@
 //     hard-stops. We pair it with `pool.end()` in the role entrypoints so
 //     both pg-boss' own pool AND Drizzle's app pool drain on SIGTERM.
 
-import PgBoss from 'pg-boss';
-import { env } from './config/env.js';
-import { logger } from './logger.js';
-import { declareAllQueues } from './queues.js';
+import PgBoss from "pg-boss";
+import { env } from "./config/env.js";
+import { logger } from "./logger.js";
+import { declareAllQueues } from "./queues.js";
 
 /**
  * Create + start a pg-boss instance with all Phase 1 queues declared.
@@ -50,8 +50,8 @@ export async function createBoss(): Promise<PgBoss> {
     // (Plan 03's runMigrations()), which target the public schema.
   });
 
-  boss.on('error', (err) => {
-    logger.error({ err }, 'pg-boss error');
+  boss.on("error", (err) => {
+    logger.error({ err }, "pg-boss error");
   });
 
   await boss.start();
@@ -77,7 +77,7 @@ export async function createBoss(): Promise<PgBoss> {
  *                       expect SIGTERM→exit within their own grace period.
  */
 export async function stopBoss(boss: PgBoss): Promise<void> {
-  logger.info('pg-boss draining');
+  logger.info("pg-boss draining");
   await boss.stop({ wait: true, graceful: true, timeout: 60_000 });
-  logger.info('pg-boss stopped');
+  logger.info("pg-boss stopped");
 }

--- a/src/lib/server/services/users.ts
+++ b/src/lib/server/services/users.ts
@@ -27,9 +27,7 @@ export async function getUserById(userId: string) {
  * Phase 2 KEYS-06) can record "user signed out N devices" without an extra
  * read. The count is also useful in tests.
  */
-export async function signOutAllDevices(
-  userId: string,
-): Promise<{ deletedCount: number }> {
+export async function signOutAllDevices(userId: string): Promise<{ deletedCount: number }> {
   const result = await db
     .delete(session)
     .where(eq(session.userId, userId))

--- a/src/roles/app.ts
+++ b/src/roles/app.ts
@@ -12,11 +12,11 @@
 // pg.Pool. Force-exit fallback at 60 s to keep an orchestrator from hanging
 // on a wedged drain.
 
-import { serve } from '@hono/node-server';
-import { createApp } from '../lib/server/http/app.js';
-import { env } from '../lib/server/config/env.js';
-import { logger } from '../lib/server/logger.js';
-import { pool } from '../lib/server/db/client.js';
+import { serve } from "@hono/node-server";
+import { createApp } from "../lib/server/http/app.js";
+import { env } from "../lib/server/config/env.js";
+import { logger } from "../lib/server/logger.js";
+import { pool } from "../lib/server/db/client.js";
 
 export async function start(): Promise<void> {
   const app = createApp();
@@ -26,53 +26,49 @@ export async function start(): Promise<void> {
   // is for production. We import dynamically so dev-mode does not require
   // build/handler.js to exist.
   let svelteHandler: (
-    req: import('node:http').IncomingMessage,
-    res: import('node:http').ServerResponse,
+    req: import("node:http").IncomingMessage,
+    res: import("node:http").ServerResponse,
     next?: () => void,
   ) => void;
   try {
-    const built = (await import(
-      /* @vite-ignore */ '../../build/handler.js' as string
-    )) as {
+    const built = (await import(/* @vite-ignore */ "../../build/handler.js" as string)) as {
       handler: typeof svelteHandler;
     };
     svelteHandler = built.handler;
   } catch {
-    logger.warn(
-      'build/handler.js not found — SvelteKit pass-through disabled (dev mode?)',
-    );
+    logger.warn("build/handler.js not found — SvelteKit pass-through disabled (dev mode?)");
     svelteHandler = (_req, res, next) => {
       res.statusCode = 404;
-      res.end('SvelteKit dev server runs on a different port; build first');
+      res.end("SvelteKit dev server runs on a different port; build first");
       if (next) next();
     };
   }
 
   // SvelteKit pass-through: anything not matched above goes to SvelteKit.
-  app.all('*', async (c) => {
+  app.all("*", async (c) => {
     return new Promise<Response>((resolve) => {
       const ctx = c.env as
         | {
-            incoming?: import('node:http').IncomingMessage;
-            outgoing?: import('node:http').ServerResponse;
+            incoming?: import("node:http").IncomingMessage;
+            outgoing?: import("node:http").ServerResponse;
           }
         | undefined;
       const incoming = ctx?.incoming;
       const outgoing = ctx?.outgoing;
       if (!incoming || !outgoing) {
-        resolve(c.text('node adapter context missing', 500));
+        resolve(c.text("node adapter context missing", 500));
         return;
       }
       let resolved = false;
       svelteHandler(incoming, outgoing, () => {
         if (!resolved) {
           resolved = true;
-          resolve(c.text('not found', 404));
+          resolve(c.text("not found", 404));
         }
       });
       // adapter-node writes directly to outgoing; we resolve a sentinel
       // Response once the response has been finished so Hono can settle.
-      outgoing.on('finish', () => {
+      outgoing.on("finish", () => {
         if (!resolved) {
           resolved = true;
           resolve(new Response(null, { status: outgoing.statusCode }));
@@ -82,30 +78,30 @@ export async function start(): Promise<void> {
   });
 
   const server = serve({ fetch: app.fetch, port: env.PORT }, (info) => {
-    logger.info({ port: info.port, role: 'app' }, 'app role listening');
+    logger.info({ port: info.port, role: "app" }, "app role listening");
   });
 
   // Graceful shutdown (D-22).
   const shutdown = async (signal: string): Promise<void> => {
-    logger.info({ signal }, 'received shutdown signal, draining…');
+    logger.info({ signal }, "received shutdown signal, draining…");
     server.close(async () => {
       try {
         await pool.end();
       } catch (err) {
-        logger.warn({ err }, 'pool drain error');
+        logger.warn({ err }, "pool drain error");
       }
       process.exit(0);
     });
     // Force exit after 60 s if drain hangs.
     setTimeout(() => {
-      logger.error('drain timed out, force-exit');
+      logger.error("drain timed out, force-exit");
       process.exit(1);
     }, 60_000).unref();
   };
-  process.on('SIGTERM', () => {
-    void shutdown('SIGTERM');
+  process.on("SIGTERM", () => {
+    void shutdown("SIGTERM");
   });
-  process.on('SIGINT', () => {
-    void shutdown('SIGINT');
+  process.on("SIGINT", () => {
+    void shutdown("SIGINT");
   });
 }

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -20,9 +20,7 @@ const PROTECTED_PATHS: string[] = [
 ];
 
 export const load: LayoutServerLoad = ({ locals, url }) => {
-  const isProtected = PROTECTED_PATHS.some((p) =>
-    url.pathname.startsWith(p),
-  );
+  const isProtected = PROTECTED_PATHS.some((p) => url.pathname.startsWith(p));
   if (isProtected && !locals.user) {
     throw redirect(303, `/login?next=${encodeURIComponent(url.pathname)}`);
   }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,7 +2,7 @@
   // Minimal Phase 1 shell — a single `<main>` with the page slot.
   // Phase 4 lands the real navigation chrome and dashboard layout.
   // Plan 01-09: page <title> sourced from Paraglide so it is i18n-ready (UX-04, D-17/D-18).
-  import { m } from '$lib/paraglide/messages.js';
+  import { m } from "$lib/paraglide/messages.js";
   let { children } = $props();
 </script>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,8 +5,8 @@
   // Phase 2 lands real game cards in this slot.
   // Plan 01-09: every user-facing string flows through Paraglide's compiled m.*
   // exports (UX-04, D-17 baseLocale only, D-18 single messages file at root).
-  import { m } from '$lib/paraglide/messages.js';
-  import { signIn, signOut } from '$lib/auth-client';
+  import { m } from "$lib/paraglide/messages.js";
+  import { signIn, signOut } from "$lib/auth-client";
   let { data } = $props();
 </script>
 
@@ -17,9 +17,7 @@
 {:else}
   <h1>{m.dashboard_title()}</h1>
   <p>{m.dashboard_unauth_intro()}</p>
-  <button
-    onclick={() => signIn.social({ provider: 'google', callbackURL: '/' })}
-  >
+  <button onclick={() => signIn.social({ provider: "google", callbackURL: "/" })}>
     {m.login_button()}
   </button>
 {/if}

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -3,13 +3,11 @@
   // when an unauthenticated browser request hits a protected page. Plan 07
   // wires the redirect; this page just renders the Google sign-in button.
   // Plan 01-09: strings sourced from Paraglide (UX-04, D-17/D-18).
-  import { m } from '$lib/paraglide/messages.js';
-  import { signIn } from '$lib/auth-client';
+  import { m } from "$lib/paraglide/messages.js";
+  import { signIn } from "$lib/auth-client";
 </script>
 
 <h1>{m.login_page_title()}</h1>
-<button
-  onclick={() => signIn.social({ provider: 'google', callbackURL: '/' })}
->
+<button onclick={() => signIn.social({ provider: "google", callbackURL: "/" })}>
   {m.login_continue()}
 </button>

--- a/src/scheduler/index.ts
+++ b/src/scheduler/index.ts
@@ -15,10 +15,10 @@
 //   - print `scheduler ready` to stdout for Plan 10's grep-based assertion
 //   - honor SIGTERM with pg-boss graceful drain + pg.Pool drain (D-22)
 
-import { createBoss, stopBoss } from '../lib/server/queue-client.js';
-import { pool } from '../lib/server/db/client.js';
-import { logger } from '../lib/server/logger.js';
-import { QUEUES } from '../lib/server/queues.js';
+import { createBoss, stopBoss } from "../lib/server/queue-client.js";
+import { pool } from "../lib/server/db/client.js";
+import { logger } from "../lib/server/logger.js";
+import { QUEUES } from "../lib/server/queues.js";
 
 /**
  * Boot the pg-boss scheduler, declare queues, register the healthcheck cron,
@@ -41,40 +41,39 @@ export async function startScheduler(): Promise<void> {
   // so the container exits non-zero (faster failure than a silent never-
   // scheduled cron).
   try {
-    await boss.schedule(QUEUES.INTERNAL_HEALTHCHECK, '*/5 * * * *');
+    await boss.schedule(QUEUES.INTERNAL_HEALTHCHECK, "*/5 * * * *");
   } catch (err) {
-    logger.error({ err }, 'failed to register internal.healthcheck schedule');
+    logger.error({ err }, "failed to register internal.healthcheck schedule");
     throw err;
   }
 
   // D-15 smoke assertion #3 — exact string `scheduler ready` on stdout.
   // Mirror the worker's dual emission: structured log for production
   // observability, raw console.log for Plan 10's grep contract.
-  logger.info({ role: 'scheduler' }, 'scheduler ready');
-  // eslint-disable-next-line no-console
-  console.log('scheduler ready');
+  logger.info({ role: "scheduler" }, "scheduler ready");
+  console.log("scheduler ready");
 
   // D-22 graceful shutdown. Same shape as the worker — drain pg-boss first
   // (which stops emitting new scheduled enqueues), then drain the pg.Pool.
   const shutdown = async (signal: string): Promise<void> => {
-    logger.info({ signal }, 'scheduler received shutdown signal');
+    logger.info({ signal }, "scheduler received shutdown signal");
     try {
       await stopBoss(boss);
     } catch (err) {
-      logger.warn({ err }, 'pg-boss stop failed');
+      logger.warn({ err }, "pg-boss stop failed");
     }
     try {
       await pool.end();
     } catch (err) {
-      logger.warn({ err }, 'pool.end failed');
+      logger.warn({ err }, "pool.end failed");
     }
     process.exit(0);
   };
-  process.on('SIGTERM', () => {
-    void shutdown('SIGTERM');
+  process.on("SIGTERM", () => {
+    void shutdown("SIGTERM");
   });
-  process.on('SIGINT', () => {
-    void shutdown('SIGINT');
+  process.on("SIGINT", () => {
+    void shutdown("SIGINT");
   });
 
   // Scheduler idles forever — pg-boss owns the cron loop. Block on a

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,35 +10,35 @@
 // containers also fail fast on schema drift, and so /readyz semantics hold
 // for the app role (D-21).
 
-import { env } from './lib/server/config/env.js';
-import { logger } from './lib/server/logger.js';
-import { runMigrations } from './lib/server/db/migrate.js';
+import { env } from "./lib/server/config/env.js";
+import { logger } from "./lib/server/logger.js";
+import { runMigrations } from "./lib/server/db/migrate.js";
 
 async function main(): Promise<void> {
   // Every role runs migrations (idempotent, advisory-locked per Plan 03).
   await runMigrations();
 
   switch (env.APP_ROLE) {
-    case 'app': {
-      const { start } = await import('./roles/app.js');
+    case "app": {
+      const { start } = await import("./roles/app.js");
       return start();
     }
-    case 'worker': {
-      const { startWorker } = await import('./worker/index.js');
+    case "worker": {
+      const { startWorker } = await import("./worker/index.js");
       return startWorker();
     }
-    case 'scheduler': {
-      const { startScheduler } = await import('./scheduler/index.js');
+    case "scheduler": {
+      const { startScheduler } = await import("./scheduler/index.js");
       return startScheduler();
     }
     default: {
-      logger.fatal({ role: env.APP_ROLE }, 'unknown APP_ROLE');
+      logger.fatal({ role: env.APP_ROLE }, "unknown APP_ROLE");
       process.exit(1);
     }
   }
 }
 
 main().catch((err) => {
-  logger.fatal({ err }, 'boot failed');
+  logger.fatal({ err }, "boot failed");
   process.exit(1);
 });

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -16,10 +16,10 @@
 //   - print `worker ready` to stdout for Plan 10's grep-based assertion
 //   - honor SIGTERM with pg-boss graceful drain + pg.Pool drain (D-22)
 
-import { createBoss, stopBoss } from '../lib/server/queue-client.js';
-import { pool } from '../lib/server/db/client.js';
-import { logger } from '../lib/server/logger.js';
-import { QUEUES } from '../lib/server/queues.js';
+import { createBoss, stopBoss } from "../lib/server/queue-client.js";
+import { pool } from "../lib/server/db/client.js";
+import { logger } from "../lib/server/logger.js";
+import { QUEUES } from "../lib/server/queues.js";
 
 /**
  * Boot the pg-boss worker, declare queues, subscribe to internal.healthcheck,
@@ -41,7 +41,7 @@ export async function startWorker(): Promise<void> {
     for (const job of jobs) {
       logger.debug(
         { jobId: job.id, queue: QUEUES.INTERNAL_HEALTHCHECK },
-        'healthcheck job processed',
+        "healthcheck job processed",
       );
     }
   });
@@ -51,33 +51,32 @@ export async function startWorker(): Promise<void> {
   // raw console.log line. Plan 10's smoke test greps for `worker ready`
   // and does not parse JSON; the raw line is the grep target. The
   // structured line preserves observability for production deploys.
-  logger.info({ role: 'worker' }, 'worker ready');
-  // eslint-disable-next-line no-console
-  console.log('worker ready');
+  logger.info({ role: "worker" }, "worker ready");
+  console.log("worker ready");
 
   // D-22 graceful shutdown. SIGTERM/SIGINT drain pg-boss first (so in-flight
   // handlers complete), THEN pool.end() (so any handler that took a Drizzle
   // connection releases cleanly). Either drain failure logs and continues —
   // we still want process.exit(0) so the orchestrator sees a clean stop.
   const shutdown = async (signal: string): Promise<void> => {
-    logger.info({ signal }, 'worker received shutdown signal');
+    logger.info({ signal }, "worker received shutdown signal");
     try {
       await stopBoss(boss);
     } catch (err) {
-      logger.warn({ err }, 'pg-boss stop failed');
+      logger.warn({ err }, "pg-boss stop failed");
     }
     try {
       await pool.end();
     } catch (err) {
-      logger.warn({ err }, 'pool.end failed');
+      logger.warn({ err }, "pool.end failed");
     }
     process.exit(0);
   };
-  process.on('SIGTERM', () => {
-    void shutdown('SIGTERM');
+  process.on("SIGTERM", () => {
+    void shutdown("SIGTERM");
   });
-  process.on('SIGINT', () => {
-    void shutdown('SIGINT');
+  process.on("SIGINT", () => {
+    void shutdown("SIGINT");
   });
 
   // Worker idles forever — pg-boss owns the polling loop. Block on a

--- a/tests/fixtures/users.ts
+++ b/tests/fixtures/users.ts
@@ -1,4 +1,4 @@
-import { pool } from '../setup.js';
+import { pool } from "../setup.js";
 
 // User seed fixture. Plan 01-03 lands the `users` table; Plan 01-05 lands Better Auth
 // session-cookie creation. Until Plan 03 lands the schema, the function throws a loud,
@@ -32,8 +32,8 @@ export async function seedUser(_input: SeedUserInput): Promise<SeededUser> {
     .catch(() => ({ rows: [{ exists: false }] }));
 
   if (!rows[0]?.exists) {
-    throw new Error('users table not yet created (Plan 01-03)');
+    throw new Error("users table not yet created (Plan 01-03)");
   }
   // Will be filled in by Plan 01-05 — direct insert + Better Auth session row.
-  throw new Error('seedUser implementation lands in Plan 01-05');
+  throw new Error("seedUser implementation lands in Plan 01-05");
 }

--- a/tests/integration/anonymous-401.test.ts
+++ b/tests/integration/anonymous-401.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { createApp } from '../../src/lib/server/http/app.js';
+import { describe, it, expect } from "vitest";
+import { createApp } from "../../src/lib/server/http/app.js";
 
 // Plan 01-07 (Wave 4) — VALIDATION 5/6 (anonymous-401 invariant + no-public-route).
 // Revision 1 BLOCKER 2 fix: vacuous-pass guard with MUST_BE_PROTECTED allowlist
@@ -8,30 +8,30 @@ import { createApp } from '../../src/lib/server/http/app.js';
 // sweep would silently pass. The allowlist forces it to fail loudly when
 // expected routes disappear, and the explicit /api/me checks below assert the
 // concrete behavior on the canonical Phase 1 route.
-describe('anonymous-401 sweep (PRIV-01, VALIDATION 5/6)', () => {
+describe("anonymous-401 sweep (PRIV-01, VALIDATION 5/6)", () => {
   const app = createApp();
 
   // Whitelist of endpoints that are intentionally unauthenticated.
   // /healthz and /readyz are pure liveness — CONTEXT.md deferred section
   // explicitly excludes them from "every endpoint refuses anonymous".
-  const PUBLIC_PATHS = ['/healthz', '/readyz'];
+  const PUBLIC_PATHS = ["/healthz", "/readyz"];
 
   // Auth handler routes are managed by Better Auth and have their own auth model
   // (OAuth callbacks must accept anonymous requests by definition).
-  const AUTH_HANDLER_PREFIX = '/api/auth';
+  const AUTH_HANDLER_PREFIX = "/api/auth";
 
   // Hardcoded allowlist: these routes MUST be in the swept set (vacuous-pass guard).
   // The sweep above is a COMPLEMENT to (not a REPLACEMENT for) explicit per-route
   // assertions — if no /api/* routes exist in the future, the sweep would silently
   // pass. The allowlist forces the sweep to fail loudly when expected routes
   // disappear.
-  const MUST_BE_PROTECTED = ['/api/me'];
+  const MUST_BE_PROTECTED = ["/api/me"];
 
-  it('every /api/* route except /api/auth/* refuses anonymous with 401', async () => {
+  it("every /api/* route except /api/auth/* refuses anonymous with 401", async () => {
     // Hono exposes app.routes (array of {path, method, handler}).
     const routes = (app as unknown as { routes: Array<{ path: string; method: string }> }).routes;
     const protectedRoutes = routes.filter((r) => {
-      if (!r.path.startsWith('/api/')) return false;
+      if (!r.path.startsWith("/api/")) return false;
       if (r.path.startsWith(AUTH_HANDLER_PREFIX)) return false;
       if (PUBLIC_PATHS.some((p) => r.path === p)) return false;
       return true;
@@ -47,14 +47,14 @@ describe('anonymous-401 sweep (PRIV-01, VALIDATION 5/6)', () => {
 
     for (const r of protectedRoutes) {
       // Substitute :param placeholders with sentinel value.
-      const path = r.path.replace(/:[A-Za-z_]+/g, 'fixture-id');
-      const method = r.method === 'ALL' ? 'GET' : r.method;
+      const path = r.path.replace(/:[A-Za-z_]+/g, "fixture-id");
+      const method = r.method === "ALL" ? "GET" : r.method;
       const res = await app.request(path, { method });
       expect.soft(res.status, `${method} ${path} should be 401`).toBe(401);
     }
   });
 
-  it('VALIDATION 6: no public dashboard / share-link / read-only viewer route exists', async () => {
+  it("VALIDATION 6: no public dashboard / share-link / read-only viewer route exists", async () => {
     // Phase 1 invariant: PRIV-01 — no public routes anywhere (PITFALL P18).
     const routes = (app as unknown as { routes: Array<{ path: string }> }).routes;
     for (const r of routes) {
@@ -64,27 +64,27 @@ describe('anonymous-401 sweep (PRIV-01, VALIDATION 5/6)', () => {
   });
 
   it('AUTH-01: /api/me with no cookie returns 401 + {error:"unauthorized"} (Pattern 3)', async () => {
-    const res = await app.request('/api/me');
+    const res = await app.request("/api/me");
     expect(res.status).toBe(401);
     const body = await res.json();
-    expect(body).toEqual({ error: 'unauthorized' });
+    expect(body).toEqual({ error: "unauthorized" });
   });
 
-  it('AUTH-01: /api/me with valid session returns 200 + UserDto', async () => {
-    const { seedUserDirectly } = await import('./helpers.js');
-    const seeded = await seedUserDirectly({ email: 'priv@test.local', name: 'Priv Tester' });
-    const res = await app.request('/api/me', {
+  it("AUTH-01: /api/me with valid session returns 200 + UserDto", async () => {
+    const { seedUserDirectly } = await import("./helpers.js");
+    const seeded = await seedUserDirectly({ email: "priv@test.local", name: "Priv Tester" });
+    const res = await app.request("/api/me", {
       headers: { cookie: `neotolis.session_token=${seeded.sessionToken}` },
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.id).toBe(seeded.id);
-    expect(body.email).toBe('priv@test.local');
-    expect(body.name).toBe('Priv Tester');
+    expect(body.email).toBe("priv@test.local");
+    expect(body.name).toBe("Priv Tester");
     // P3: DTO must NOT contain provider tokens or google_sub.
-    expect(body).not.toHaveProperty('googleSub');
-    expect(body).not.toHaveProperty('refreshToken');
-    expect(body).not.toHaveProperty('accessToken');
-    expect(body).not.toHaveProperty('idToken');
+    expect(body).not.toHaveProperty("googleSub");
+    expect(body).not.toHaveProperty("refreshToken");
+    expect(body).not.toHaveProperty("accessToken");
+    expect(body).not.toHaveProperty("idToken");
   });
 });

--- a/tests/integration/auth.test.ts
+++ b/tests/integration/auth.test.ts
@@ -33,10 +33,7 @@ describe("Better Auth — DB session lifecycle (AUTH-01/02/03)", () => {
     });
 
     // Find the session id from the token.
-    const rows = await db
-      .select()
-      .from(session)
-      .where(eq(session.token, sessionToken));
+    const rows = await db.select().from(session).where(eq(session.token, sessionToken));
     expect(rows.length).toBe(1);
 
     await invalidateSession(rows[0]!.id);
@@ -63,19 +60,13 @@ describe("Better Auth — DB session lifecycle (AUTH-01/02/03)", () => {
       expiresAt: new Date(Date.now() + 86_400_000),
     });
 
-    const before = await db
-      .select()
-      .from(session)
-      .where(eq(session.userId, userId));
+    const before = await db.select().from(session).where(eq(session.userId, userId));
     expect(before.length).toBeGreaterThanOrEqual(2);
 
     const result = await signOutAllDevices(userId);
     expect(result.deletedCount).toBeGreaterThanOrEqual(2);
 
-    const after = await db
-      .select()
-      .from(session)
-      .where(eq(session.userId, userId));
+    const after = await db.select().from(session).where(eq(session.userId, userId));
     expect(after.length).toBe(0);
   });
 
@@ -87,10 +78,7 @@ describe("Better Auth — DB session lifecycle (AUTH-01/02/03)", () => {
     // resolve the same row on a returning sign-in instead of inserting a duplicate.
     await expect(seedUserDirectly({ email: "dave@test.local" })).rejects.toThrow();
 
-    const all = await db
-      .select()
-      .from(user)
-      .where(eq(user.email, "dave@test.local"));
+    const all = await db.select().from(user).where(eq(user.email, "dave@test.local"));
     expect(all.length).toBe(1);
   });
 });

--- a/tests/integration/health.test.ts
+++ b/tests/integration/health.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { createApp } from '../../src/lib/server/http/app.js';
-import { migrationsApplied } from '../../src/lib/server/db/migrate.js';
+import { describe, it, expect } from "vitest";
+import { createApp } from "../../src/lib/server/http/app.js";
+import { migrationsApplied } from "../../src/lib/server/db/migrate.js";
 
 // VALIDATION ad-hoc — D-21 (`/healthz` always 200; `/readyz` 200 only after
 // migrations applied + DB reachable). Plan 06 lands the routes; this file
@@ -11,20 +11,20 @@ import { migrationsApplied } from '../../src/lib/server/db/migrate.js';
 // time these specs run. The pre-migration test temporarily flips the flag
 // off, asserts 503, then restores it for the rest of the suite.
 
-describe('/healthz and /readyz', () => {
+describe("/healthz and /readyz", () => {
   it('GET /healthz returns 200 with body "ok"', async () => {
     const app = createApp();
-    const res = await app.request('/healthz');
+    const res = await app.request("/healthz");
     expect(res.status).toBe(200);
-    expect(await res.text()).toBe('ok');
+    expect(await res.text()).toBe("ok");
   });
 
-  it('GET /readyz returns 503 before migrations applied', async () => {
+  it("GET /readyz returns 503 before migrations applied", async () => {
     const before = migrationsApplied.current;
     migrationsApplied.current = false;
     try {
       const app = createApp();
-      const res = await app.request('/readyz');
+      const res = await app.request("/readyz");
       expect(res.status).toBe(503);
       const body = (await res.json()) as { ok: boolean };
       expect(body.ok).toBe(false);
@@ -33,14 +33,14 @@ describe('/healthz and /readyz', () => {
     }
   });
 
-  it('GET /readyz returns 200 after migrations applied (and DB up)', async () => {
+  it("GET /readyz returns 200 after migrations applied (and DB up)", async () => {
     // tests/setup.ts beforeAll runs runMigrations() — so
     // migrationsApplied.current === true by this point. If the DB is
     // unreachable in this run, /readyz answers 503 instead — both are
     // acceptable here; the 503-before-migrations branch above is the
     // authoritative pre-migration test.
     const app = createApp();
-    const res = await app.request('/readyz');
+    const res = await app.request("/readyz");
     expect([200, 503]).toContain(res.status);
     if (res.status === 200) {
       const body = (await res.json()) as { ok: boolean };

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -37,9 +37,7 @@ export async function seedUserDirectly(opts: {
 }): Promise<CreatedUser> {
   // Lazy-import the Drizzle layer so unit tests don't pull pg.Pool when not needed.
   const { db } = await import("../../src/lib/server/db/client.js");
-  const { user, session } = await import(
-    "../../src/lib/server/db/schema/auth.js"
-  );
+  const { user, session } = await import("../../src/lib/server/db/schema/auth.js");
   const { uuidv7 } = await import("../../src/lib/server/ids.js");
 
   const userId = uuidv7();
@@ -82,10 +80,7 @@ export async function createUser(email: string): Promise<CreatedUser> {
 
 // Phase 2 lands the games table; this stub stays so Plan 10's smoke test imports
 // the same module shape that Phase 2 will fill in.
-export async function createGame(
-  _userId: string,
-  _title: string,
-): Promise<{ id: string }> {
+export async function createGame(_userId: string, _title: string): Promise<{ id: string }> {
   throw new Error("games table arrives in Phase 2");
 }
 

--- a/tests/integration/i18n.test.ts
+++ b/tests/integration/i18n.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
 
 // Plan 01-09 (Wave 4) — UX-04 i18n at runtime.
 // VALIDATION 18 end-to-end "render a SvelteKit page through Hono and grep
@@ -12,19 +12,19 @@ import * as path from 'node:path';
 //   build-time check would also catch (Paraglide generates typed exports),
 //   but matters in addition because the test runs without requiring the
 //   Paraglide compile step to have produced output yet.
-describe('i18n at runtime (UX-04, VALIDATION 18)', () => {
-  it('messages/en.json exists, is valid JSON, and contains every key referenced by Phase 1 .svelte files', () => {
-    const raw = JSON.parse(fs.readFileSync(path.resolve('messages/en.json'), 'utf8'));
+describe("i18n at runtime (UX-04, VALIDATION 18)", () => {
+  it("messages/en.json exists, is valid JSON, and contains every key referenced by Phase 1 .svelte files", () => {
+    const raw = JSON.parse(fs.readFileSync(path.resolve("messages/en.json"), "utf8"));
     // Grep the .svelte files for m.<key>(...) references and assert each key exists.
     const svelteFiles = [
-      path.resolve('src/routes/+page.svelte'),
-      path.resolve('src/routes/login/+page.svelte'),
-      path.resolve('src/routes/+layout.svelte'),
+      path.resolve("src/routes/+page.svelte"),
+      path.resolve("src/routes/login/+page.svelte"),
+      path.resolve("src/routes/+layout.svelte"),
     ].filter((f) => fs.existsSync(f));
     const usedKeys = new Set<string>();
     const re = /m\.([a-z][a-z_0-9]*)\s*\(/g;
     for (const f of svelteFiles) {
-      const src = fs.readFileSync(f, 'utf8');
+      const src = fs.readFileSync(f, "utf8");
       let match: RegExpExecArray | null;
       while ((match = re.exec(src)) !== null) {
         usedKeys.add(match[1]!);
@@ -32,7 +32,9 @@ describe('i18n at runtime (UX-04, VALIDATION 18)', () => {
     }
     expect(usedKeys.size).toBeGreaterThan(0);
     for (const key of usedKeys) {
-      expect(raw, `messages/en.json missing key referenced from .svelte: ${key}`).toHaveProperty(key);
+      expect(raw, `messages/en.json missing key referenced from .svelte: ${key}`).toHaveProperty(
+        key,
+      );
     }
   });
 });

--- a/tests/integration/migrate.test.ts
+++ b/tests/integration/migrate.test.ts
@@ -1,9 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import pg from 'pg';
-import {
-  runMigrations,
-  migrationsApplied,
-} from '../../src/lib/server/db/migrate.js';
+import { describe, it, expect } from "vitest";
+import pg from "pg";
+import { runMigrations, migrationsApplied } from "../../src/lib/server/db/migrate.js";
 
 // VALIDATION 14 + 15 (Plan 01-03):
 //   14. migrations idempotent on second boot
@@ -15,11 +12,10 @@ import {
 // final schema shape.
 
 const TEST_URL =
-  process.env.TEST_DATABASE_URL ??
-  'postgres://postgres:postgres@localhost:5432/neotolis_test';
+  process.env.TEST_DATABASE_URL ?? "postgres://postgres:postgres@localhost:5432/neotolis_test";
 
-describe('migrations', () => {
-  it('idempotent on second boot (re-running migrate() is a no-op)', async () => {
+describe("migrations", () => {
+  it("idempotent on second boot (re-running migrate() is a no-op)", async () => {
     // First call (may have already run via tests/setup.ts beforeAll, but
     // runMigrations is idempotent — second invocation must complete cleanly).
     await runMigrations();
@@ -34,17 +30,17 @@ describe('migrations', () => {
         `select tablename from pg_tables where schemaname = 'public' order by tablename`,
       );
       const names = rows.map((r) => r.tablename);
-      expect(names).toContain('user');
-      expect(names).toContain('session');
-      expect(names).toContain('account');
-      expect(names).toContain('verification');
-      expect(names).toContain('audit_log');
+      expect(names).toContain("user");
+      expect(names).toContain("session");
+      expect(names).toContain("account");
+      expect(names).toContain("verification");
+      expect(names).toContain("audit_log");
     } finally {
       await pool.end();
     }
   });
 
-  it('advisory lock prevents concurrent races (BIGINT 5_494_251_782_888_259_377)', async () => {
+  it("advisory lock prevents concurrent races (BIGINT 5_494_251_782_888_259_377)", async () => {
     // Spawn two concurrent runMigrations calls. The advisory lock means one
     // waits while the other runs migrate(); both must resolve without error
     // and the final schema must be consistent.
@@ -58,8 +54,8 @@ describe('migrations', () => {
       );
       const names = rows.map((r) => r.tablename);
       // Schema is consistent (no half-applied state from a race).
-      expect(names).toContain('user');
-      expect(names).toContain('audit_log');
+      expect(names).toContain("user");
+      expect(names).toContain("audit_log");
     } finally {
       await pool.end();
     }

--- a/tests/integration/tenant-scope.test.ts
+++ b/tests/integration/tenant-scope.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect } from 'vitest';
-import { and, eq } from 'drizzle-orm';
-import { db } from '../../src/lib/server/db/client.js';
-import { auditLog } from '../../src/lib/server/db/schema/audit-log.js';
-import { writeAudit } from '../../src/lib/server/audit.js';
-import { NotFoundError } from '../../src/lib/server/services/errors.js';
-import { seedUserDirectly } from './helpers.js';
+import { describe, it, expect } from "vitest";
+import { and, eq } from "drizzle-orm";
+import { db } from "../../src/lib/server/db/client.js";
+import { auditLog } from "../../src/lib/server/db/schema/audit-log.js";
+import { writeAudit } from "../../src/lib/server/audit.js";
+import { NotFoundError } from "../../src/lib/server/services/errors.js";
+import { seedUserDirectly } from "./helpers.js";
 
 /**
  * Plan 01-07 (Wave 4) — VALIDATION 7/8/9 (cross-tenant 404 not 403).
@@ -18,14 +18,14 @@ import { seedUserDirectly } from './helpers.js';
  * resource in Phase 1` and `deferred to Phase 2: no deletable resource in
  * Phase 1`. No silent skips; every behavior accounted for.
  */
-describe('cross-tenant 404 (PRIV-01, VALIDATION 7/8/9)', () => {
-  it('user A cannot READ user B audit row (404 NOT 403)', async () => {
-    const userA = await seedUserDirectly({ email: 'a@test.local' });
-    const userB = await seedUserDirectly({ email: 'b@test.local' });
+describe("cross-tenant 404 (PRIV-01, VALIDATION 7/8/9)", () => {
+  it("user A cannot READ user B audit row (404 NOT 403)", async () => {
+    const userA = await seedUserDirectly({ email: "a@test.local" });
+    const userB = await seedUserDirectly({ email: "b@test.local" });
     await writeAudit({
       userId: userB.id,
-      action: 'session.signin',
-      ipAddress: '127.0.0.1',
+      action: "session.signin",
+      ipAddress: "127.0.0.1",
     });
 
     // Sentinel "service": fetch one audit row scoped by userId. The double
@@ -36,68 +36,58 @@ describe('cross-tenant 404 (PRIV-01, VALIDATION 7/8/9)', () => {
       const rows = await db
         .select()
         .from(auditLog)
-        .where(
-          and(eq(auditLog.userId, callerId), eq(auditLog.userId, rowOwnerId)),
-        )
+        .where(and(eq(auditLog.userId, callerId), eq(auditLog.userId, rowOwnerId)))
         .limit(1);
       if (rows.length === 0) throw new NotFoundError();
       return rows[0]!;
     }
 
     // user A scoping user B's row: NotFoundError, never a result.
-    await expect(getAuditRowFor(userA.id, userB.id)).rejects.toBeInstanceOf(
-      NotFoundError,
-    );
+    await expect(getAuditRowFor(userA.id, userB.id)).rejects.toBeInstanceOf(NotFoundError);
   });
 
   // VALIDATION behavior 8 — cross-tenant WRITE — is deferred to Phase 2 (which lands the
   // first writable resource: /api/games). Phase 1 has no write-able tenant resource;
   // documenting the deferral explicitly here (per checker iteration 1 W1) so the
   // skip is not silent.
-  it.skip(
-    'user A cannot WRITE user B resource — returns 404 (deferred to Phase 2: no writable resource in Phase 1)',
-    () => {
-      /* Phase 2 GAMES-01 lands /api/games and turns this on. */
-    },
-  );
+  it.skip("user A cannot WRITE user B resource — returns 404 (deferred to Phase 2: no writable resource in Phase 1)", () => {
+    /* Phase 2 GAMES-01 lands /api/games and turns this on. */
+  });
 
   // VALIDATION behavior 9 — cross-tenant DELETE — same deferral.
-  it.skip(
-    'user A cannot DELETE user B resource — returns 404 (deferred to Phase 2: no deletable resource in Phase 1)',
-    () => {
-      /* Phase 2 GAMES-01 lands /api/games and turns this on. */
-    },
-  );
+  it.skip("user A cannot DELETE user B resource — returns 404 (deferred to Phase 2: no deletable resource in Phase 1)", () => {
+    /* Phase 2 GAMES-01 lands /api/games and turns this on. */
+  });
 
   it('NotFoundError serializes to {error: "not_found"} status 404 (never "forbidden")', () => {
     const err = new NotFoundError();
     expect(err.status).toBe(404);
-    expect(err.code).toBe('not_found');
+    expect(err.code).toBe("not_found");
     // Body must NOT contain "forbidden" or "permission".
     const body = JSON.stringify({ error: err.code });
-    expect(body).not.toContain('forbidden');
-    expect(body).not.toContain('permission');
+    expect(body).not.toContain("forbidden");
+    expect(body).not.toContain("permission");
   });
 
-  it('user A reading their own /api/me returns 200; user B reading their own returns 200 with different data', async () => {
-    const { createApp } = await import('../../src/lib/server/http/app.js');
+  it("user A reading their own /api/me returns 200; user B reading their own returns 200 with different data", async () => {
+    const { createApp } = await import("../../src/lib/server/http/app.js");
     const app = createApp();
-    const userA = await seedUserDirectly({ email: 'mine-a@test.local', name: 'A' });
-    const userB = await seedUserDirectly({ email: 'mine-b@test.local', name: 'B' });
+    const userA = await seedUserDirectly({ email: "mine-a@test.local", name: "A" });
+    const userB = await seedUserDirectly({ email: "mine-b@test.local", name: "B" });
 
-    const resA = await app.request('/api/me', {
+    const resA = await app.request("/api/me", {
       headers: { cookie: `neotolis.session_token=${userA.sessionToken}` },
     });
     expect(resA.status).toBe(200);
     const bodyA = (await resA.json()) as Record<string, unknown>;
-    expect(bodyA.email).toBe('mine-a@test.local');
+    expect(bodyA.email).toBe("mine-a@test.local");
 
-    const resB = await app.request('/api/me', {
+    const resB = await app.request("/api/me", {
       headers: { cookie: `neotolis.session_token=${userB.sessionToken}` },
     });
     expect(resB.status).toBe(200);
     const bodyB = (await resB.json()) as Record<string, unknown>;
-    expect(bodyB.email).toBe('mine-b@test.local');
+    expect(bodyB.email).toBe("mine-b@test.local");
     expect(bodyA.id).not.toBe(bodyB.id);
   });
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeAll } from 'vitest';
-import pg from 'pg';
+import { afterEach, beforeAll } from "vitest";
+import pg from "pg";
 
 // Vitest setup file imported by the `integration` project (see vitest.config.ts).
 //
@@ -11,23 +11,17 @@ import pg from 'pg';
 // Until then, the dynamic import below throws and we print a warn so contributors understand
 // why integration tests skip-with-context. Once Plan 03 lands, the warn disappears.
 const dbUrl =
-  process.env.TEST_DATABASE_URL ??
-  'postgres://postgres:postgres@localhost:5432/neotolis_test';
+  process.env.TEST_DATABASE_URL ?? "postgres://postgres:postgres@localhost:5432/neotolis_test";
 
 export const pool = new pg.Pool({ connectionString: dbUrl, max: 5 });
 
 beforeAll(async () => {
   try {
     // @ts-expect-error — module lands in Plan 01-03; until then this throws and we warn.
-    const { runMigrations } = await import('../src/lib/server/db/migrate.js');
+    const { runMigrations } = await import("../src/lib/server/db/migrate.js");
     await runMigrations();
   } catch (err) {
-    // Plan 03 lands runMigrations; until then, integration tests will skip-with-context.
-    // eslint-disable-next-line no-console
-    console.warn(
-      '[tests/setup] migrations not yet wired (Plan 01-03):',
-      (err as Error).message,
-    );
+    console.warn("[tests/setup] migrations not yet wired (Plan 01-03):", (err as Error).message);
   }
 });
 
@@ -39,7 +33,7 @@ afterEach(async () => {
       `select tablename from pg_tables where schemaname = 'public'`,
     );
     if (rows.length === 0) return;
-    const names = rows.map((r) => `"${r.tablename}"`).join(', ');
+    const names = rows.map((r) => `"${r.tablename}"`).join(", ");
     await pool.query(`TRUNCATE ${names} RESTART IDENTITY CASCADE`);
   } catch {
     // Pre-migration: nothing to truncate. Swallow — integration tests will skip-with-context.

--- a/tests/setup/db.ts
+++ b/tests/setup/db.ts
@@ -1,5 +1,5 @@
-import type { PoolClient } from 'pg';
-import { pool } from '../setup.js';
+import type { PoolClient } from "pg";
+import { pool } from "../setup.js";
 
 // Per-test transactional Postgres helpers (BEGIN/SAVEPOINT/ROLLBACK pattern from
 // 01-VALIDATION.md "Test Infrastructure"). Used by tests that want stricter isolation
@@ -13,18 +13,16 @@ import { pool } from '../setup.js';
 //   });
 //
 // Pre-Plan-03 the schema is empty; helper still works (you just have nothing to write).
-export async function withTx<T>(
-  fn: (client: PoolClient) => Promise<T>,
-): Promise<T> {
+export async function withTx<T>(fn: (client: PoolClient) => Promise<T>): Promise<T> {
   const client = await pool.connect();
   try {
-    await client.query('BEGIN');
+    await client.query("BEGIN");
     try {
       const result = await fn(client);
-      await client.query('ROLLBACK');
+      await client.query("ROLLBACK");
       return result;
     } catch (err) {
-      await client.query('ROLLBACK');
+      await client.query("ROLLBACK");
       throw err;
     }
   } finally {

--- a/tests/setup/oauth.ts
+++ b/tests/setup/oauth.ts
@@ -32,9 +32,7 @@ type MockServer = {
   service: {
     on: (event: string, handler: (...args: unknown[]) => void) => void;
     removeAllListeners: (event?: string) => void;
-    buildResponse?: (
-      claims: Record<string, unknown>,
-    ) => Promise<{ id_token: string }>;
+    buildResponse?: (claims: Record<string, unknown>) => Promise<{ id_token: string }>;
   };
 };
 

--- a/tests/smoke/lib/oauth-mock-driver.ts
+++ b/tests/smoke/lib/oauth-mock-driver.ts
@@ -45,7 +45,7 @@
  */
 
 // @ts-expect-error — oauth2-mock-server (CJS) types may lag in this TS config.
-import { OAuth2Server } from 'oauth2-mock-server';
+import { OAuth2Server } from "oauth2-mock-server";
 
 interface Args {
   appUrl: string;
@@ -78,11 +78,11 @@ function parseArgs(): Args {
     return argv[i + 1]!;
   };
   return {
-    appUrl: get('--app-url'),
-    mockPort: parseInt(get('--mock-port'), 10),
-    sub: get('--sub'),
-    email: get('--email'),
-    name: get('--name'),
+    appUrl: get("--app-url"),
+    mockPort: parseInt(get("--mock-port"), 10),
+    sub: get("--sub"),
+    email: get("--email"),
+    name: get("--name"),
   };
 }
 
@@ -103,9 +103,9 @@ function resolveLocation(location: string, base: string): string {
  * `name=value` on subsequent requests; that's what every browser does.
  */
 function parseSetCookie(setCookie: string): [string, string] | null {
-  const firstSemi = setCookie.indexOf(';');
+  const firstSemi = setCookie.indexOf(";");
   const pair = firstSemi === -1 ? setCookie : setCookie.slice(0, firstSemi);
-  const eq = pair.indexOf('=');
+  const eq = pair.indexOf("=");
   if (eq === -1) return null;
   const name = pair.slice(0, eq).trim();
   const value = pair.slice(eq + 1).trim();
@@ -121,13 +121,13 @@ function readSetCookies(res: Response): string[] {
   const headers = res.headers as Headers & {
     getSetCookie?: () => string[];
   };
-  if (typeof headers.getSetCookie === 'function') {
+  if (typeof headers.getSetCookie === "function") {
     return headers.getSetCookie();
   }
   // Fallback: comma-split a single Set-Cookie header. Imperfect (cookies
   // with `Expires=...` contain commas) but Node 22's fetch always exposes
   // getSetCookie() so this branch is mostly defensive.
-  const single = res.headers.get('set-cookie');
+  const single = res.headers.get("set-cookie");
   return single ? [single] : [];
 }
 
@@ -135,16 +135,16 @@ async function main(): Promise<void> {
   const args = parseArgs();
 
   const server = new OAuth2Server() as MockServer;
-  await server.issuer.keys.generate('RS256');
-  await server.start(args.mockPort, '127.0.0.1');
+  await server.issuer.keys.generate("RS256");
+  await server.start(args.mockPort, "127.0.0.1");
 
   try {
     // Reset previous handlers so successive driver invocations from the
     // same bash process see only the current claims.
-    server.service.removeAllListeners('beforeUserinfo');
-    server.service.removeAllListeners('beforeTokenSigning');
+    server.service.removeAllListeners("beforeUserinfo");
+    server.service.removeAllListeners("beforeTokenSigning");
 
-    server.service.on('beforeUserinfo', (...handlerArgs: unknown[]) => {
+    server.service.on("beforeUserinfo", (...handlerArgs: unknown[]) => {
       const userInfo = handlerArgs[0] as {
         body: Record<string, unknown>;
         statusCode: number;
@@ -158,18 +158,18 @@ async function main(): Promise<void> {
       userInfo.statusCode = 200;
     });
 
-    server.service.on('beforeTokenSigning', (...handlerArgs: unknown[]) => {
+    server.service.on("beforeTokenSigning", (...handlerArgs: unknown[]) => {
       const token = handlerArgs[0] as { payload: Record<string, unknown> };
       token.payload = {
         ...token.payload,
         // INFO I2 Path 3 (locked by Plan 01-05): coerce iss so Better Auth
         // 1.6.x's hardcoded google-provider issuer check accepts the token.
-        iss: 'https://accounts.google.com',
+        iss: "https://accounts.google.com",
         sub: args.sub,
         email: args.email,
         email_verified: true,
         name: args.name,
-        aud: process.env.GOOGLE_CLIENT_ID ?? 'mock-client-id',
+        aud: process.env.GOOGLE_CLIENT_ID ?? "mock-client-id",
       };
     });
 
@@ -186,16 +186,16 @@ async function main(): Promise<void> {
     const jar = new Map<string, string>();
     const initialUrl = `${args.appUrl}/api/auth/sign-in/social`;
     const initialBody = JSON.stringify({
-      provider: 'google',
-      callbackURL: '/',
+      provider: "google",
+      callbackURL: "/",
     });
 
     const initial = await fetch(initialUrl, {
-      method: 'POST',
-      redirect: 'manual',
+      method: "POST",
+      redirect: "manual",
       headers: {
-        'content-type': 'application/json',
-        accept: 'application/json',
+        "content-type": "application/json",
+        accept: "application/json",
       },
       body: initialBody,
     });
@@ -211,19 +211,19 @@ async function main(): Promise<void> {
     //   - 200 with JSON { url: '<authorize URL>', redirect: true } (fetch-style)
     let nextUrl: string | null = null;
     if (initial.status >= 300 && initial.status < 400) {
-      const loc = initial.headers.get('location');
+      const loc = initial.headers.get("location");
       if (loc) nextUrl = resolveLocation(loc, initialUrl);
     } else if (initial.status === 200) {
       const json = (await initial.json()) as { url?: string };
-      if (json && typeof json.url === 'string') {
+      if (json && typeof json.url === "string") {
         nextUrl = json.url;
       }
     }
 
     if (!nextUrl) {
       console.error(
-        '[oauth-mock-driver] sign-in did not return a redirect URL',
-        'status=',
+        "[oauth-mock-driver] sign-in did not return a redirect URL",
+        "status=",
         initial.status,
       );
       process.exit(1);
@@ -236,12 +236,10 @@ async function main(): Promise<void> {
     let hops = 0;
     while (currentUrl && hops < 10) {
       hops++;
-      const cookieHeader = [...jar.entries()]
-        .map(([k, v]) => `${k}=${v}`)
-        .join('; ');
+      const cookieHeader = [...jar.entries()].map(([k, v]) => `${k}=${v}`).join("; ");
       const res: Response = await fetch(currentUrl, {
-        method: 'GET',
-        redirect: 'manual',
+        method: "GET",
+        redirect: "manual",
         headers: cookieHeader ? { cookie: cookieHeader } : {},
       });
 
@@ -251,7 +249,7 @@ async function main(): Promise<void> {
       }
 
       if (res.status >= 300 && res.status < 400) {
-        const loc = res.headers.get('location');
+        const loc = res.headers.get("location");
         currentUrl = loc ? resolveLocation(loc, currentUrl) : null;
       } else {
         currentUrl = null;
@@ -262,12 +260,12 @@ async function main(): Promise<void> {
     // locked the prefix to `neotolis`. In production with `useSecureCookies`
     // the name is prefixed with `__Secure-`; the smoke test runs over plain
     // HTTP (NODE_ENV=test or unset), so the unprefixed name applies.
-    const sessionTokenValue = jar.get('neotolis.session_token');
+    const sessionTokenValue = jar.get("neotolis.session_token");
     if (!sessionTokenValue) {
       console.error(
-        '[oauth-mock-driver] no session cookie set after',
+        "[oauth-mock-driver] no session cookie set after",
         hops,
-        'hops. Captured jar:',
+        "hops. Captured jar:",
         JSON.stringify([...jar.entries()]),
       );
       process.exit(1);
@@ -289,6 +287,6 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  console.error('[oauth-mock-driver] failed:', err);
+  console.error("[oauth-mock-driver] failed:", err);
   process.exit(2);
 });

--- a/tests/unit/dto.test.ts
+++ b/tests/unit/dto.test.ts
@@ -1,52 +1,52 @@
-import { describe, it, expect } from 'vitest';
-import { toUserDto, toSessionDto } from '../../src/lib/server/dto.js';
+import { describe, it, expect } from "vitest";
+import { toUserDto, toSessionDto } from "../../src/lib/server/dto.js";
 
 // Plan 01-07 (Wave 4) — PITFALL P3 DTO discipline. Round-trip projection
 // asserted to strip every secret-shaped field even when the input row
 // carries them (defense-in-depth — schema-as-types alone is not sufficient,
 // because TypeScript erases at runtime; the projection is the runtime guard).
-describe('DTO discipline (PITFALL P3)', () => {
-  it('toUserDto strips google_sub / accountId / passwords / verification', () => {
+describe("DTO discipline (PITFALL P3)", () => {
+  it("toUserDto strips google_sub / accountId / passwords / verification", () => {
     const fakeUser = {
-      id: 'u-1',
-      email: 'a@b.test',
-      name: 'A',
+      id: "u-1",
+      email: "a@b.test",
+      name: "A",
       image: null,
       // Fields that MUST NOT appear in DTO:
-      googleSub: 'gsub-secret',
-      refreshToken: 'r-tok',
-      accessToken: 'a-tok',
-      idToken: 'i-tok',
-      password: 'should-not-exist',
+      googleSub: "gsub-secret",
+      refreshToken: "r-tok",
+      accessToken: "a-tok",
+      idToken: "i-tok",
+      password: "should-not-exist",
       emailVerified: true,
       createdAt: new Date(),
       updatedAt: new Date(),
     } as unknown as Parameters<typeof toUserDto>[0];
 
     const dto = toUserDto(fakeUser);
-    expect(dto).toEqual({ id: 'u-1', email: 'a@b.test', name: 'A', image: null });
-    expect(dto).not.toHaveProperty('googleSub');
-    expect(dto).not.toHaveProperty('refreshToken');
-    expect(dto).not.toHaveProperty('accessToken');
-    expect(dto).not.toHaveProperty('idToken');
-    expect(dto).not.toHaveProperty('password');
-    expect(dto).not.toHaveProperty('emailVerified');
+    expect(dto).toEqual({ id: "u-1", email: "a@b.test", name: "A", image: null });
+    expect(dto).not.toHaveProperty("googleSub");
+    expect(dto).not.toHaveProperty("refreshToken");
+    expect(dto).not.toHaveProperty("accessToken");
+    expect(dto).not.toHaveProperty("idToken");
+    expect(dto).not.toHaveProperty("password");
+    expect(dto).not.toHaveProperty("emailVerified");
   });
 
-  it('toSessionDto omits the session token (=cookie value)', () => {
+  it("toSessionDto omits the session token (=cookie value)", () => {
     const fakeSession = {
-      id: 's-1',
-      userId: 'u-1',
-      token: 'cookie-token-secret',
+      id: "s-1",
+      userId: "u-1",
+      token: "cookie-token-secret",
       expiresAt: new Date(),
-      ipAddress: '1.2.3.4',
-      userAgent: 'test',
+      ipAddress: "1.2.3.4",
+      userAgent: "test",
       createdAt: new Date(),
       updatedAt: new Date(),
     } as unknown as Parameters<typeof toSessionDto>[0];
 
     const dto = toSessionDto(fakeSession);
-    expect(dto).not.toHaveProperty('token');
-    expect(dto).not.toHaveProperty('userId');
+    expect(dto).not.toHaveProperty("token");
+    expect(dto).not.toHaveProperty("userId");
   });
 });

--- a/tests/unit/encryption.test.ts
+++ b/tests/unit/encryption.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { randomBytes } from 'node:crypto';
+import { describe, it, expect, beforeEach } from "vitest";
+import { randomBytes } from "node:crypto";
 
 // Plan 01-04 RED — failing tests for envelope encryption per VALIDATION behaviors
 // 10/11/12/13 (round-trip, tamper detection, missing KEK fail-fast, rotation D-10).
@@ -18,39 +18,38 @@ import { randomBytes } from 'node:crypto';
 
 // Seed the bare minimum env the schema requires. APP_KEK_BASE64 is decoded then
 // scrubbed by env.ts; KEK_CURRENT_VERSION defaults to 1.
-process.env.DATABASE_URL ??= 'postgres://test:test@localhost:5432/test';
-process.env.BETTER_AUTH_URL ??= 'http://localhost:3000';
-process.env.BETTER_AUTH_SECRET ??= 'x'.repeat(40);
-process.env.GOOGLE_CLIENT_ID ??= 'test-google-id';
-process.env.GOOGLE_CLIENT_SECRET ??= 'test-google-secret';
+process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+process.env.BETTER_AUTH_URL ??= "http://localhost:3000";
+process.env.BETTER_AUTH_SECRET ??= "x".repeat(40);
+process.env.GOOGLE_CLIENT_ID ??= "test-google-id";
+process.env.GOOGLE_CLIENT_SECRET ??= "test-google-secret";
 // 32 raw bytes, base64 encoded (44 chars including padding).
-process.env.APP_KEK_BASE64 ??= randomBytes(32).toString('base64');
+process.env.APP_KEK_BASE64 ??= randomBytes(32).toString("base64");
 
-const { env } = await import('../../src/lib/server/config/env.js');
-const { encryptSecret, decryptSecret, rotateDek } = await import(
-  '../../src/lib/server/crypto/envelope.js'
-);
+const { env } = await import("../../src/lib/server/config/env.js");
+const { encryptSecret, decryptSecret, rotateDek } =
+  await import("../../src/lib/server/crypto/envelope.js");
 
-describe('envelope encryption — round-trip (VALIDATION behaviors 10/11)', () => {
-  it('RT1: decryptSecret(encryptSecret(plaintext)) returns identical plaintext', () => {
-    const plaintext = 'hello world';
+describe("envelope encryption — round-trip (VALIDATION behaviors 10/11)", () => {
+  it("RT1: decryptSecret(encryptSecret(plaintext)) returns identical plaintext", () => {
+    const plaintext = "hello world";
     const enc = encryptSecret(plaintext);
     expect(decryptSecret(enc)).toBe(plaintext);
   });
 
-  it('RT2: round trip empty string', () => {
-    expect(decryptSecret(encryptSecret(''))).toBe('');
+  it("RT2: round trip empty string", () => {
+    expect(decryptSecret(encryptSecret(""))).toBe("");
   });
 
-  it('RT3: round trip 4KB unicode (mixed CJK / Cyrillic / emoji)', () => {
+  it("RT3: round trip 4KB unicode (mixed CJK / Cyrillic / emoji)", () => {
     // Validate UTF-8 round-trip across multi-byte code points.
-    const big = '日本語κίνησηабв🎮🎲'.repeat(200).slice(0, 4096);
+    const big = "日本語κίνησηабв🎮🎲".repeat(200).slice(0, 4096);
     expect(decryptSecret(encryptSecret(big))).toBe(big);
   });
 
-  it('U1: same plaintext encrypted twice produces different ciphertexts (random nonce + DEK)', () => {
-    const e1 = encryptSecret('repeat me');
-    const e2 = encryptSecret('repeat me');
+  it("U1: same plaintext encrypted twice produces different ciphertexts (random nonce + DEK)", () => {
+    const e1 = encryptSecret("repeat me");
+    const e2 = encryptSecret("repeat me");
     // Different DEKs and different nonces => different ciphertexts and wrapped DEKs.
     expect(Buffer.compare(e1.secretCt, e2.secretCt)).not.toBe(0);
     expect(Buffer.compare(e1.wrappedDek, e2.wrappedDek)).not.toBe(0);
@@ -59,51 +58,51 @@ describe('envelope encryption — round-trip (VALIDATION behaviors 10/11)', () =
   });
 });
 
-describe('envelope encryption — tamper detection (VALIDATION behavior 12)', () => {
-  it('T1: tampered secretCt throws on decrypt (AES-256-GCM auth-tag mismatch)', () => {
-    const enc = encryptSecret('confidential');
+describe("envelope encryption — tamper detection (VALIDATION behavior 12)", () => {
+  it("T1: tampered secretCt throws on decrypt (AES-256-GCM auth-tag mismatch)", () => {
+    const enc = encryptSecret("confidential");
     const tampered = { ...enc, secretCt: Buffer.from(enc.secretCt) };
     tampered.secretCt[0] ^= 0xff;
     expect(() => decryptSecret(tampered)).toThrow();
   });
 
-  it('T2: tampered secretTag throws on decrypt (auth-tag mismatch)', () => {
-    const enc = encryptSecret('confidential');
+  it("T2: tampered secretTag throws on decrypt (auth-tag mismatch)", () => {
+    const enc = encryptSecret("confidential");
     const tampered = { ...enc, secretTag: Buffer.from(enc.secretTag) };
     tampered.secretTag[0] ^= 0x01;
     expect(() => decryptSecret(tampered)).toThrow();
   });
 
-  it('T3: tampered wrappedDek throws on decrypt (KEK->DEK auth-tag fails first)', () => {
-    const enc = encryptSecret('confidential');
+  it("T3: tampered wrappedDek throws on decrypt (KEK->DEK auth-tag fails first)", () => {
+    const enc = encryptSecret("confidential");
     const tampered = { ...enc, wrappedDek: Buffer.from(enc.wrappedDek) };
     tampered.wrappedDek[0] ^= 0x01;
     expect(() => decryptSecret(tampered)).toThrow();
   });
 
-  it('T4: tampered dekTag throws on decrypt', () => {
-    const enc = encryptSecret('confidential');
+  it("T4: tampered dekTag throws on decrypt", () => {
+    const enc = encryptSecret("confidential");
     const tampered = { ...enc, dekTag: Buffer.from(enc.dekTag) };
     tampered.dekTag[0] ^= 0x01;
     expect(() => decryptSecret(tampered)).toThrow();
   });
 });
 
-describe('envelope encryption — KEK availability (VALIDATION behavior 13)', () => {
-  it('B1: missing KEK version causes clear error mentioning the version number', () => {
+describe("envelope encryption — KEK availability (VALIDATION behavior 13)", () => {
+  it("B1: missing KEK version causes clear error mentioning the version number", () => {
     // Encrypt with the current KEK (v1), then forge a row claiming kek v99
     // which is not loaded into env.KEK_VERSIONS. decryptSecret must fail
     // loudly — proxy for "missing/short KEK at boot" (PITFALL P2 fail-fast):
     // env.ts itself enforces 32-byte length on boot, but if a stored row was
     // encrypted with v2 and the running process only holds v1, we MUST throw
     // before silently corrupting data.
-    const enc = encryptSecret('hello');
+    const enc = encryptSecret("hello");
     const fakeRow = { ...enc, kekVersion: 99 };
     expect(() => decryptSecret(fakeRow)).toThrow(/KEK v99/);
   });
 });
 
-describe('envelope encryption — rotation (D-10, AUTH-03)', () => {
+describe("envelope encryption — rotation (D-10, AUTH-03)", () => {
   beforeEach(() => {
     // Seed a v2 KEK so rotation tests can exercise the two-version path.
     // env.KEK_VERSIONS is exported by reference (Map) so this mutation is seen
@@ -112,8 +111,8 @@ describe('envelope encryption — rotation (D-10, AUTH-03)', () => {
     env.KEK_VERSIONS.set(2, randomBytes(32));
   });
 
-  it('R1: rotateDek re-wraps DEK only — ciphertext is byte-identical', () => {
-    const enc = encryptSecret('confidential payload');
+  it("R1: rotateDek re-wraps DEK only — ciphertext is byte-identical", () => {
+    const enc = encryptSecret("confidential payload");
     const rotated = rotateDek(enc, 2);
     // Ciphertext + its IV + its tag are the unchanged secret payload.
     expect(Buffer.compare(rotated.secretCt, enc.secretCt)).toBe(0);
@@ -127,8 +126,8 @@ describe('envelope encryption — rotation (D-10, AUTH-03)', () => {
     expect(rotated.kekVersion).toBe(2);
   });
 
-  it('R2: rotated row decrypts to original plaintext', () => {
-    const original = 'top secret';
+  it("R2: rotated row decrypts to original plaintext", () => {
+    const original = "top secret";
     const enc = encryptSecret(original);
     const rotated = rotateDek(enc, 2);
     expect(decryptSecret(rotated)).toBe(original);

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -1,27 +1,27 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 
 // Wave 0 placeholder for D-23/D-24 logger discipline.
 // Plan 01-01 lands `src/lib/server/logger.ts`; this file does a sanity check today and
 // Plan 01-04 / Plan 01-07 expand redaction-path assertions.
-describe('logger redaction', () => {
-  it('logger module exposes pino-shaped interface', async () => {
+describe("logger redaction", () => {
+  it("logger module exposes pino-shaped interface", async () => {
     // Until Plan 01-01 lands the logger, this import throws — that's fine; we're scaffolded.
     let logger: unknown = null;
     try {
-      const mod = await import('../../src/lib/server/logger.js');
+      const mod = await import("../../src/lib/server/logger.js");
       logger = (mod as { logger?: unknown }).logger ?? mod;
     } catch {
       // Module not yet present — skip the shape check; placeholder still asserts file exists.
       return;
     }
-    expect(typeof (logger as { info?: unknown }).info).toBe('function');
+    expect(typeof (logger as { info?: unknown }).info).toBe("function");
   });
 
-  it.skip('redacts every D-24 path with [REDACTED]', () => {
+  it.skip("redacts every D-24 path with [REDACTED]", () => {
     /* Plan 01-04 wires real redaction-path assertions (apiKey, refreshToken, wrappedDek, …) */
   });
 
-  it.skip('process.env.* is not accessed outside src/lib/server/config/env.ts', () => {
+  it.skip("process.env.* is not accessed outside src/lib/server/config/env.ts", () => {
     /* Plan 01-07: lint/grep gate so KEK-shaped secrets cannot leak via console.log */
   });
 });

--- a/tests/unit/paraglide.test.ts
+++ b/tests/unit/paraglide.test.ts
@@ -1,65 +1,65 @@
-import { describe, it, expect } from 'vitest';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
 
 // Plan 01-09 (Wave 4) — UX-04 i18n structure.
 // VALIDATION 18: Paraglide message function resolves at runtime.
 // VALIDATION 19: Adding a locale = drop a JSON file (no source-code change).
 // D-17: baseLocale only in MVP — no locale detection.
 // D-18: single messages/en.json at repo root.
-describe('paraglide i18n (UX-04)', () => {
-  it('VALIDATION 18: messages/en.json contains expected keys with the right English values', () => {
-    const raw = JSON.parse(fs.readFileSync(path.resolve('messages/en.json'), 'utf8'));
-    expect(raw.dashboard_title).toBe('Promotion diary');
-    expect(raw.login_button).toBe('Sign in with Google');
-    expect(raw.sign_out).toBe('Sign out');
-    expect(raw.sign_out_all_devices).toBe('Sign out from all devices');
+describe("paraglide i18n (UX-04)", () => {
+  it("VALIDATION 18: messages/en.json contains expected keys with the right English values", () => {
+    const raw = JSON.parse(fs.readFileSync(path.resolve("messages/en.json"), "utf8"));
+    expect(raw.dashboard_title).toBe("Promotion diary");
+    expect(raw.login_button).toBe("Sign in with Google");
+    expect(raw.sign_out).toBe("Sign out");
+    expect(raw.sign_out_all_devices).toBe("Sign out from all devices");
   });
 
-  it('VALIDATION 18: m.dashboard_title resolves to English at runtime (when paraglide built)', async () => {
+  it("VALIDATION 18: m.dashboard_title resolves to English at runtime (when paraglide built)", async () => {
     // The compiled messages.js is gitignored. If present (CI runs `pnpm build`
     // first; local dev runs `pnpm dev` which compiles on demand), import it.
     // Otherwise this test is a contract assertion against the JSON.
     try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const mod: any = await import('../../src/lib/paraglide/messages.js' as string);
-      expect(typeof mod.m.dashboard_title).toBe('function');
-      expect(mod.m.dashboard_title()).toBe('Promotion diary');
+      const mod: any = await import("../../src/lib/paraglide/messages.js" as string);
+      expect(typeof mod.m.dashboard_title).toBe("function");
+      expect(mod.m.dashboard_title()).toBe("Promotion diary");
     } catch {
       // Compiled output not available (test not run after build).
       // Assertion above on messages/en.json is sufficient for the unit-test gate.
     }
   });
 
-  it('VALIDATION 19: adding messages/ru.json is content-only — keyset must match en.json (snapshot)', () => {
+  it("VALIDATION 19: adding messages/ru.json is content-only — keyset must match en.json (snapshot)", () => {
     // The CONTRACT is: every locale file MUST share en.json's keyset.
     // This test snapshots the en.json keyset; if a future PR adds a key to en.json,
     // the snapshot must be updated AND every other locale file extended.
     // Adding a brand new locale is purely "drop a JSON file matching this keyset"
     // — no source change required.
-    const raw = JSON.parse(fs.readFileSync(path.resolve('messages/en.json'), 'utf8'));
+    const raw = JSON.parse(fs.readFileSync(path.resolve("messages/en.json"), "utf8"));
     const keys = Object.keys(raw)
-      .filter((k) => !k.startsWith('$'))
+      .filter((k) => !k.startsWith("$"))
       .sort();
     // Asserting an explicit keyset (vs toMatchSnapshot) is more durable across renames.
     expect(keys).toEqual([
-      'app_title',
-      'dashboard_title',
-      'dashboard_unauth_intro',
-      'dashboard_welcome_intro',
-      'login_button',
-      'login_continue',
-      'login_page_title',
-      'sign_out',
-      'sign_out_all_devices',
+      "app_title",
+      "dashboard_title",
+      "dashboard_unauth_intro",
+      "dashboard_welcome_intro",
+      "login_button",
+      "login_continue",
+      "login_page_title",
+      "sign_out",
+      "sign_out_all_devices",
     ]);
   });
 
-  it('UX-04 invariant: project.inlang/settings.json has baseLocale=en and a single locale in MVP (D-17)', () => {
+  it("UX-04 invariant: project.inlang/settings.json has baseLocale=en and a single locale in MVP (D-17)", () => {
     const settings = JSON.parse(
-      fs.readFileSync(path.resolve('project.inlang/settings.json'), 'utf8'),
+      fs.readFileSync(path.resolve("project.inlang/settings.json"), "utf8"),
     );
-    expect(settings.baseLocale).toBe('en');
-    expect(settings.locales).toEqual(['en']);
+    expect(settings.baseLocale).toBe("en");
+    expect(settings.locales).toEqual(["en"]);
   });
 });

--- a/tests/unit/proxy-trust.test.ts
+++ b/tests/unit/proxy-trust.test.ts
@@ -1,22 +1,20 @@
-import { describe, it, expect } from 'vitest';
-import { Hono } from 'hono';
-import { randomBytes } from 'node:crypto';
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { randomBytes } from "node:crypto";
 
 // Seed env BEFORE importing the module under test (matches Plan 04's env-shape contract).
-process.env.DATABASE_URL ??= 'postgres://test:test@localhost:5432/test';
-process.env.BETTER_AUTH_URL ??= 'http://localhost:3000';
-process.env.BETTER_AUTH_SECRET ??= 'x'.repeat(40);
-process.env.GOOGLE_CLIENT_ID ??= 'test';
-process.env.GOOGLE_CLIENT_SECRET ??= 'test';
-process.env.APP_KEK_BASE64 ??= randomBytes(32).toString('base64');
+process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+process.env.BETTER_AUTH_URL ??= "http://localhost:3000";
+process.env.BETTER_AUTH_SECRET ??= "x".repeat(40);
+process.env.GOOGLE_CLIENT_ID ??= "test";
+process.env.GOOGLE_CLIENT_SECRET ??= "test";
+process.env.APP_KEK_BASE64 ??= randomBytes(32).toString("base64");
 // Trusted CIDRs for these tests: private LAN, loopback, IPv6 loopback,
 // and a real Cloudflare IPv6 prefix (PT4).
-process.env.TRUSTED_PROXY_CIDR ??=
-  '10.0.0.0/8,127.0.0.1/32,::1/128,2400:cb00::/32';
+process.env.TRUSTED_PROXY_CIDR ??= "10.0.0.0/8,127.0.0.1/32,::1/128,2400:cb00::/32";
 
-const { parseCidrList, isTrusted, proxyTrust } = await import(
-  '../../src/lib/server/http/middleware/proxy-trust.js'
-);
+const { parseCidrList, isTrusted, proxyTrust } =
+  await import("../../src/lib/server/http/middleware/proxy-trust.js");
 
 /**
  * Build a tiny Hono app under proxyTrust that echoes the resolved
@@ -26,12 +24,10 @@ const { parseCidrList, isTrusted, proxyTrust } = await import(
  */
 function buildEchoApp() {
   const app = new Hono<{
-    Variables: { clientIp: string; clientProto: 'http' | 'https' };
+    Variables: { clientIp: string; clientProto: "http" | "https" };
   }>();
-  app.use('*', proxyTrust);
-  app.get('/echo', (c) =>
-    c.json({ clientIp: c.var.clientIp, clientProto: c.var.clientProto }),
-  );
+  app.use("*", proxyTrust);
+  app.get("/echo", (c) => c.json({ clientIp: c.var.clientIp, clientProto: c.var.clientProto }));
   return app;
 }
 
@@ -40,123 +36,123 @@ function fakeIncoming(remoteAddress: string, encrypted = false) {
   return { incoming: { socket: { remoteAddress, encrypted } } };
 }
 
-describe('proxy-trust: parseCidrList (helper)', () => {
-  it('empty string returns empty array', () => {
-    expect(parseCidrList('')).toEqual([]);
-    expect(parseCidrList('   ')).toEqual([]);
+describe("proxy-trust: parseCidrList (helper)", () => {
+  it("empty string returns empty array", () => {
+    expect(parseCidrList("")).toEqual([]);
+    expect(parseCidrList("   ")).toEqual([]);
   });
 
-  it('parses IPv4 and IPv6 CIDRs', () => {
-    const r = parseCidrList('10.0.0.0/8, 192.168.0.0/16, ::1/128');
+  it("parses IPv4 and IPv6 CIDRs", () => {
+    const r = parseCidrList("10.0.0.0/8, 192.168.0.0/16, ::1/128");
     expect(r).toHaveLength(3);
-    expect(r[0]!.kind).toBe('ipv4');
-    expect(r[2]!.kind).toBe('ipv6');
+    expect(r[0]!.kind).toBe("ipv4");
+    expect(r[2]!.kind).toBe("ipv6");
   });
 
-  it('throws on invalid CIDR', () => {
-    expect(() => parseCidrList('not-a-cidr')).toThrow(/invalid CIDR/);
-  });
-});
-
-describe('proxy-trust: isTrusted (helper)', () => {
-  it('10.0.0.5 is trusted (matches 10.0.0.0/8)', () => {
-    expect(isTrusted('10.0.0.5')).toBe(true);
-  });
-
-  it('1.2.3.4 is NOT trusted', () => {
-    expect(isTrusted('1.2.3.4')).toBe(false);
-  });
-
-  it('IPv4-mapped IPv6 normalises to IPv4 matcher', () => {
-    expect(isTrusted('::ffff:10.0.0.5')).toBe(true);
-  });
-
-  it('IPv6 ::1 matches ::1/128', () => {
-    expect(isTrusted('::1')).toBe(true);
+  it("throws on invalid CIDR", () => {
+    expect(() => parseCidrList("not-a-cidr")).toThrow(/invalid CIDR/);
   });
 });
 
-describe('proxy-trust: middleware behavior PT1-PT6 (CVE-2026-27700 mitigation)', () => {
-  it('PT1: untrusted source — XFF ignored, clientIp = socket peer', async () => {
-    const app = buildEchoApp();
-    const res = await app.request(
-      '/echo',
-      { headers: { 'x-forwarded-for': '1.2.3.4' } },
-      fakeIncoming('99.99.99.99'), // not trusted
-    );
-    const body = (await res.json()) as { clientIp: string };
-    expect(body.clientIp).toBe('99.99.99.99');
+describe("proxy-trust: isTrusted (helper)", () => {
+  it("10.0.0.5 is trusted (matches 10.0.0.0/8)", () => {
+    expect(isTrusted("10.0.0.5")).toBe(true);
   });
 
-  it('PT2: trusted source + multi-hop XFF — walk right-to-left, drop trusted hops, return first untrusted IP', async () => {
-    const app = buildEchoApp();
-    const res = await app.request(
-      '/echo',
-      { headers: { 'x-forwarded-for': '1.2.3.4, 10.0.0.1, 10.0.0.2' } },
-      fakeIncoming('10.0.0.5'), // trusted (10.0.0.0/8)
-    );
-    const body = (await res.json()) as { clientIp: string };
-    expect(body.clientIp).toBe('1.2.3.4');
+  it("1.2.3.4 is NOT trusted", () => {
+    expect(isTrusted("1.2.3.4")).toBe(false);
   });
 
-  it('PT3: untrusted source — XFF spoofing rejected; CVE-2026-27700 mitigation', async () => {
-    const app = buildEchoApp();
-    const res = await app.request(
-      '/echo',
-      { headers: { 'x-forwarded-for': '8.8.8.8' } },
-      fakeIncoming('203.0.113.7'), // untrusted public IP
-    );
-    const body = (await res.json()) as { clientIp: string };
-    expect(body.clientIp).toBe('203.0.113.7');
-    expect(body.clientIp).not.toBe('8.8.8.8');
+  it("IPv4-mapped IPv6 normalises to IPv4 matcher", () => {
+    expect(isTrusted("::ffff:10.0.0.5")).toBe(true);
   });
 
-  it('PT4: trusted CF source — CF-Connecting-IP preferred over XFF', async () => {
+  it("IPv6 ::1 matches ::1/128", () => {
+    expect(isTrusted("::1")).toBe(true);
+  });
+});
+
+describe("proxy-trust: middleware behavior PT1-PT6 (CVE-2026-27700 mitigation)", () => {
+  it("PT1: untrusted source — XFF ignored, clientIp = socket peer", async () => {
     const app = buildEchoApp();
     const res = await app.request(
-      '/echo',
+      "/echo",
+      { headers: { "x-forwarded-for": "1.2.3.4" } },
+      fakeIncoming("99.99.99.99"), // not trusted
+    );
+    const body = (await res.json()) as { clientIp: string };
+    expect(body.clientIp).toBe("99.99.99.99");
+  });
+
+  it("PT2: trusted source + multi-hop XFF — walk right-to-left, drop trusted hops, return first untrusted IP", async () => {
+    const app = buildEchoApp();
+    const res = await app.request(
+      "/echo",
+      { headers: { "x-forwarded-for": "1.2.3.4, 10.0.0.1, 10.0.0.2" } },
+      fakeIncoming("10.0.0.5"), // trusted (10.0.0.0/8)
+    );
+    const body = (await res.json()) as { clientIp: string };
+    expect(body.clientIp).toBe("1.2.3.4");
+  });
+
+  it("PT3: untrusted source — XFF spoofing rejected; CVE-2026-27700 mitigation", async () => {
+    const app = buildEchoApp();
+    const res = await app.request(
+      "/echo",
+      { headers: { "x-forwarded-for": "8.8.8.8" } },
+      fakeIncoming("203.0.113.7"), // untrusted public IP
+    );
+    const body = (await res.json()) as { clientIp: string };
+    expect(body.clientIp).toBe("203.0.113.7");
+    expect(body.clientIp).not.toBe("8.8.8.8");
+  });
+
+  it("PT4: trusted CF source — CF-Connecting-IP preferred over XFF", async () => {
+    const app = buildEchoApp();
+    const res = await app.request(
+      "/echo",
       {
         headers: {
-          'cf-connecting-ip': '5.6.7.8',
-          'x-forwarded-for': '99.99.99.99, 10.0.0.1',
+          "cf-connecting-ip": "5.6.7.8",
+          "x-forwarded-for": "99.99.99.99, 10.0.0.1",
         },
       },
-      fakeIncoming('2400:cb00::1'), // trusted Cloudflare CIDR
+      fakeIncoming("2400:cb00::1"), // trusted Cloudflare CIDR
     );
     const body = (await res.json()) as { clientIp: string };
-    expect(body.clientIp).toBe('5.6.7.8');
+    expect(body.clientIp).toBe("5.6.7.8");
   });
 
-  it('PT5: untrusted source with CF-Connecting-IP set — header IGNORED (attacker can set arbitrary headers)', async () => {
+  it("PT5: untrusted source with CF-Connecting-IP set — header IGNORED (attacker can set arbitrary headers)", async () => {
     const app = buildEchoApp();
     const res = await app.request(
-      '/echo',
-      { headers: { 'cf-connecting-ip': '5.6.7.8' } },
-      fakeIncoming('203.0.113.99'), // untrusted
+      "/echo",
+      { headers: { "cf-connecting-ip": "5.6.7.8" } },
+      fakeIncoming("203.0.113.99"), // untrusted
     );
     const body = (await res.json()) as { clientIp: string };
-    expect(body.clientIp).toBe('203.0.113.99');
-    expect(body.clientIp).not.toBe('5.6.7.8');
+    expect(body.clientIp).toBe("203.0.113.99");
+    expect(body.clientIp).not.toBe("5.6.7.8");
   });
 
-  it('PT6: X-Forwarded-Proto respected only from trusted source (HSTS-relevant)', async () => {
+  it("PT6: X-Forwarded-Proto respected only from trusted source (HSTS-relevant)", async () => {
     const app = buildEchoApp();
     // From trusted source: XFP=https → clientProto='https'
     const trustedRes = await app.request(
-      '/echo',
-      { headers: { 'x-forwarded-proto': 'https' } },
-      fakeIncoming('10.0.0.5'),
+      "/echo",
+      { headers: { "x-forwarded-proto": "https" } },
+      fakeIncoming("10.0.0.5"),
     );
     const trustedBody = (await trustedRes.json()) as { clientProto: string };
-    expect(trustedBody.clientProto).toBe('https');
+    expect(trustedBody.clientProto).toBe("https");
 
     // From untrusted source: XFP=https → IGNORED, clientProto remains http
     const untrustedRes = await app.request(
-      '/echo',
-      { headers: { 'x-forwarded-proto': 'https' } },
-      fakeIncoming('203.0.113.7'),
+      "/echo",
+      { headers: { "x-forwarded-proto": "https" } },
+      fakeIncoming("203.0.113.7"),
     );
     const untrustedBody = (await untrustedRes.json()) as { clientProto: string };
-    expect(untrustedBody.clientProto).toBe('http');
+    expect(untrustedBody.clientProto).toBe("http");
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,15 +7,11 @@
     "moduleResolution": "bundler",
     "module": "ESNext",
     "target": "ES2022",
-    "lib": ["ES2023"],
+    "lib": ["ES2023", "DOM"],
     "types": ["node", "vitest/globals"],
-    "baseUrl": ".",
-    "paths": {
-      "$lib": ["./src/lib"],
-      "$lib/*": ["./src/lib/*"]
-    },
     "resolveJsonModule": true,
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true
   },
   "include": ["src/**/*", "tests/**/*", "*.config.ts", "*.config.js"],
   "exclude": ["node_modules", "build", ".svelte-kit", "dist"]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from "vitest/config";
 
 // Vitest 4 supports test.projects to split unit (no DB) from integration (with DB).
 // Plan 01-02 (Phase 1 Wave 0) lands the structural split; later plans wire real assertions.
@@ -15,25 +15,25 @@ export default defineConfig({
     projects: [
       {
         test: {
-          name: 'unit',
-          include: ['tests/unit/**/*.test.ts'],
-          environment: 'node',
+          name: "unit",
+          include: ["tests/unit/**/*.test.ts"],
+          environment: "node",
         },
       },
       {
         test: {
-          name: 'integration',
-          include: ['tests/integration/**/*.test.ts'],
-          environment: 'node',
-          setupFiles: ['./tests/setup.ts'],
+          name: "integration",
+          include: ["tests/integration/**/*.test.ts"],
+          environment: "node",
+          setupFiles: ["./tests/setup.ts"],
           testTimeout: 30_000,
           // Each spec file runs in its own forked worker; avoids global pg.Pool state leak
           // between specs while keeping parallelism for unrelated files.
-          pool: 'forks',
+          pool: "forks",
           poolOptions: { forks: { singleFork: false } },
         },
       },
     ],
-    reporters: ['default'],
+    reporters: ["default"],
   },
 });


### PR DESCRIPTION
## Summary

First feature-branch PR after switching to a PR-only workflow.

- `prettier --write` over `src/`, `tests/`, plus the three root files prettier was complaining about (`docker-compose.selfhost.yml`, `eslint.config.js`, `vitest.config.ts`).
- Drop stale `eslint-disable-next-line no-restricted-properties` comments in `src/lib/server/config/env.ts` (the flat-config carve-out already exempts this file).
- Drop stale `eslint-disable-next-line no-console` comments in `src/worker/index.ts`, `src/scheduler/index.ts`, `tests/setup.ts` (no-console is not enabled).
- `tsconfig.json`: add `skipLibCheck: true` (drizzle-orm bundles `gel-core` and `mysql-core` dialect types we don't use), drop the redundant `baseUrl`/`paths` block (kit.alias in `svelte.config.js` already provides `$lib`), add `DOM` to `lib` for `RequestInit` in test fetch helpers.

## Status

- [x] `Run pnpm lint` is **green** — the eight lint warnings + every prettier formatting warning are resolved
- [x] `Run pnpm test:unit` is **green**
- [x] `Run pnpm install --frozen-lockfile` is **green**
- [ ] `Run pnpm typecheck` — still red, but fails on real Phase 1 implementation issues, not on `node_modules`. Belongs in a separate PR (Paraglide compiled output missing, noUncheckedIndexedAccess hits, paraglide-js/vite import path, oauth2-mock-server type cast).
- [ ] `Run pnpm test:integration` — still red on auth (3) + tenant-scope (1) + anonymous-401 (1). Pre-existing master state. Belongs in a separate PR.

## Test plan

- [x] CI `lint-typecheck` job's `pnpm lint` step passes
- [x] Unit-test job runs to completion (test:unit green; test:integration is pre-existing red)
- [x] No new prettier `[warn]` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)