### PR TITLE
Post Phase 1 review: P0/P1 fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,16 +5,24 @@
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/neotolis
 BETTER_AUTH_URL=http://localhost:3000
 BETTER_AUTH_SECRET=replace-with-32-char-random-hex-or-longer-please
-GOOGLE_CLIENT_ID=your-google-oauth-client-id
-GOOGLE_CLIENT_SECRET=your-google-oauth-client-secret
+OAUTH_CLIENT_ID=your-google-oauth-client-id
+OAUTH_CLIENT_SECRET=your-google-oauth-client-secret
 APP_KEK_BASE64=base64-encoded-32-bytes-here  # generate with: openssl rand -base64 32
 
-# OAuth discovery URL — Better Auth's genericOAuth plugin fetches the
-# authorize/token/userinfo endpoints from this OIDC discovery document at
-# boot. Default is real Google. Override for self-host operators using a
-# different IdP (e.g. Authentik, Keycloak) or for CI/smoke pointing at
-# oauth2-mock-server.
-# GOOGLE_DISCOVERY_URL=https://accounts.google.com/.well-known/openid-configuration
+# OAuth identity provider (advanced — self-host only)
+#
+# By default the app authenticates against Google. SaaS NEVER overrides
+# any of these. A self-host operator MAY point at any OIDC-compatible
+# IdP (Keycloak, Authentik, Auth0, ...) at their own risk — this is
+# unsupported / advanced: the app's UX, message strings, and audit
+# semantics assume Google, and switching IdPs after rows already exist
+# requires manual data migration.
+#
+# OAUTH_PROVIDER_ID is written to `account.providerId`. If you change
+# OAUTH_DISCOVERY_URL to a non-Google IdP you MUST also change
+# OAUTH_PROVIDER_ID — otherwise rows are mislabelled.
+# OAUTH_PROVIDER_ID=google
+# OAUTH_DISCOVERY_URL=https://accounts.google.com/.well-known/openid-configuration
 
 # Override Better Auth's secure-cookie default. Defaults to NODE_ENV ===
 # "production". Set to "false" if you run the production image behind a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,13 +49,13 @@ jobs:
       # (override via repo secret CI_BETTER_AUTH_SECRET if you want a unique one per repo).
       BETTER_AUTH_SECRET: ${{ secrets.CI_BETTER_AUTH_SECRET || 'ci-secret-must-be-32-chars-long-or-more' }}
       BETTER_AUTH_URL: http://localhost:3000
-      GOOGLE_CLIENT_ID: ci-mock-client-id
-      GOOGLE_CLIENT_SECRET: ci-mock-client-secret
+      OAUTH_CLIENT_ID: ci-mock-client-id
+      OAUTH_CLIENT_SECRET: ci-mock-client-secret
       # Better Auth's genericOAuth plugin fetches OIDC discovery from this URL
       # at boot. Integration tests don't actually drive the OAuth dance (they
       # use seedUserDirectly), but env.ts validates this at module load so a
       # syntactically-valid URL is required.
-      GOOGLE_DISCOVERY_URL: http://localhost:9090/.well-known/openid-configuration
+      OAUTH_DISCOVERY_URL: http://localhost:9090/.well-known/openid-configuration
       # Test KEK is a base64-encoded 32-byte string ("test-kek-" repeated to fill 32 bytes
       # then base64-encoded). Plan 01-04's envelope module verifies this passes the
       # length / base64 / fail-fast guards.
@@ -91,10 +91,10 @@ jobs:
     env:
       BETTER_AUTH_SECRET: ci-smoke-better-auth-secret-32-chars-min
       BETTER_AUTH_URL: http://localhost:3000
-      GOOGLE_CLIENT_ID: mock-client-id
-      GOOGLE_CLIENT_SECRET: mock-client-secret
+      OAUTH_CLIENT_ID: mock-client-id
+      OAUTH_CLIENT_SECRET: mock-client-secret
       # genericOAuth plugin discovery URL; smoke runs the mock on localhost:9090.
-      GOOGLE_DISCOVERY_URL: http://localhost:9090/.well-known/openid-configuration
+      OAUTH_DISCOVERY_URL: http://localhost:9090/.well-known/openid-configuration
       APP_KEK_BASE64: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/neotolis
       # Smoke runs the production image over plain HTTP; Better Auth would

--- a/.planning/phases/01-foundation/01-10-SUMMARY.md
+++ b/.planning/phases/01-foundation/01-10-SUMMARY.md
@@ -1,0 +1,91 @@
+---
+phase: 01-foundation
+plan: 10
+subsystem: self-host-smoke
+tags: [smoke, deploy-05, oauth2-mock-server, d-13, d-14, d-15, ci-gate, image-entrypoint, generic-oauth, info-i2-path-2]
+
+# Dependency graph
+requires:
+  - phase: 01-foundation
+    provides: Plan 01-02 (CI workflow scaffold + smoke job + Wave 0 self-host.sh stub), Plan 01-05 (Better Auth handler with genericOAuth plugin — INFO I2 Path 2), Plan 01-06 (Hono app + SvelteKit pass-through + /healthz + /readyz at D-21 semantics + worker/scheduler stubs at D-01 paths), Plan 01-07 (tenantScope on /api/* + /api/me + DTO discipline), Plan 01-08 (real pg-boss worker/scheduler entrypoints emitting `worker ready` / `scheduler ready`), Plan 01-09 (Paraglide compiled `Promotion diary` literal in messages/en.json)
+provides:
+  - tests/smoke/self-host.sh — full Phase-1-scoped self-host smoke test gating every PR (DEPLOY-05). Six numbered assertions per D-15: (1) APP_ROLE=app boots, /healthz 200, /readyz 200; (2) APP_ROLE=worker boots, stdout contains `worker ready`; (3) APP_ROLE=scheduler boots, stdout contains `scheduler ready`; (4) OAuth login lands on /api/me + dashboard renders Paraglide English; (5) anonymous /api/me returns 401, cross-tenant probe returns user B (never user A); (6) container has no CF_*/CLOUDFLARE_*/ANALYTICS_* env vars set. Exits non-zero on any miss; cleanup trap stops/removes containers on exit. ALL `docker run` invocations exercise the image's actual ENTRYPOINT (no `sh -c` wrapper, no `--entrypoint` override) — the production startup path is what's under test.
+  - tests/smoke/lib/oauth-mock-driver.ts — `oauth2-mock-server`-driven OAuth dance helper invoked from the bash script via `pnpm tsx`. Boots an OIDC mock IdP on localhost:9090, configures `beforeUserinfo` + `beforeTokenSigning` to mint claims for the requested fixture user, replays the Better Auth `/api/auth/sign-in/google?callbackURL=/` redirect dance manually with `redirect: 'manual'` so cookies accumulate in a Map jar, prints `neotolis.session_token=<value>` on stdout for the bash script to `$()`-capture.
+  - .github/workflows/ci.yml — smoke job adjusted: `pnpm build` runs BEFORE `docker build` (so the host workspace's compiled SvelteKit + Paraglide artifacts match the image's), `BETTER_AUTH_SECURE_COOKIES=false` env (review blocker P1 — production image runs over plain HTTP behind a TLS-terminating proxy in self-host), `GOOGLE_DISCOVERY_URL` points at the mock IdP for the smoke job's lifetime.
+  - .planning/phases/01-foundation/01-VALIDATION.md — Per-Task Verification Map fully populated (33 rows including PT1-PT6 split + deferred Phase-2 cross-tenant write/delete), `nyquist_compliant: true`, status: ratified.
+affects: [Phase 2 SC#1 (smoke extends to "user A creates a game" via the new /api/games endpoints; cross-tenant matrix expands from /api/me sentinel to /api/games), Phase 3 SC#2 (smoke extends to enqueue + process a poll-stub job end-to-end + assert metric_snapshots immutability + worker SIGTERM drain), every later phase (the smoke gate is now load-bearing — any PR that breaks self-host parity fails CI before merge)]
+
+# Tech tracking
+tech-stack:
+  added: []  # oauth2-mock-server@^7.2.0 already pinned by Plan 01-02 Wave 0; no new deps.
+  patterns:
+    - "Image-ENTRYPOINT exercise (BLOCKER 7 fix): every `docker run` in the smoke script omits `--entrypoint` and never uses `sh -c`. The Dockerfile's `ENTRYPOINT [\"node\", \"build/server.js\"]` is the production startup path; the smoke test exercises it verbatim. APP_ROLE=app boots a long-lived container detached with `-d`; worker/scheduler boot detached and the bash script tails `docker logs -f <name> | grep -m1 \"<signal>\"` with `set +o pipefail` around the pipe (grep -m1 closes the pipe → docker logs dies with SIGPIPE → pipefail would propagate that nonzero even though grep matched; disable pipefail just for the pipeline)."
+    - "INFO I2 Path 2 (genericOAuth) chosen over Path 1 (env-driven Google issuer override) and Path 3 (mock-mints-real-Google-iss). Better Auth 1.6.x's `socialProviders.google` hardcodes Google's authorize/token endpoints — no `discoveryUrl` knob. The genericOAuth plugin DOES expose `discoveryUrl`, so the same code points at https://accounts.google.com/.well-known/openid-configuration in production and http://localhost:9090/.well-known/openid-configuration in CI/smoke. The account row's `providerId` stays 'google' by construction (the plugin uses the configured providerId verbatim). Rationale recorded in src/lib/auth.ts header comment."
+    - "D-13 mechanism = `oauth2-mock-server` (CONTEXT.md `<deviations>` 2026-04-27): Better Auth has no native dev provider in 1.6.x, so the original D-13 phrasing 'Better Auth's built-in test provider' was substituted at planning time. The mock server runs as a sidecar in the smoke job (started inside `oauth-mock-driver.ts`), generates its own RS256 keypair, and exposes `/.well-known/openid-configuration` so the genericOAuth plugin's discovery flow works end-to-end."
+    - "Common-env helper (`common_env_args`): every role gets the full env set via a shared bash function rather than three near-identical `-e` lists. env.ts is module-level and validates everything at import time, so worker/scheduler need every var the app role needs even though they don't use the HTTP/auth ones at runtime. Helper makes it impossible to drift the lists."
+    - "Cleanup trap: bash `trap cleanup EXIT` ensures `docker stop` + `docker rm` of all three smoke containers run even on failure or Ctrl-C. Without it a failed CI run leaks dangling containers that the next run's `docker run --name smoke-app` would conflict with."
+
+key-files:
+  created:
+    - tests/smoke/self-host.sh
+    - tests/smoke/lib/oauth-mock-driver.ts
+  modified:
+    - .github/workflows/ci.yml             # smoke job: pnpm build before docker build; BETTER_AUTH_SECURE_COOKIES=false; GOOGLE_DISCOVERY_URL pointing at mock
+    - .planning/phases/01-foundation/01-VALIDATION.md  # frontmatter ratified; nyquist_compliant: true; full per-task map with PT1-PT6 split + deferred Phase-2 entries
+
+key-decisions:
+  - "INFO I2 path resolution = Path 2 (genericOAuth plugin with discoveryUrl). Original D-13 mechanism (Better Auth's built-in dev/test provider) does not exist in 1.6.x; original drop-in (`socialProviders.google`) hardcodes Google's endpoints with no override knob. genericOAuth was chosen during the post-Phase-1 review-blocker fix (P0-2) because: (a) it gives env-driven `discoveryUrl` so the same code serves real Google in production and oauth2-mock-server in CI/smoke; (b) the account row's `providerId` stays 'google' verbatim — no schema migration; (c) PKCE + scopes config is identical between paths. Rationale captured in src/lib/auth.ts inline comment + this summary."
+  - "BLOCKER 7 mitigation choice — `docker run -d` + `docker logs -f | grep -m1`. Alternatives considered: (a) `docker run --rm` blocking and parsing exit code — rejected because pg-boss workers are long-lived; we want to test that they BOOT, not that they exit; (b) `docker exec` after a startup poll — rejected because the worker doesn't expose an HTTP endpoint to poll. The detached + log-grep pattern is the standard way to test 'service emits ready signal then keeps running'. The pipefail-around-grep nuance is documented inline in the script."
+  - "All env vars to all three roles. The temptation was to send only DATABASE_URL + APP_KEK_BASE64 to worker/scheduler since they don't use Better Auth at runtime. But env.ts is module-level — `RawSchema.parse(process.env)` runs on every import. Worker/scheduler imports the env module (transitively, via logger / db / queue-client). If GOOGLE_CLIENT_ID is missing, parse fails, container exits non-zero, and the smoke test reports 'worker did not print ready signal' — confusing root cause. Sending the full env set keeps env.ts as the SOLE diagnostic point for missing config."
+  - "Six explicit numbered assertions, no clever DRY. The script reads top-to-bottom as a checklist matching D-15 verbatim. A future contributor reading a CI failure log sees `(2) FAIL: worker did not print 'worker ready' within 30s` — knows exactly which D-15 invariant broke. Earlier draft tried to loop over a `(role, signal)` table; rejected because the loop noise made CI logs harder to scan."
+  - "Re-fataling the dashboard-render assertion (post-Phase-1 review Fix 1 + Fix 2). The original Plan 10 contract had `(4)` fail loudly when the SvelteKit dashboard didn't render the Paraglide string. During the original Phase-1 cleanup the assertion was softened to a `PARTIAL` log line because `build/handler.js` was failing to load inside the production image — the dynamic import in src/roles/app.ts caught the throw and fell back to the 404 stub, so `GET /` never returned the dashboard HTML. Root cause was a zod version mismatch (Better Auth 1.6.9 uses zod-v4 syntax `.meta()`; the project pinned zod ^3.23.8 which hoisted to 3.25.76; the bundled `import * as z$1 from 'zod'` resolved to v3 and threw at hooks-init). Fixed by aligning the project's zod to ^4.3.6 (and @hono/zod-validator to ^0.7.0 for compatibility). Once handler.js loaded cleanly, the dashboard-render assertion was flipped back to fatal. Both diffs landed in the same review PR."
+
+requirements-completed: [DEPLOY-05, AUTH-01, AUTH-02, AUTH-03, PRIV-01, UX-04]
+
+# Metrics
+duration: ~30min (initial plan + post-Phase-1 review fixes)
+completed: 2026-04-27
+---
+
+# Phase 1 Plan 10: Self-Host Smoke Test Gating Every PR (DEPLOY-05) Summary
+
+**Landed the Phase-1-scoped self-host CI smoke gate: `tests/smoke/self-host.sh` boots the production Docker image in all three roles via the image's actual ENTRYPOINT, drives a real Google OAuth login through `oauth2-mock-server` via `tests/smoke/lib/oauth-mock-driver.ts` (D-13 mechanism per CONTEXT.md `<deviations>` 2026-04-27), asserts the empty dashboard renders the Paraglide English string `Promotion diary`, hits anonymous-401 + cross-tenant /api/me sentinel, and confirms no SaaS-only env var is required for boot. CI's smoke job runs `pnpm build` → `docker build -t neotolis:ci .` → SaaS-leak source grep → `bash tests/smoke/self-host.sh` and fails the PR on any miss. Better Auth's Google integration uses the genericOAuth plugin with env-driven `discoveryUrl` (INFO I2 Path 2, chosen during the post-Phase-1 review-blocker fix to replace the original Path 0 'Better Auth socialProviders.google' that hardcoded Google's endpoints) so the same code points at real Google in production and at the mock IdP in CI. The dashboard-render assertion was softened during the original Phase-1 cleanup (HTTP 404 from a failed `build/handler.js` import inside the container) and was made fatal again in the post-Phase-1 review PR after the root cause — a zod version mismatch between the project (v3) and Better Auth (v4) — was fixed by aligning the project's zod to ^4.3.6.**
+
+## Performance
+
+- **Duration:** ~30 min initial; ~25 min for the post-Phase-1 review fixes (Fix 1 root-cause investigation + Fix 2 re-fataling)
+- **Tasks:** 3 / 3 (Task 1 script + driver, Task 2 human checkpoint, Task 3 VALIDATION.md ratification)
+
+## Accomplishments
+
+- `tests/smoke/self-host.sh` ships the full six-assertion D-15 contract (Phase 1 scope per the 2026-04-27 deferral):
+  1. APP_ROLE=app boots → `/healthz` returns `ok` → `/readyz` returns `{"ok":true}` after migrations.
+  2. APP_ROLE=worker boots → stdout contains `worker ready` (Plan 08 dual-emit; bash greps the literal line).
+  3. APP_ROLE=scheduler boots → stdout contains `scheduler ready`.
+  4. OAuth login via `oauth-mock-driver.ts` → `/api/me` returns the seeded user → dashboard renders `Promotion diary` (Paraglide UX-04).
+  5. Anonymous `/api/me` returns 401; user B's `/api/me` shows user B (never user A's email leaks across tenants).
+  6. Running app container has no `CF_*` / `CLOUDFLARE_*` / `ANALYTICS_*` env vars set (D-14 runtime side; the `.github/workflows/ci.yml` source grep is the static side).
+- `tests/smoke/lib/oauth-mock-driver.ts` boots `oauth2-mock-server` on localhost:9090, generates RS256 keys, configures `beforeUserinfo` + `beforeTokenSigning` so the mock mints `{ sub, email, email_verified: true, name, iss: server.issuer.url, aud: 'mock-client-id' }` claims for whatever `--sub --email --name` triple the bash script asks for. The driver replays the redirect dance manually with `redirect: 'manual'` and a `Map`-based cookie jar (auto-follow loses cookies). Prints exactly `neotolis.session_token=<value>` on stdout so the bash script can `$()`-capture in one line.
+- `.github/workflows/ci.yml` smoke job: `pnpm build` step inserted between `pnpm install --frozen-lockfile` and `docker build` so the host workspace's compiled SvelteKit + Paraglide artifacts match the image's; `BETTER_AUTH_SECURE_COOKIES=false` job env (review blocker P1 — production image runs over plain HTTP in CI); `GOOGLE_DISCOVERY_URL` job env points at the mock IdP.
+- `.planning/phases/01-foundation/01-VALIDATION.md` ratified: frontmatter `nyquist_compliant: true`, `wave_0_complete: true`, `status: ratified`. Per-Task Verification Map populated with one row per task plus PT1-PT6 split and explicit deferred-to-Phase-2 entries for VALIDATION 8 (cross-tenant WRITE) and 9 (cross-tenant DELETE).
+
+## Deviations from the original plan
+
+- **D-13 mechanism update.** Original CONTEXT.md text said "Better Auth's built-in dev / test provider"; that mechanism doesn't exist in Better Auth 1.6.x. Substitute = `oauth2-mock-server` package, recorded in CONTEXT.md `<deviations>` block on 2026-04-27 with user acceptance.
+- **DEPLOY-05 SC#4 scope.** Original D-15 #4 said the smoke must "create a game and run a poll stub". Phase 1 has no game model (Phase 2 lands GAMES-01) and no poll handlers (Phase 3 lands POLL-01..06). Those clauses are scope-deferred: Phase 2 smoke extends with "create a game"; Phase 3 smoke extends with "run a poll stub". Recorded in CONTEXT.md `<deviations>` 2026-04-27 with user acceptance and reflected in ROADMAP Phase 1 SC#4.
+- **INFO I2 issuer-URL path.** Original Plan 05 + Plan 10 considered three paths for routing Better Auth at the mock IdP. Path 2 (genericOAuth plugin with `discoveryUrl`) was chosen during the post-Phase-1 review-blocker fix because Better Auth's `socialProviders.google` hardcodes Google's authorize/token endpoints with no override knob. Recorded in src/lib/auth.ts header comment.
+- **Dashboard-render assertion was softened, then re-fataled.** During the original Phase-1 cleanup the dashboard-render assertion at smoke step (4) was downgraded to a `PARTIAL` log line because `GET /` returned 404 from inside the production image. The post-Phase-1 review (Fix 1) traced the 404 to a zod version mismatch (Better Auth 1.6.9 uses zod v4; project pinned ^3.23.8 → resolved to 3.25.76 → bundled `z$1.coerce.boolean().meta()` threw because zod 3 has no `.meta()` method); aligning zod to ^4.3.6 (and `@hono/zod-validator` to ^0.7.0 for compatibility) made `build/handler.js` load cleanly and produce real dashboard HTML. Fix 2 then restored the original `fail "..."` assertion. Both diffs landed in the same review PR. Documented inline in `tests/smoke/self-host.sh` and in this summary.
+
+## What this enables
+
+The smoke gate is the load-bearing trust signal for the open-source angle (PROJECT.md): every PR is exercised through the same Docker image a self-host operator pulls. PITFALL P13 (self-host parity rot) cannot accumulate silently across phases — Phase 2's GAMES endpoints, Phase 3's poll workers, Phase 4's UI, and Phase 6's deploy hardening each extend this script in their own Wave 5 plans. Three CI jobs (lint-typecheck, unit-integration, smoke) together gate every PR; the smoke job is the deepest one.
+
+## Open follow-ups (out of scope for Plan 10)
+
+- Phase 2 smoke extension: "user A creates a game" via /api/games; cross-tenant matrix expands to /api/games.
+- Phase 3 smoke extension: enqueue + process a poll-stub job end-to-end; metric_snapshots immutability; worker SIGTERM drain timing.
+- Phase 6 deploy-doc smoke extension: assert TRUSTED_PROXY_CIDR=Cloudflare-ranges scenario and Cloudflare-Tunnel-fronted scenario produce identical /api/me + audit-log IP.
+
+## Task Commits
+
+The original Plan-10 work landed in commits c1eaca7..eed82c3 on `master` (Wave 5). The post-Phase-1 review re-fataling and root-cause fix landed on `fix/post-phase-1-review` (this branch).

--- a/.planning/phases/01-foundation/01-10-SUMMARY.md
+++ b/.planning/phases/01-foundation/01-10-SUMMARY.md
@@ -88,4 +88,21 @@ The smoke gate is the load-bearing trust signal for the open-source angle (PROJE
 
 ## Task Commits
 
-The original Plan-10 work landed in commits c1eaca7..eed82c3 on `master` (Wave 5). The post-Phase-1 review re-fataling and root-cause fix landed on `fix/post-phase-1-review` (this branch).
+The original Plan-10 work landed in commit `b69eb81` ("#4 Phase 1: foundation") on `master` — the squashed root commit that captures all 10 plans of Phase 1 in one revision. The post-Phase-1 review's re-fataling of the dashboard-render assertion and the underlying zod-version root-cause fix landed on `fix/post-phase-1-review` (this branch, closing issue #5).
+
+## Self-Check: PASSED
+
+- [x] Smoke script + driver written and committed
+- [x] Smoke job wired into `.github/workflows/ci.yml`
+- [x] All six numbered D-15 assertions present and active in `tests/smoke/self-host.sh` (Phase 1 scope)
+- [x] Image ENTRYPOINT exercised — no `sh -c` wrapper, no entrypoint override (BLOCKER 7 mitigation)
+- [x] D-13 mechanism deviation captured in `01-CONTEXT.md` `<deviations>` block
+- [x] INFO I2 path resolved via genericOAuth `discoveryUrl` env knob (post-Phase-1 review fix)
+- [x] Dashboard-render assertion fatal at merge time (no PARTIAL fall-through)
+- [x] VALIDATION.md frontmatter ratified
+
+---
+
+*Phase: 01-foundation*
+*Plan: 10*
+*Completed: 2026-04-27 (re-fataled in #5 / post-Phase-1 review)*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,22 @@ The repo enforces this via GitHub settings:
 
 CI gates every PR with three jobs: `lint-typecheck`, `unit-integration` (Postgres service container), `smoke` (production Docker image, all three roles, OAuth dance via `oauth2-mock-server`, cross-tenant + anonymous-401 invariants). Smoke is the load-bearing trust signal — when it's green, a self-host operator can deploy with confidence.
 
+## Validation
+
+Before any PR is handed off for human review, the agent that authored it must self-review. The decision to merge into master is made by a human after external review (Codex + senior developer). The agent's job is to make sure that review has the smallest possible surface to flag.
+
+Self-review checklist — every PR, every time, before declaring done:
+
+1. **Constraints compliance.** Read the Constraints block above. For each constraint, identify whether the diff touches it. If it does, cite where + why the diff is compliant. Examples: any new code that reads `process.env` outside `src/lib/server/config/env.ts` is a Constraint violation; any new at-rest secret stored without envelope encryption is a Constraint violation; any new code path that diverges between SaaS and self-host is a Constraint violation.
+2. **Philosophy compliance.** Walk the five Philosophy bullets (simplicity for an outsider, SaaS/self-host parity, modularity, no premature abstraction, security as floor). For each, identify whether the diff drifts. Be honest: drift is fine if justified, but it must be acknowledged in the PR body.
+3. **Practices compliance.** Walk the Practices list. Atomic? Tests with feature? Migrations forward-only? Env reads centralized? Self-host parity holds? Secrets redaction unbroken? Comments only WHY? Conventional Commits? Versions pinned?
+4. **CI gate honesty.** Is every assertion in new tests load-bearing or is something vacuous-pass? If a smoke / integration test was softened, is the softening justified and tracked, or is it hiding a real regression?
+5. **Documentation drift.** Does any planning artifact (`.planning/...`, `CLAUDE.md`, `AGENTS.md`, `01-VALIDATION.md`, `01-CONTEXT.md`) now claim something the code no longer matches? Either the docs or the code must move.
+
+Output of the self-review goes in the PR body under a `## Self-review` heading, with one line per item ("Constraints: ✓ no new env reads outside config/env.ts", or "Philosophy: drift — see note in commit Y, accepted because Z"). After self-review, the agent runs a second-pass code review (separate agent, fresh context) and includes the findings as a `## Self-review (second pass)` section.
+
+If second-pass review finds new P0/P1 issues, the agent fixes them in the same branch before handoff. The human reviewer should not be the first to catch a P0.
+
 ## Practices
 
 - **Atomic PRs.** Each PR has one clear goal. If you start fixing unrelated things mid-branch, branch off a second PR — don't bundle.

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -6,7 +6,7 @@
 # Use:
 #   APP_KEK_BASE64=$(openssl rand -base64 32) \
 #   BETTER_AUTH_SECRET=$(openssl rand -hex 32) \
-#   GOOGLE_CLIENT_ID=... GOOGLE_CLIENT_SECRET=... \
+#   OAUTH_CLIENT_ID=... OAUTH_CLIENT_SECRET=... \
 #   docker compose -f docker-compose.selfhost.yml up -d --build
 
 services:
@@ -32,8 +32,8 @@ services:
       DATABASE_URL: postgres://postgres:postgres@postgres:5432/neotolis
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:3000}
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET}
-      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
-      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
+      OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID}
+      OAUTH_CLIENT_SECRET: ${OAUTH_CLIENT_SECRET}
       APP_KEK_BASE64: ${APP_KEK_BASE64}
       # D-20: empty default = trust nothing (use socket peer). Override for self-host
       # behind nginx/Caddy: TRUSTED_PROXY_CIDR=127.0.0.1/32
@@ -56,8 +56,8 @@ services:
       # though the worker process never serves auth requests. Future-proofs against
       # accidental top-level env reads in shared modules.
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:3000}
-      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
-      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
+      OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID}
+      OAUTH_CLIENT_SECRET: ${OAUTH_CLIENT_SECRET}
     depends_on:
       postgres: { condition: service_healthy }
 
@@ -70,8 +70,8 @@ services:
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET}
       APP_KEK_BASE64: ${APP_KEK_BASE64}
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:3000}
-      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
-      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
+      OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID}
+      OAUTH_CLIENT_SECRET: ${OAUTH_CLIENT_SECRET}
     depends_on:
       postgres: { condition: service_healthy }
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@hono/node-server": "1.19.14",
-    "@hono/zod-validator": "^0.4.0",
+    "@hono/zod-validator": "^0.7.0",
     "@inlang/paraglide-js": "2.16.1",
     "@sveltejs/adapter-node": "^5.2.0",
     "@sveltejs/kit": "^2.58.0",
@@ -43,7 +43,7 @@
     "svelte": "^5.55.5",
     "uuidv7": "^1.0.2",
     "vite": "^8.0.0",
-    "zod": "^3.23.8"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "packageManager": "pnpm@9.15.0",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build && tsup",
+    "build": "pnpm paraglide:compile && svelte-kit sync && vite build && tsup",
     "preview": "vite preview",
     "paraglide:compile": "paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide",
     "typecheck": "pnpm paraglide:compile && svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 1.19.14
         version: 1.19.14(hono@4.12.15)
       '@hono/zod-validator':
-        specifier: ^0.4.0
-        version: 0.4.3(hono@4.12.15)(zod@3.25.76)
+        specifier: ^0.7.0
+        version: 0.7.6(hono@4.12.15)(zod@4.3.6)
       '@inlang/paraglide-js':
         specifier: 2.16.1
         version: 2.16.1
@@ -63,8 +63,8 @@ importers:
         specifier: ^8.0.0
         version: 8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
       zod:
-        specifier: ^3.23.8
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@eslint/js':
         specifier: ^9.13.0
@@ -746,11 +746,11 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@hono/zod-validator@0.4.3':
-    resolution: {integrity: sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ==}
+  '@hono/zod-validator@0.7.6':
+    resolution: {integrity: sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==}
     peerDependencies:
       hono: '>=3.9.0'
-      zod: ^3.19.1
+      zod: ^3.25.0 || ^4.0.0
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -3158,9 +3158,6 @@ packages:
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -3181,7 +3178,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)':
+  '@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)':
     dependencies:
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
@@ -3193,40 +3190,40 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.3.6
 
-  '@better-auth/drizzle-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@prisma/client@5.22.0)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(kysely@0.28.16)(pg@8.20.0))':
+  '@better-auth/drizzle-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@prisma/client@5.22.0)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(kysely@0.28.16)(pg@8.20.0))':
     dependencies:
-      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
     optionalDependencies:
       drizzle-orm: 0.45.2(@prisma/client@5.22.0)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(kysely@0.28.16)(pg@8.20.0)
 
-  '@better-auth/kysely-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)':
+  '@better-auth/kysely-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)':
     dependencies:
-      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
     optionalDependencies:
       kysely: 0.28.16
 
-  '@better-auth/memory-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/memory-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
 
-  '@better-auth/mongo-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/mongo-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
 
-  '@better-auth/prisma-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@prisma/client@5.22.0)':
+  '@better-auth/prisma-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@prisma/client@5.22.0)':
     dependencies:
-      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
     optionalDependencies:
       '@prisma/client': 5.22.0
 
-  '@better-auth/telemetry@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)':
+  '@better-auth/telemetry@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)':
     dependencies:
-      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
 
@@ -3536,10 +3533,10 @@ snapshots:
     dependencies:
       hono: 4.12.15
 
-  '@hono/zod-validator@0.4.3(hono@4.12.15)(zod@3.25.76)':
+  '@hono/zod-validator@0.7.6(hono@4.12.15)(zod@4.3.6)':
     dependencies:
       hono: 4.12.15
-      zod: 3.25.76
+      zod: 4.3.6
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -4111,13 +4108,13 @@ snapshots:
 
   better-auth@1.6.9(@prisma/client@5.22.0)(@sveltejs/kit@2.58.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.0))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.0))(typescript@5.9.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)))(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@prisma/client@5.22.0)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(svelte@5.55.5(@typescript-eslint/types@8.59.0))(vitest@4.1.5):
     dependencies:
-      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@prisma/client@5.22.0)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(kysely@0.28.16)(pg@8.20.0))
-      '@better-auth/kysely-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)
-      '@better-auth/memory-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/mongo-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/prisma-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@prisma/client@5.22.0)
-      '@better-auth/telemetry': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/drizzle-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@prisma/client@5.22.0)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(kysely@0.28.16)(pg@8.20.0))
+      '@better-auth/kysely-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)
+      '@better-auth/memory-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/mongo-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/prisma-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@prisma/client@5.22.0)
+      '@better-auth/telemetry': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.2.0
@@ -5832,7 +5829,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zimmerframe@1.1.4: {}
-
-  zod@3.25.76: {}
 
   zod@4.3.6: {}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -28,14 +28,20 @@
 // node_modules/better-auth/dist/plugins/generic-oauth/routes.mjs:246,266).
 
 import { betterAuth } from "better-auth";
-import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { genericOAuth } from "better-auth/plugins/generic-oauth";
+import { encryptedDrizzleAdapter } from "./server/auth-adapter.js";
 import { db } from "./server/db/client.js";
 import * as authSchema from "./server/db/schema/auth.js";
 import { env } from "./server/config/env.js";
 
 export const auth = betterAuth({
-  database: drizzleAdapter(db, {
+  // CLAUDE.md "Secrets at rest" + D-11: OAuth provider tokens
+  // (accessToken / refreshToken / idToken on the `account` row) are
+  // envelope-encrypted in src/lib/server/auth-adapter.ts. The wrapper sits
+  // between Better Auth and the official drizzleAdapter without changing
+  // schema columns — the `text` column now holds an `ev1:`-prefixed JSON
+  // blob; decryption happens transparently on read.
+  database: encryptedDrizzleAdapter(db, {
     provider: "pg",
     schema: {
       user: authSchema.user,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -22,10 +22,15 @@
 // redirect always points at real Google — incompatible with CI/smoke runs
 // that need to talk to oauth2-mock-server. The genericOAuth plugin exposes
 // `discoveryUrl` (and explicit endpoint overrides), so the same code works
-// against real Google in production and the mock IdP in CI/smoke. The
-// account row's `providerId` stays "google" by construction
-// (genericOAuth uses the configured providerId verbatim — see
-// node_modules/better-auth/dist/plugins/generic-oauth/routes.mjs:246,266).
+// against real Google in production and the mock IdP in CI/smoke.
+//
+// The account row's `providerId` is env-driven via OAUTH_PROVIDER_ID
+// (default "google" — SaaS never overrides). Self-host operators who
+// override OAUTH_DISCOVERY_URL to point at a non-Google IdP MUST also
+// override OAUTH_PROVIDER_ID, otherwise rows are mislabelled (a Keycloak
+// account stored as `providerId="google"`). See env.ts for the full
+// rationale on the OAUTH_* family of env vars and the SaaS-vs-self-host
+// support contract.
 
 import { betterAuth } from "better-auth";
 import { genericOAuth } from "better-auth/plugins/generic-oauth";
@@ -54,18 +59,17 @@ export const auth = betterAuth({
   secret: env.BETTER_AUTH_SECRET,
   trustedOrigins: env.TRUSTED_ORIGINS,
   plugins: [
-    // genericOAuth plugin used so discoveryUrl is env-driven; CI/smoke point
-    // at oauth2-mock-server, prod points at
-    // https://accounts.google.com/.well-known/openid-configuration.
-    // account.providerId='google' preserved (the plugin uses the configured
-    // providerId verbatim for the account row).
+    // genericOAuth plugin — discoveryUrl + providerId are env-driven via
+    // the OAUTH_* family. SaaS uses defaults (Google). Self-host can override
+    // to any OIDC-compatible IdP at their own risk; see env.ts for the
+    // support contract.
     genericOAuth({
       config: [
         {
-          providerId: "google",
-          clientId: env.GOOGLE_CLIENT_ID,
-          clientSecret: env.GOOGLE_CLIENT_SECRET,
-          discoveryUrl: env.GOOGLE_DISCOVERY_URL,
+          providerId: env.OAUTH_PROVIDER_ID,
+          clientId: env.OAUTH_CLIENT_ID,
+          clientSecret: env.OAUTH_CLIENT_SECRET,
+          discoveryUrl: env.OAUTH_DISCOVERY_URL,
           scopes: ["openid", "email", "profile"],
           pkce: true,
         },

--- a/src/lib/server/auth-adapter.ts
+++ b/src/lib/server/auth-adapter.ts
@@ -1,0 +1,228 @@
+// Better Auth adapter wrapper that envelope-encrypts OAuth provider tokens at
+// rest in the `account` table.
+//
+// CLAUDE.md "Secrets at rest" constraint: API keys and OAuth refresh tokens
+// must be envelope-encrypted with a per-row DEK wrapped by an env-loaded KEK
+// (D-09, D-10, D-11). The Better Auth canonical `account` schema stores
+// `accessToken` / `refreshToken` / `idToken` as plain `text` columns by
+// default — a DB exfil leaks these directly. This wrapper sits between
+// Better Auth and the official `drizzleAdapter`, intercepting create/update
+// so token columns are written as JSON-encoded `EncryptedSecret` blobs, and
+// intercepting findOne/findMany so reads return plaintext to Better Auth's
+// internal session/refresh logic.
+//
+// Approach A from the post-Phase-1 review:
+//   * The wrapper preserves the `text` column type (still `account.refreshToken
+//     text`) — column shape is unchanged, no migration required. The contents
+//     change from `<plaintext>` to `{"v":1,"secretCt":"...","wrappedDek":"...",
+//     "secretIv":"...","secretTag":"...","dekIv":"...","dekTag":"...",
+//     "kekVersion":1}` (JSON, fields base64-encoded so the column stays text).
+//   * Encryption is best-effort: if the Better Auth `account` model is not
+//     involved, the wrapper transparently delegates. Existing plaintext rows
+//     (e.g. seeded by integration test fixtures) still decrypt to themselves
+//     via a graceful-fallback path so a half-migrated database does not break
+//     authentication.
+//   * `select` projection on findOne/findMany means a column we'd want to
+//     decrypt may not be present; we only decrypt the fields that actually
+//     came back.
+//
+// The Pino redaction list (src/lib/server/logger.ts) covers `accessToken` /
+// `refreshToken` / `idToken` paths so even a panicked logger.warn(account)
+// after a decryption failure does not leak the plaintext token.
+
+import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { encryptSecret, decryptSecret, type EncryptedSecret } from "./crypto/envelope.js";
+import { logger } from "./logger.js";
+
+type DrizzleAdapterArgs = Parameters<typeof drizzleAdapter>;
+type DrizzleAdapterFactory = ReturnType<typeof drizzleAdapter>;
+
+// Better Auth's account-row token columns (camelCase as the framework sees them
+// before its own field-mapping; the underlying Drizzle column name is whatever
+// the schema's `.column("...")` says). We list the framework-side names because
+// `transformInput` / `transformOutput` and the create/update hooks below all see
+// the framework-side keys.
+const ENCRYPTED_FIELDS = ["accessToken", "refreshToken", "idToken"] as const;
+type EncryptedField = (typeof ENCRYPTED_FIELDS)[number];
+
+const ENVELOPE_PREFIX = "ev1:";
+
+function isEncryptedField(field: string): field is EncryptedField {
+  return (ENCRYPTED_FIELDS as readonly string[]).includes(field);
+}
+
+interface SerializedEnvelope {
+  v: 1;
+  secretCt: string;
+  secretIv: string;
+  secretTag: string;
+  wrappedDek: string;
+  dekIv: string;
+  dekTag: string;
+  kekVersion: number;
+}
+
+/**
+ * Wrap a plaintext token into an encrypted JSON blob that fits in a `text`
+ * column. The `ev1:` prefix marks a wrapped value so we never double-encrypt
+ * on update (Better Auth re-writes accounts on every refresh) and so a
+ * legacy plaintext row falls through to the decrypt-fallback path cleanly.
+ */
+function encryptField(plaintext: string): string {
+  if (plaintext.startsWith(ENVELOPE_PREFIX)) {
+    return plaintext;
+  }
+  const env = encryptSecret(plaintext);
+  const blob: SerializedEnvelope = {
+    v: 1,
+    secretCt: env.secretCt.toString("base64"),
+    secretIv: env.secretIv.toString("base64"),
+    secretTag: env.secretTag.toString("base64"),
+    wrappedDek: env.wrappedDek.toString("base64"),
+    dekIv: env.dekIv.toString("base64"),
+    dekTag: env.dekTag.toString("base64"),
+    kekVersion: env.kekVersion,
+  };
+  return ENVELOPE_PREFIX + JSON.stringify(blob);
+}
+
+/**
+ * Decrypt an `ev1:`-prefixed value to plaintext. A value missing the prefix
+ * is returned as-is — covers legacy rows and the integration-test fixtures
+ * that insert plaintext directly via Drizzle. A prefixed value that fails
+ * to decode/decrypt throws, since that means tampering or a KEK rotation
+ * defect (PITFALL P2 — fail fast).
+ */
+function decryptField(stored: string): string {
+  if (!stored.startsWith(ENVELOPE_PREFIX)) {
+    return stored;
+  }
+  const json = stored.slice(ENVELOPE_PREFIX.length);
+  let blob: SerializedEnvelope;
+  try {
+    blob = JSON.parse(json) as SerializedEnvelope;
+  } catch (err) {
+    logger.error({ err }, "envelope: failed to parse stored token JSON");
+    throw new Error("envelope: malformed stored token");
+  }
+  const env: EncryptedSecret = {
+    secretCt: Buffer.from(blob.secretCt, "base64"),
+    secretIv: Buffer.from(blob.secretIv, "base64"),
+    secretTag: Buffer.from(blob.secretTag, "base64"),
+    wrappedDek: Buffer.from(blob.wrappedDek, "base64"),
+    dekIv: Buffer.from(blob.dekIv, "base64"),
+    dekTag: Buffer.from(blob.dekTag, "base64"),
+    kekVersion: blob.kekVersion,
+  };
+  return decryptSecret(env);
+}
+
+function encryptAccountRow<T extends Record<string, unknown>>(row: T): T {
+  const out: Record<string, unknown> = { ...row };
+  for (const field of ENCRYPTED_FIELDS) {
+    const v = out[field];
+    if (typeof v === "string" && v.length > 0) {
+      out[field] = encryptField(v);
+    }
+  }
+  return out as T;
+}
+
+function decryptAccountRow<T extends Record<string, unknown>>(row: T): T {
+  const out: Record<string, unknown> = { ...row };
+  for (const field of ENCRYPTED_FIELDS) {
+    const v = out[field];
+    if (typeof v === "string" && v.length > 0) {
+      try {
+        out[field] = decryptField(v);
+      } catch (err) {
+        // Fail closed: surface the error to Better Auth so the auth flow
+        // returns a clean error rather than a corrupted token. The redaction
+        // list keeps the stored ciphertext from leaking.
+        logger.error({ err, field }, "envelope: account row decrypt failed");
+        throw err;
+      }
+    }
+  }
+  return out as T;
+}
+
+/**
+ * Build a Better-Auth-compatible adapter that delegates to `drizzleAdapter`
+ * for everything but transparently envelope-encrypts/decrypts the
+ * `account.{accessToken,refreshToken,idToken}` columns. The wrapped factory
+ * has the same call signature Better Auth expects:
+ *   `(options) => DBAdapter`.
+ */
+export function encryptedDrizzleAdapter(...args: DrizzleAdapterArgs): DrizzleAdapterFactory {
+  const inner = drizzleAdapter(...args);
+  return ((options) => {
+    const adapter = inner(options);
+    const isAccount = (model: string): boolean =>
+      // Better Auth normalizes the model to the schema key ("account") even when
+      // the underlying table is plural — be lenient here to cover plural-table
+      // configs in case a future schema config flips that knob.
+      model === "account" || model === "accounts";
+
+    return {
+      ...adapter,
+      create: (async (data: Parameters<typeof adapter.create>[0]) => {
+        if (isAccount(data.model)) {
+          const enriched = { ...data, data: encryptAccountRow(data.data) };
+          const result = (await adapter.create(enriched)) as Record<string, unknown> | null;
+          return (result ? decryptAccountRow(result) : result) as ReturnType<
+            typeof adapter.create
+          > extends Promise<infer R>
+            ? R
+            : never;
+        }
+        return adapter.create(data) as ReturnType<typeof adapter.create> extends Promise<infer R>
+          ? R
+          : never;
+      }) as typeof adapter.create,
+      update: (async (data: Parameters<typeof adapter.update>[0]) => {
+        if (isAccount(data.model)) {
+          const enriched = { ...data, update: encryptAccountRow(data.update) };
+          const result = (await adapter.update(enriched)) as Record<string, unknown> | null;
+          return (result ? decryptAccountRow(result) : result) as ReturnType<
+            typeof adapter.update
+          > extends Promise<infer R>
+            ? R
+            : never;
+        }
+        return adapter.update(data) as ReturnType<typeof adapter.update> extends Promise<infer R>
+          ? R
+          : never;
+      }) as typeof adapter.update,
+      updateMany: (async (data: Parameters<typeof adapter.updateMany>[0]) => {
+        if (isAccount(data.model)) {
+          const enriched = { ...data, update: encryptAccountRow(data.update) };
+          return adapter.updateMany(enriched);
+        }
+        return adapter.updateMany(data);
+      }) as typeof adapter.updateMany,
+      findOne: (async (data: Parameters<typeof adapter.findOne>[0]) => {
+        const result = (await adapter.findOne(data)) as Record<string, unknown> | null;
+        if (result && isAccount(data.model)) {
+          return decryptAccountRow(result) as ReturnType<typeof adapter.findOne> extends Promise<
+            infer R
+          >
+            ? R
+            : never;
+        }
+        return result as ReturnType<typeof adapter.findOne> extends Promise<infer R> ? R : never;
+      }) as typeof adapter.findOne,
+      findMany: (async (data: Parameters<typeof adapter.findMany>[0]) => {
+        const result = (await adapter.findMany(data)) as Record<string, unknown>[];
+        if (isAccount(data.model)) {
+          return result.map((r) => decryptAccountRow(r)) as ReturnType<
+            typeof adapter.findMany
+          > extends Promise<infer R>
+            ? R
+            : never;
+        }
+        return result as ReturnType<typeof adapter.findMany> extends Promise<infer R> ? R : never;
+      }) as typeof adapter.findMany,
+    };
+  }) as DrizzleAdapterFactory;
+}

--- a/src/lib/server/auth-adapter.ts
+++ b/src/lib/server/auth-adapter.ts
@@ -43,13 +43,8 @@ type DrizzleAdapterFactory = ReturnType<typeof drizzleAdapter>;
 // `transformInput` / `transformOutput` and the create/update hooks below all see
 // the framework-side keys.
 const ENCRYPTED_FIELDS = ["accessToken", "refreshToken", "idToken"] as const;
-type EncryptedField = (typeof ENCRYPTED_FIELDS)[number];
 
 const ENVELOPE_PREFIX = "ev1:";
-
-function isEncryptedField(field: string): field is EncryptedField {
-  return (ENCRYPTED_FIELDS as readonly string[]).includes(field);
-}
 
 interface SerializedEnvelope {
   v: 1;

--- a/src/lib/server/config/env.ts
+++ b/src/lib/server/config/env.ts
@@ -18,12 +18,23 @@ const RawSchema = z.object({
   DATABASE_URL: z.string().url(),
   BETTER_AUTH_URL: z.string().url(),
   BETTER_AUTH_SECRET: z.string().min(32),
-  GOOGLE_CLIENT_ID: z.string().min(1),
-  GOOGLE_CLIENT_SECRET: z.string().min(1),
-  // Better Auth's genericOAuth plugin reads OIDC discovery from this URL so
-  // CI / smoke / self-host can point at oauth2-mock-server while production
-  // points at Google. Default = real Google's discovery document.
-  GOOGLE_DISCOVERY_URL: z
+  // OAuth identity provider — Google by default in both SaaS and self-host.
+  // Self-host operators MAY override OAUTH_DISCOVERY_URL + OAUTH_PROVIDER_ID
+  // to point at any OIDC-compatible IdP (Keycloak, Authentik, Auth0, ...).
+  // This is unsupported / advanced for self-host: SaaS only ships Google,
+  // and the project's auth UX, message strings, and audit semantics are
+  // written assuming Google. SaaS env never overrides any of these.
+  //
+  // OAUTH_PROVIDER_ID is the value written to `account.providerId` in the
+  // Better Auth schema and the value passed to genericOAuth's `providerId`.
+  // If you switch IdP, switch this too — otherwise rows are mislabelled
+  // ("google" against a Keycloak realm) and Better Auth treats them as the
+  // same logical provider (which can be intentional for migrations, but is
+  // a foot-gun by default).
+  OAUTH_PROVIDER_ID: z.string().min(1).default("google"),
+  OAUTH_CLIENT_ID: z.string().min(1),
+  OAUTH_CLIENT_SECRET: z.string().min(1),
+  OAUTH_DISCOVERY_URL: z
     .string()
     .url()
     .default("https://accounts.google.com/.well-known/openid-configuration"),
@@ -109,9 +120,10 @@ export const env = {
   DATABASE_URL: raw.DATABASE_URL,
   BETTER_AUTH_URL: raw.BETTER_AUTH_URL,
   BETTER_AUTH_SECRET: raw.BETTER_AUTH_SECRET,
-  GOOGLE_CLIENT_ID: raw.GOOGLE_CLIENT_ID,
-  GOOGLE_CLIENT_SECRET: raw.GOOGLE_CLIENT_SECRET,
-  GOOGLE_DISCOVERY_URL: raw.GOOGLE_DISCOVERY_URL,
+  OAUTH_PROVIDER_ID: raw.OAUTH_PROVIDER_ID,
+  OAUTH_CLIENT_ID: raw.OAUTH_CLIENT_ID,
+  OAUTH_CLIENT_SECRET: raw.OAUTH_CLIENT_SECRET,
+  OAUTH_DISCOVERY_URL: raw.OAUTH_DISCOVERY_URL,
   TRUSTED_ORIGINS,
   TRUSTED_PROXY_CIDR: raw.TRUSTED_PROXY_CIDR,
   COOKIE_DOMAIN: raw.COOKIE_DOMAIN,

--- a/src/lib/server/config/env.ts
+++ b/src/lib/server/config/env.ts
@@ -74,12 +74,27 @@ if (!kekVersions.has(raw.KEK_CURRENT_VERSION)) {
   );
 }
 
-// PITFALL P2 mitigation #4: scrub the original env vars after consumption so
-// the raw KEK material cannot leak via accidental console.log(process.env) or
-// debug dumps. The decoded buffers live in `kekVersions` Map only.
-delete process.env.APP_KEK_BASE64;
-for (let v = 2; v <= 9; v++) {
-  delete process.env[`APP_KEK_V${v}_BASE64`];
+// PITFALL P2 mitigation #4: scrub the original env vars from process.env so
+// the raw KEK material cannot leak via accidental console.log(process.env)
+// or debug dumps. The decoded buffers live in `kekVersions` Map only.
+//
+// IMPORTANT — call this AFTER all bundles that depend on env have loaded.
+// SvelteKit's vite build produces its own bundled copy of this module
+// (inside build/server/chunks/...). When build/handler.js is dynamically
+// imported, SvelteKit's bundled env.ts re-parses process.env. If we scrub
+// before that import resolves, the bundled parse sees APP_KEK_BASE64=undefined
+// and throws — the smoke gate caught this on 2026-04-27 (issue #5).
+//
+// Boot sequence is therefore:
+//   1. import env (this module) → kekVersions populated, process.env still
+//      carries the raw values
+//   2. import handler.js → bundled env.ts parses process.env successfully
+//   3. server.ts calls scrubKekFromEnv() once startup is complete
+export function scrubKekFromEnv(): void {
+  delete process.env.APP_KEK_BASE64;
+  for (let v = 2; v <= 9; v++) {
+    delete process.env[`APP_KEK_V${v}_BASE64`];
+  }
 }
 
 const TRUSTED_ORIGINS = raw.TRUSTED_ORIGINS.split(",")

--- a/src/lib/server/db/migrate.ts
+++ b/src/lib/server/db/migrate.ts
@@ -33,23 +33,34 @@ const LOCK_KEY = 0x4d49475241544531n; // BIGINT-safe; pg accepts numeric/bigint
 export async function runMigrations(): Promise<void> {
   const pool = new Pool({ connectionString: env.DATABASE_URL, max: 2 });
   const client = await pool.connect();
+  let lockHeld = false;
   try {
     logger.info({ phase: "migrate" }, "acquiring advisory lock");
     await client.query(`SELECT pg_advisory_lock($1)`, [LOCK_KEY.toString()]);
+    lockHeld = true;
     const localDb = drizzle(client);
     await migrate(localDb, { migrationsFolder: "./drizzle" });
     // Defensive ordering: release the advisory lock BEFORE flipping the
-    // readyz flag. The previous order ran `migrationsApplied.current = true`
-    // first; if the subsequent unlock query failed (transient network blip
-    // during the unlock RPC), /readyz would answer 200 while this session
-    // still held the lock — the lock would only release on pool drain. With
-    // unlock first, /readyz can only flip true after the lock is gone, so an
-    // orchestrator that watches /readyz never routes traffic to a process
-    // still holding a session-level Postgres lock.
+    // readyz flag. With unlock first, /readyz can only flip true after the
+    // lock is gone, so an orchestrator that watches /readyz never routes
+    // traffic to a process still holding a session-level Postgres lock.
     await client.query(`SELECT pg_advisory_unlock($1)`, [LOCK_KEY.toString()]);
+    lockHeld = false;
     migrationsApplied.current = true;
     logger.info({ phase: "migrate" }, "migrations applied");
   } finally {
+    // Belt-and-suspenders: if migrate() threw, ensure unlock is still
+    // attempted. Even if this RPC fails, the session-level advisory lock is
+    // released when client.release() returns the connection to the pool and
+    // pool.end() closes it — so this is a defensive cleanup, not the only
+    // safety net.
+    if (lockHeld) {
+      try {
+        await client.query(`SELECT pg_advisory_unlock($1)`, [LOCK_KEY.toString()]);
+      } catch (err) {
+        logger.warn({ err, phase: "migrate" }, "advisory_unlock failed in finally");
+      }
+    }
     client.release();
     await pool.end();
   }

--- a/src/lib/server/db/migrate.ts
+++ b/src/lib/server/db/migrate.ts
@@ -38,14 +38,18 @@ export async function runMigrations(): Promise<void> {
     await client.query(`SELECT pg_advisory_lock($1)`, [LOCK_KEY.toString()]);
     const localDb = drizzle(client);
     await migrate(localDb, { migrationsFolder: "./drizzle" });
+    // Defensive ordering: release the advisory lock BEFORE flipping the
+    // readyz flag. The previous order ran `migrationsApplied.current = true`
+    // first; if the subsequent unlock query failed (transient network blip
+    // during the unlock RPC), /readyz would answer 200 while this session
+    // still held the lock — the lock would only release on pool drain. With
+    // unlock first, /readyz can only flip true after the lock is gone, so an
+    // orchestrator that watches /readyz never routes traffic to a process
+    // still holding a session-level Postgres lock.
+    await client.query(`SELECT pg_advisory_unlock($1)`, [LOCK_KEY.toString()]);
     migrationsApplied.current = true;
     logger.info({ phase: "migrate" }, "migrations applied");
   } finally {
-    try {
-      await client.query(`SELECT pg_advisory_unlock($1)`, [LOCK_KEY.toString()]);
-    } catch (err) {
-      logger.warn({ err }, "advisory unlock failed (non-fatal)");
-    }
     client.release();
     await pool.end();
   }

--- a/src/lib/server/http/app.ts
+++ b/src/lib/server/http/app.ts
@@ -17,6 +17,7 @@ import { secureHeaders } from "hono/secure-headers";
 import { proxyTrust } from "./middleware/proxy-trust.js";
 import { tenantScope } from "./middleware/tenant.js";
 import { meRoutes } from "./routes/me.js";
+import { sessionRoutes } from "./routes/sessions.js";
 import { auth } from "../../auth.js";
 import { migrationsApplied } from "../db/migrate.js";
 import { pool } from "../db/client.js";
@@ -82,8 +83,9 @@ export function createApp(): Hono<AppContext> {
   // by service functions (see src/lib/server/services/errors.ts).
   app.use("/api/*", tenantScope);
 
-  // /api routes (Phase 1: just /api/me; Phase 2 adds /api/games, etc.).
+  // /api routes (Phase 1: /api/me + /api/me/sessions/all; Phase 2 adds /api/games, etc.).
   app.route("/api", meRoutes);
+  app.route("/api", sessionRoutes);
 
   return app;
 }

--- a/src/lib/server/http/routes/sessions.ts
+++ b/src/lib/server/http/routes/sessions.ts
@@ -23,9 +23,6 @@ export const sessionRoutes = new Hono<{
 sessionRoutes.post("/me/sessions/all", async (c) => {
   const userId = c.var.userId;
   const result = await signOutAllDevices(userId);
-  logger.info(
-    { userId, deletedCount: result.deletedCount },
-    "user signed out of all devices",
-  );
+  logger.info({ userId, deletedCount: result.deletedCount }, "user signed out of all devices");
   return c.json(result);
 });

--- a/src/lib/server/http/routes/sessions.ts
+++ b/src/lib/server/http/routes/sessions.ts
@@ -1,0 +1,31 @@
+// Session-management routes (Plan 01-07 surface, D-08 wiring).
+//
+// `POST /api/me/sessions/all` — implements the "Sign out from all devices"
+// settings action. Behind tenantScope (mounted under /api/* in
+// src/lib/server/http/app.ts), so anonymous requests are 401'd before
+// reaching this handler. Authenticated requests delete every session row for
+// `c.var.userId` via the `signOutAllDevices` service helper, including the
+// caller's current session — the next request from any device sees a stale
+// cookie that no longer maps to a session row and lands on the login page.
+//
+// D-08 rationale (CONTEXT.md): with database-backed sessions (D-05) the
+// server can invalidate all of a user's sessions instantly. This is the free
+// security win that JWE cookies cannot offer.
+
+import { Hono } from "hono";
+import { signOutAllDevices } from "../../services/users.js";
+import { logger } from "../../logger.js";
+
+export const sessionRoutes = new Hono<{
+  Variables: { userId: string; sessionId: string };
+}>();
+
+sessionRoutes.post("/me/sessions/all", async (c) => {
+  const userId = c.var.userId;
+  const result = await signOutAllDevices(userId);
+  logger.info(
+    { userId, deletedCount: result.deletedCount },
+    "user signed out of all devices",
+  );
+  return c.json(result);
+});

--- a/src/lib/server/logger.ts
+++ b/src/lib/server/logger.ts
@@ -5,6 +5,13 @@ import { env } from "./config/env.js";
 // `logger.info({ user })` cannot leak an api_key, refresh_token, KEK material,
 // or an Authorization/Cookie header. Add new paths here whenever a new
 // secret-shaped field is introduced anywhere in the codebase.
+//
+// Pino's fast-redact only supports `*` as a full-segment wildcard (e.g.
+// `*.password` or `req.headers.*`); fragment-globs like `encrypted_*` are
+// silently ignored, so each `encrypted_<thing>` field is enumerated explicitly.
+// tests/unit/logger.test.ts exercises every path here against a sentinel value
+// — a typo here will fail that test loudly instead of silently disabling the
+// protection (PITFALL P2 mitigation).
 const REDACT_PATHS = [
   "*.password",
   "*.api_key",
@@ -13,8 +20,11 @@ const REDACT_PATHS = [
   "*.accessToken",
   "*.refresh_token",
   "*.refreshToken",
+  "*.id_token",
+  "*.idToken",
   "*.secret",
-  "*.encrypted_*",
+  "*.encrypted_secret",
+  "*.encrypted_dek",
   "*.wrapped_dek",
   "*.wrappedDek",
   "*.dek",

--- a/src/roles/app.ts
+++ b/src/roles/app.ts
@@ -55,34 +55,45 @@ export async function start(): Promise<void> {
   }
 
   // SvelteKit pass-through: anything not matched above goes to SvelteKit.
+  //
+  // adapter-node writes directly to `outgoing` (Node's http.ServerResponse),
+  // so we cannot return a normal Hono Response — @hono/node-server would try
+  // to writeHead again and trip ERR_HTTP_HEADERS_SENT. Instead we return a
+  // sentinel Response and rely on @hono/node-server's outgoing.writableEnded
+  // check to bail before writing. The `next` callback is the explicit
+  // "SvelteKit didn't match this route" path — we serve a 404 in that case.
   app.all("*", async (c) => {
+    const ctx = c.env as
+      | {
+          incoming?: import("node:http").IncomingMessage;
+          outgoing?: import("node:http").ServerResponse;
+        }
+      | undefined;
+    const incoming = ctx?.incoming;
+    const outgoing = ctx?.outgoing;
+    if (!incoming || !outgoing) {
+      return c.text("node adapter context missing", 500);
+    }
     return new Promise<Response>((resolve) => {
-      const ctx = c.env as
-        | {
-            incoming?: import("node:http").IncomingMessage;
-            outgoing?: import("node:http").ServerResponse;
-          }
-        | undefined;
-      const incoming = ctx?.incoming;
-      const outgoing = ctx?.outgoing;
-      if (!incoming || !outgoing) {
-        resolve(c.text("node adapter context missing", 500));
-        return;
-      }
       let resolved = false;
+      const settle = (resp: Response): void => {
+        if (resolved) return;
+        resolved = true;
+        resolve(resp);
+      };
       svelteHandler(incoming, outgoing, () => {
-        if (!resolved) {
-          resolved = true;
-          resolve(c.text("not found", 404));
-        }
+        // SvelteKit decided this request is not its responsibility.
+        // outgoing has not been written; we can safely return a Hono 404.
+        settle(c.text("not found", 404));
       });
-      // adapter-node writes directly to outgoing; we resolve a sentinel
-      // Response once the response has been finished so Hono can settle.
+      // SvelteKit handled the request and wrote directly to outgoing.
+      // Return an empty Response — @hono/node-server checks
+      // outgoing.writableEnded before writing, so this is a no-op.
+      outgoing.on("close", () => {
+        settle(new Response(null, { status: outgoing.statusCode || 200 }));
+      });
       outgoing.on("finish", () => {
-        if (!resolved) {
-          resolved = true;
-          resolve(new Response(null, { status: outgoing.statusCode }));
-        }
+        settle(new Response(null, { status: outgoing.statusCode || 200 }));
       });
     });
   });

--- a/src/roles/app.ts
+++ b/src/roles/app.ts
@@ -36,17 +36,21 @@ export async function start(): Promise<void> {
     res: import("node:http").ServerResponse,
     next?: () => void,
   ) => void;
+  const handlerPath =
+    typeof __SVELTEKIT_HANDLER__ !== "undefined"
+      ? __SVELTEKIT_HANDLER__
+      : "../../build/handler.js";
   try {
-    const handlerPath =
-      typeof __SVELTEKIT_HANDLER__ !== "undefined"
-        ? __SVELTEKIT_HANDLER__
-        : "../../build/handler.js";
     const built = (await import(/* @vite-ignore */ handlerPath)) as {
       handler: typeof svelteHandler;
     };
     svelteHandler = built.handler;
-  } catch {
-    logger.warn("build/handler.js not found — SvelteKit pass-through disabled (dev mode?)");
+    logger.info({ handlerPath }, "SvelteKit handler loaded");
+  } catch (err) {
+    logger.error(
+      { err, handlerPath },
+      "SvelteKit handler import failed — falling back to dev-mode 404 stub",
+    );
     svelteHandler = (_req, res, next) => {
       res.statusCode = 404;
       res.end("SvelteKit dev server runs on a different port; build first");

--- a/src/roles/app.ts
+++ b/src/roles/app.ts
@@ -37,9 +37,7 @@ export async function start(): Promise<void> {
     next?: () => void,
   ) => void;
   const handlerPath =
-    typeof __SVELTEKIT_HANDLER__ !== "undefined"
-      ? __SVELTEKIT_HANDLER__
-      : "../../build/handler.js";
+    typeof __SVELTEKIT_HANDLER__ !== "undefined" ? __SVELTEKIT_HANDLER__ : "../../build/handler.js";
   try {
     const built = (await import(/* @vite-ignore */ handlerPath)) as {
       handler: typeof svelteHandler;

--- a/src/roles/app.ts
+++ b/src/roles/app.ts
@@ -14,7 +14,7 @@
 
 import { serve } from "@hono/node-server";
 import { createApp } from "../lib/server/http/app.js";
-import { env } from "../lib/server/config/env.js";
+import { env, scrubKekFromEnv } from "../lib/server/config/env.js";
 import { logger } from "../lib/server/logger.js";
 import { pool } from "../lib/server/db/client.js";
 
@@ -44,6 +44,9 @@ export async function start(): Promise<void> {
     };
     svelteHandler = built.handler;
     logger.info({ handlerPath }, "SvelteKit handler loaded");
+    // P2 scrub: run NOW that every bundle that needs APP_KEK_BASE64 has
+    // already parsed it into its own kekVersions Map. See env.ts header.
+    scrubKekFromEnv();
   } catch (err) {
     logger.error(
       { err, handlerPath },

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,15 +5,27 @@
   // Phase 2 lands real game cards in this slot.
   // Plan 01-09: every user-facing string flows through Paraglide's compiled m.*
   // exports (UX-04, D-17 baseLocale only, D-18 single messages file at root).
+  import { goto } from "$app/navigation";
   import { m } from "$lib/paraglide/messages.js";
   import { signIn, signOut } from "$lib/auth-client";
   let { data } = $props();
+
+  // D-08: sign-out-from-all-devices. POSTs to /api/me/sessions/all (mounted in
+  // src/lib/server/http/routes/sessions.ts behind tenantScope). The route
+  // deletes every session row for the current user — including this one — so
+  // the next page load sees no session and lands on the login flow. Force a
+  // navigation to / immediately so the user isn't stuck on a stale dashboard.
+  async function signOutAllDevices(): Promise<void> {
+    await fetch("/api/me/sessions/all", { method: "POST" });
+    await goto("/", { invalidateAll: true });
+  }
 </script>
 
 {#if data.user}
   <h1>{m.dashboard_title()}</h1>
   <p>{m.dashboard_welcome_intro({ name: data.user.name })}</p>
   <button onclick={() => signOut()}>{m.sign_out()}</button>
+  <button onclick={signOutAllDevices}>{m.sign_out_all_devices()}</button>
 {:else}
   <h1>{m.dashboard_title()}</h1>
   <p>{m.dashboard_unauth_intro()}</p>

--- a/src/scheduler/index.ts
+++ b/src/scheduler/index.ts
@@ -19,6 +19,7 @@ import { createBoss, stopBoss } from "../lib/server/queue-client.js";
 import { pool } from "../lib/server/db/client.js";
 import { logger } from "../lib/server/logger.js";
 import { QUEUES } from "../lib/server/queues.js";
+import { scrubKekFromEnv } from "../lib/server/config/env.js";
 
 /**
  * Boot the pg-boss scheduler, declare queues, register the healthcheck cron,
@@ -28,6 +29,9 @@ import { QUEUES } from "../lib/server/queues.js";
  */
 export async function startScheduler(): Promise<void> {
   const boss = await createBoss();
+  // P2 KEK scrub: same as worker — scheduler has no bundled second copy of
+  // env.ts, so it's safe to scrub immediately. See env.ts header.
+  scrubKekFromEnv();
 
   // pg-boss 10.x `schedule(queueName, cronExpression, data?, options?)`
   // registers a recurring enqueue against the named queue. The schedule

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -20,6 +20,7 @@ import { createBoss, stopBoss } from "../lib/server/queue-client.js";
 import { pool } from "../lib/server/db/client.js";
 import { logger } from "../lib/server/logger.js";
 import { QUEUES } from "../lib/server/queues.js";
+import { scrubKekFromEnv } from "../lib/server/config/env.js";
 
 /**
  * Boot the pg-boss worker, declare queues, subscribe to internal.healthcheck,
@@ -29,6 +30,10 @@ import { QUEUES } from "../lib/server/queues.js";
  */
 export async function startWorker(): Promise<void> {
   const boss = await createBoss();
+  // P2 KEK scrub: worker has no bundled second copy of env.ts (no SvelteKit
+  // handler.js import), so it's safe to scrub immediately after createBoss
+  // resolves. See env.ts header for the rationale.
+  scrubKekFromEnv();
 
   // Phase 1 no-op handler on `internal.healthcheck`. Phase 3 replaces with
   // real work + adds `poll.*` subscriptions.

--- a/tests/integration/auth.test.ts
+++ b/tests/integration/auth.test.ts
@@ -6,6 +6,7 @@ import { session, user } from "../../src/lib/server/db/schema/auth.js";
 import { uuidv7 } from "../../src/lib/server/ids.js";
 import { signOutAllDevices } from "../../src/lib/server/services/users.js";
 import { invalidateSession } from "../../src/lib/server/services/sessions.js";
+import { createApp } from "../../src/lib/server/http/app.js";
 import { seedUserDirectly } from "./helpers.js";
 
 // VALIDATION 1/2/3/4 (Better Auth Google OAuth happy path) — the full HTTP redirect
@@ -84,5 +85,49 @@ describe("Better Auth — DB session lifecycle (AUTH-01/02/03)", () => {
 
     const all = await db.select().from(user).where(eq(user.email, "dave@test.local"));
     expect(all.length).toBe(1);
+  });
+
+  it("D-08: POST /api/me/sessions/all deletes every session row for the caller", async () => {
+    const { id: userId, signedSessionCookieValue } = await seedUserDirectly({
+      email: "erin@test.local",
+    });
+
+    // Add a second session row directly so we can verify both go.
+    await db.insert(session).values({
+      id: uuidv7(),
+      userId,
+      token: "second-device-token",
+      expiresAt: new Date(Date.now() + 86_400_000),
+    });
+
+    const before = await db.select().from(session).where(eq(session.userId, userId));
+    expect(before.length).toBeGreaterThanOrEqual(2);
+
+    // Drive the route via Hono's testClient — exercises the real
+    // tenantScope middleware + sessionRoutes mount.
+    const app = createApp();
+    const res = await app.fetch(
+      new Request("http://localhost/api/me/sessions/all", {
+        method: "POST",
+        headers: { cookie: `neotolis.session_token=${signedSessionCookieValue}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { deletedCount: number };
+    expect(body.deletedCount).toBeGreaterThanOrEqual(2);
+
+    const after = await db.select().from(session).where(eq(session.userId, userId));
+    expect(after.length).toBe(0);
+
+    // Anonymous probe with the now-stale cookie must 401, proving the caller's
+    // own session is also invalidated (the whole point of "from all devices").
+    const probe = await app.fetch(
+      new Request("http://localhost/api/me", {
+        headers: { cookie: `neotolis.session_token=${signedSessionCookieValue}` },
+      }),
+    );
+    expect(probe.status).toBe(401);
+
+    await db.delete(user).where(eq(user.id, userId));
   });
 });

--- a/tests/smoke/lib/oauth-mock-driver.ts
+++ b/tests/smoke/lib/oauth-mock-driver.ts
@@ -153,7 +153,7 @@ async function main(): Promise<void> {
         email: args.email,
         email_verified: true,
         name: args.name,
-        aud: process.env.GOOGLE_CLIENT_ID ?? "mock-client-id",
+        aud: process.env.OAUTH_CLIENT_ID ?? "mock-client-id",
       };
     });
 

--- a/tests/smoke/self-host.sh
+++ b/tests/smoke/self-host.sh
@@ -40,14 +40,14 @@ DB_URL="${DATABASE_URL:-postgres://postgres:postgres@localhost:5432/neotolis}"
 BETTER_AUTH_URL_VAL="${BETTER_AUTH_URL:-http://localhost:$APP_PORT}"
 BETTER_AUTH_SECRET_VAL="${BETTER_AUTH_SECRET:-ci-smoke-better-auth-secret-32-chars-min}"
 KEK_BASE64="${APP_KEK_BASE64:-MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=}"
-GOOGLE_CLIENT_ID_VAL="${GOOGLE_CLIENT_ID:-mock-client-id}"
-GOOGLE_CLIENT_SECRET_VAL="${GOOGLE_CLIENT_SECRET:-mock-client-secret}"
+OAUTH_CLIENT_ID_VAL="${OAUTH_CLIENT_ID:-mock-client-id}"
+OAUTH_CLIENT_SECRET_VAL="${OAUTH_CLIENT_SECRET:-mock-client-secret}"
 # genericOAuth plugin (review blocker P0-2 fix) reads OIDC discovery from
 # this URL at boot. Smoke runs the mock IdP on localhost:$MOCK_PORT, so the
 # discovery document is at http://localhost:$MOCK_PORT/.well-known/openid-configuration.
 # Production self-host points at https://accounts.google.com/.well-known/openid-configuration
 # (the env.ts default).
-GOOGLE_DISCOVERY_URL_VAL="${GOOGLE_DISCOVERY_URL:-http://localhost:$MOCK_PORT/.well-known/openid-configuration}"
+OAUTH_DISCOVERY_URL_VAL="${OAUTH_DISCOVERY_URL:-http://localhost:$MOCK_PORT/.well-known/openid-configuration}"
 
 # ============================================================
 # Helpers
@@ -79,9 +79,9 @@ common_env_args() {
 -e DATABASE_URL=$DB_URL
 -e BETTER_AUTH_URL=$BETTER_AUTH_URL_VAL
 -e BETTER_AUTH_SECRET=$BETTER_AUTH_SECRET_VAL
--e GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID_VAL
--e GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET_VAL
--e GOOGLE_DISCOVERY_URL=$GOOGLE_DISCOVERY_URL_VAL
+-e OAUTH_CLIENT_ID=$OAUTH_CLIENT_ID_VAL
+-e OAUTH_CLIENT_SECRET=$OAUTH_CLIENT_SECRET_VAL
+-e OAUTH_DISCOVERY_URL=$OAUTH_DISCOVERY_URL_VAL
 -e APP_KEK_BASE64=$KEK_BASE64
 -e TRUSTED_PROXY_CIDR=
 -e BETTER_AUTH_SECURE_COOKIES=false

--- a/tests/smoke/self-host.sh
+++ b/tests/smoke/self-host.sh
@@ -243,15 +243,25 @@ done
 # end (Hono outer + SvelteKit adapter-node handler + Paraglide compiled
 # messages). Fatal on miss — never PARTIAL — because anything else lets a
 # regression in the SvelteKit-mount path slip through to master.
+log "----- pre-dashboard diagnostic: container state -----"
+docker ps -a --filter name=smoke-app
+docker exec smoke-app sh -c "ls -la /app/build" 2>&1 || echo "(docker exec failed)"
+docker exec smoke-app sh -c "ls -la /app/build/server" 2>&1 || true
+docker exec smoke-app sh -c "ls -la /app/.svelte-kit/output 2>/dev/null | head -10 || echo 'no .svelte-kit/output'" 2>&1 || true
+docker exec smoke-app sh -c "head -3 /app/build/handler.js" 2>&1 || true
+log "------------------------------------------------------"
+
 DASH_HTTP=$(curl -s -o /tmp/dash.html -w '%{http_code}' -H "cookie: $SESSION_COOKIE_A" "http://localhost:$APP_PORT/" || echo "curl-failed")
 DASH_HTML=$(cat /tmp/dash.html 2>/dev/null || echo "")
+log "(4) dashboard HTTP=$DASH_HTTP body-bytes=${#DASH_HTML}"
+log "----- dashboard response (first 600 chars) -----"
+echo "${DASH_HTML:0:600}"
+log "------------------------------------------------"
+log "----- recent app logs (last 80 lines) -----"
+docker logs smoke-app 2>&1 | tail -80 || true
+log "-------------------------------------------"
+
 if [[ "$DASH_HTTP" != "200" ]] || ! echo "$DASH_HTML" | grep -q "Promotion diary"; then
-  log "----- container build/ contents -----"
-  docker exec smoke-app sh -c "ls -la /app/build && echo --- && find /app/build -maxdepth 2 -name '*.js' | head -20" || true
-  log "-------------------------------------"
-  log "----- dashboard response (first 400 chars) -----"
-  echo "${DASH_HTML:0:400}"
-  log "------------------------------------------------"
   fail "(4) dashboard did not render 'Promotion diary' (Paraglide). HTTP=$DASH_HTTP"
 fi
 log "(4) PASS — OAuth login + /api/me + dashboard renders English"

--- a/tests/smoke/self-host.sh
+++ b/tests/smoke/self-host.sh
@@ -236,22 +236,25 @@ for forbidden in googleSub refreshToken accessToken idToken; do
   fi
 done
 
-# Render the dashboard — should contain English text from Paraglide (UX-04 +
-# Plan 09's `Promotion diary` literal in messages/en.json).
-# Phase 1 scope: if the SvelteKit page handler is wired, this assertion is
-# load-bearing. If not (e.g., adapter-node output is missing handler.js in
-# the image), warn and continue — the foundation auth/api proof points
-# above are the load-bearing parts of DEPLOY-05. Fix tracked separately.
+# Render the dashboard — must contain English text from Paraglide (UX-04 +
+# Plan 09's `Promotion diary` literal in messages/en.json). This is the
+# load-bearing parity assertion for DEPLOY-05 SC#1: a self-host operator who
+# pulls the production image gets a working dashboard out of the box, end to
+# end (Hono outer + SvelteKit adapter-node handler + Paraglide compiled
+# messages). Fatal on miss — never PARTIAL — because anything else lets a
+# regression in the SvelteKit-mount path slip through to master.
 DASH_HTTP=$(curl -s -o /tmp/dash.html -w '%{http_code}' -H "cookie: $SESSION_COOKIE_A" "http://localhost:$APP_PORT/" || echo "curl-failed")
 DASH_HTML=$(cat /tmp/dash.html 2>/dev/null || echo "")
-if [[ "$DASH_HTTP" == "200" ]] && echo "$DASH_HTML" | grep -q "Promotion diary"; then
-  log "(4) PASS — OAuth login + /api/me + dashboard renders English"
-else
-  log "(4) PARTIAL — OAuth login + /api/me PASS; dashboard render skipped (HTTP=$DASH_HTTP, SvelteKit page handler not wired in container)"
+if [[ "$DASH_HTTP" != "200" ]] || ! echo "$DASH_HTML" | grep -q "Promotion diary"; then
   log "----- container build/ contents -----"
   docker exec smoke-app sh -c "ls -la /app/build && echo --- && find /app/build -maxdepth 2 -name '*.js' | head -20" || true
   log "-------------------------------------"
+  log "----- dashboard response (first 400 chars) -----"
+  echo "${DASH_HTML:0:400}"
+  log "------------------------------------------------"
+  fail "(4) dashboard did not render 'Promotion diary' (Paraglide). HTTP=$DASH_HTTP"
 fi
+log "(4) PASS — OAuth login + /api/me + dashboard renders English"
 
 # ============================================================
 # 5. Cross-tenant 404 / anonymous 401 — Phase 1 sentinel

--- a/tests/unit/auth-adapter.test.ts
+++ b/tests/unit/auth-adapter.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from "vitest";
+import { randomBytes } from "node:crypto";
+
+// Seed env vars before any module that pulls env.ts loads (the wrapper
+// imports envelope.ts which imports env.ts at top level). Mirrors the
+// pattern in tests/unit/encryption.test.ts.
+process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+process.env.BETTER_AUTH_URL ??= "http://localhost:3000";
+process.env.BETTER_AUTH_SECRET ??= "x".repeat(40);
+process.env.GOOGLE_CLIENT_ID ??= "test-google-id";
+process.env.GOOGLE_CLIENT_SECRET ??= "test-google-secret";
+process.env.APP_KEK_BASE64 ??= randomBytes(32).toString("base64");
+
+// Storage shared by the mocked drizzleAdapter so we can inspect what the
+// wrapper actually wrote vs what Better Auth saw on the way back.
+const storage: { row: Record<string, unknown> | null } = { row: null };
+const calls: { op: string; model: string; payload: unknown }[] = [];
+
+vi.mock("better-auth/adapters/drizzle", () => ({
+  // The real `drizzleAdapter` is `(db, config) => (options) => DBAdapter`.
+  // We mirror that exact shape with a fake that records inputs and reads
+  // back the same row, simulating a single-row Postgres "table".
+  drizzleAdapter: () => () => ({
+    id: "fake",
+    create: async ({ model, data }: { model: string; data: Record<string, unknown> }) => {
+      calls.push({ op: "create", model, payload: data });
+      storage.row = { ...data };
+      return storage.row;
+    },
+    update: async ({ model, update }: { model: string; update: Record<string, unknown> }) => {
+      calls.push({ op: "update", model, payload: update });
+      storage.row = { ...storage.row, ...update };
+      return storage.row;
+    },
+    updateMany: async ({
+      model,
+      update,
+    }: {
+      model: string;
+      update: Record<string, unknown>;
+    }) => {
+      calls.push({ op: "updateMany", model, payload: update });
+      storage.row = { ...storage.row, ...update };
+      return 1;
+    },
+    findOne: async ({ model }: { model: string }) => {
+      calls.push({ op: "findOne", model, payload: null });
+      return storage.row;
+    },
+    findMany: async ({ model }: { model: string }) => {
+      calls.push({ op: "findMany", model, payload: null });
+      return storage.row ? [storage.row] : [];
+    },
+    count: async () => 0,
+    delete: async () => undefined,
+    deleteMany: async () => 0,
+    transaction: async <R>(cb: (trx: unknown) => Promise<R>) => cb(undefined),
+  }),
+}));
+
+// Import AFTER vi.mock so the wrapper picks up the mocked drizzleAdapter.
+const { encryptedDrizzleAdapter } = await import("../../src/lib/server/auth-adapter.js");
+
+const REFRESH_TOKEN = "1//05GoogleRefreshTokenSecretValue123";
+const ACCESS_TOKEN = "ya29.GoogleAccessTokenLooksLikeThis";
+const ID_TOKEN = "eyJhbGciOiJSUzI1NiIsImtpZCI6Im1vY2tfa2lkIn0.payload.signature";
+
+function reset() {
+  storage.row = null;
+  calls.length = 0;
+}
+
+describe("encryptedDrizzleAdapter — OAuth token envelope encryption (D-11 / Fix 4)", () => {
+  it("create on `account` writes ciphertext to storage and returns plaintext to Better Auth", async () => {
+    reset();
+    const factory = encryptedDrizzleAdapter({} as never, { provider: "pg" });
+    const adapter = factory({} as never);
+
+    const created = (await adapter.create({
+      model: "account",
+      data: {
+        userId: "u1",
+        accountId: "google-sub-1",
+        providerId: "google",
+        accessToken: ACCESS_TOKEN,
+        refreshToken: REFRESH_TOKEN,
+        idToken: ID_TOKEN,
+      },
+    })) as Record<string, unknown>;
+
+    expect(created.refreshToken).toBe(REFRESH_TOKEN);
+    expect(created.accessToken).toBe(ACCESS_TOKEN);
+    expect(created.idToken).toBe(ID_TOKEN);
+
+    expect(storage.row).not.toBeNull();
+    const stored = storage.row!;
+    const storedRefresh = stored.refreshToken as string;
+    expect(storedRefresh.startsWith("ev1:")).toBe(true);
+    expect(storedRefresh).not.toContain(REFRESH_TOKEN);
+    expect(storedRefresh).not.toContain("GoogleRefreshTokenSecretValue");
+    expect((stored.accessToken as string).startsWith("ev1:")).toBe(true);
+    expect((stored.idToken as string).startsWith("ev1:")).toBe(true);
+    // Non-token fields untouched.
+    expect(stored.providerId).toBe("google");
+    expect(stored.accountId).toBe("google-sub-1");
+  });
+
+  it("findOne on `account` decrypts back to plaintext for Better Auth", async () => {
+    reset();
+    const factory = encryptedDrizzleAdapter({} as never, { provider: "pg" });
+    const adapter = factory({} as never);
+    await adapter.create({
+      model: "account",
+      data: { userId: "u2", providerId: "google", refreshToken: REFRESH_TOKEN },
+    });
+    const found = (await adapter.findOne({ model: "account", where: [] })) as {
+      refreshToken: string;
+    };
+    expect(found.refreshToken).toBe(REFRESH_TOKEN);
+  });
+
+  it("findMany on `account` decrypts each row back to plaintext", async () => {
+    reset();
+    const factory = encryptedDrizzleAdapter({} as never, { provider: "pg" });
+    const adapter = factory({} as never);
+    await adapter.create({
+      model: "account",
+      data: { userId: "u2b", providerId: "google", refreshToken: REFRESH_TOKEN },
+    });
+    const rows = (await adapter.findMany({ model: "account", limit: 10 })) as {
+      refreshToken: string;
+    }[];
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.refreshToken).toBe(REFRESH_TOKEN);
+  });
+
+  it("update on `account` re-encrypts new tokens with fresh DEK + IV", async () => {
+    reset();
+    const factory = encryptedDrizzleAdapter({} as never, { provider: "pg" });
+    const adapter = factory({} as never);
+    await adapter.create({
+      model: "account",
+      data: { userId: "u3", providerId: "google", refreshToken: "old" },
+    });
+    const firstStored = storage.row!.refreshToken as string;
+    await adapter.update({
+      model: "account",
+      where: [],
+      update: { refreshToken: "new" },
+    });
+    const secondStored = storage.row!.refreshToken as string;
+    expect(secondStored.startsWith("ev1:")).toBe(true);
+    expect(secondStored).not.toBe(firstStored);
+    expect(secondStored).not.toContain("new");
+  });
+
+  it("does not double-encrypt an already-wrapped value (idempotent on update)", async () => {
+    reset();
+    const factory = encryptedDrizzleAdapter({} as never, { provider: "pg" });
+    const adapter = factory({} as never);
+    await adapter.create({
+      model: "account",
+      data: { userId: "u4", providerId: "google", refreshToken: REFRESH_TOKEN },
+    });
+    const wrapped = storage.row!.refreshToken as string;
+    await adapter.update({
+      model: "account",
+      where: [],
+      update: { refreshToken: wrapped },
+    });
+    expect(storage.row!.refreshToken).toBe(wrapped);
+  });
+
+  it("non-account models pass through untouched", async () => {
+    reset();
+    const factory = encryptedDrizzleAdapter({} as never, { provider: "pg" });
+    const adapter = factory({} as never);
+    await adapter.create({
+      model: "user",
+      data: { id: "u5", email: "x@x.test", refreshToken: "would-not-be-encrypted-here" },
+    });
+    expect(storage.row!.refreshToken).toBe("would-not-be-encrypted-here");
+  });
+
+  it("legacy plaintext rows decrypt to themselves (graceful migration)", async () => {
+    reset();
+    const factory = encryptedDrizzleAdapter({} as never, { provider: "pg" });
+    const adapter = factory({} as never);
+    // Plant a row with plaintext (no `ev1:` prefix) directly into storage.
+    storage.row = { userId: "u6", providerId: "google", refreshToken: "legacy-plain-token" };
+    const found = (await adapter.findOne({ model: "account", where: [] })) as {
+      refreshToken: string;
+    };
+    // Plaintext is returned as-is — graceful migration so a half-rolled-out
+    // schema doesn't break authentication for users whose row was written
+    // before this commit.
+    expect(found.refreshToken).toBe("legacy-plain-token");
+  });
+
+  it("missing/empty tokens are not encrypted (no JSON blob written for null/undefined)", async () => {
+    reset();
+    const factory = encryptedDrizzleAdapter({} as never, { provider: "pg" });
+    const adapter = factory({} as never);
+    await adapter.create({
+      model: "account",
+      data: {
+        userId: "u7",
+        providerId: "google",
+        accessToken: ACCESS_TOKEN,
+        // refreshToken omitted; idToken is empty string
+        idToken: "",
+      },
+    });
+    expect((storage.row!.accessToken as string).startsWith("ev1:")).toBe(true);
+    expect(storage.row!.refreshToken).toBeUndefined();
+    expect(storage.row!.idToken).toBe(""); // empty stays empty
+  });
+});

--- a/tests/unit/auth-adapter.test.ts
+++ b/tests/unit/auth-adapter.test.ts
@@ -7,8 +7,8 @@ import { randomBytes } from "node:crypto";
 process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
 process.env.BETTER_AUTH_URL ??= "http://localhost:3000";
 process.env.BETTER_AUTH_SECRET ??= "x".repeat(40);
-process.env.GOOGLE_CLIENT_ID ??= "test-google-id";
-process.env.GOOGLE_CLIENT_SECRET ??= "test-google-secret";
+process.env.OAUTH_CLIENT_ID ??= "test-google-id";
+process.env.OAUTH_CLIENT_SECRET ??= "test-google-secret";
 process.env.APP_KEK_BASE64 ??= randomBytes(32).toString("base64");
 
 // Storage shared by the mocked drizzleAdapter so we can inspect what the

--- a/tests/unit/auth-adapter.test.ts
+++ b/tests/unit/auth-adapter.test.ts
@@ -32,13 +32,7 @@ vi.mock("better-auth/adapters/drizzle", () => ({
       storage.row = { ...storage.row, ...update };
       return storage.row;
     },
-    updateMany: async ({
-      model,
-      update,
-    }: {
-      model: string;
-      update: Record<string, unknown>;
-    }) => {
+    updateMany: async ({ model, update }: { model: string; update: Record<string, unknown> }) => {
       calls.push({ op: "updateMany", model, payload: update });
       storage.row = { ...storage.row, ...update };
       return 1;

--- a/tests/unit/encryption.test.ts
+++ b/tests/unit/encryption.test.ts
@@ -21,8 +21,8 @@ import { randomBytes } from "node:crypto";
 process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
 process.env.BETTER_AUTH_URL ??= "http://localhost:3000";
 process.env.BETTER_AUTH_SECRET ??= "x".repeat(40);
-process.env.GOOGLE_CLIENT_ID ??= "test-google-id";
-process.env.GOOGLE_CLIENT_SECRET ??= "test-google-secret";
+process.env.OAUTH_CLIENT_ID ??= "test-google-id";
+process.env.OAUTH_CLIENT_SECRET ??= "test-google-secret";
 // 32 raw bytes, base64 encoded (44 chars including padding).
 process.env.APP_KEK_BASE64 ??= randomBytes(32).toString("base64");
 

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -1,11 +1,22 @@
 import { describe, expect, it } from "vitest";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { Writable } from "node:stream";
+import pino from "pino";
 
-// Wave 0 placeholder for D-23/D-24 logger discipline.
-// Plan 01-01 lands `src/lib/server/logger.ts`; this file does a sanity check today and
-// Plan 01-04 / Plan 01-07 expand redaction-path assertions.
+// Phase-1 final D-24 coverage: redaction-behavior + env-discipline tripwire.
+// Plan 01-01 owns src/lib/server/logger.ts; this test guards two invariants
+// that no other test catches:
+//   1. Every path in the logger's REDACT_PATHS list actually emits
+//      "[REDACTED]" in the JSON output. A typo in the list silently disables
+//      the protection — the only way to notice is to log an object shaped
+//      like the path and grep stdout in tests.
+//   2. process.env.* is read ONLY in src/lib/server/config/env.ts. Anywhere
+//      else risks a KEK-shaped secret leaking via accidental console.log
+//      (PITFALL P2).
+
 describe("logger redaction", () => {
   it("logger module exposes pino-shaped interface", async () => {
-    // Until Plan 01-01 lands the logger, this import throws — that's fine; we're scaffolded.
     let logger: unknown = null;
     try {
       const mod = await import("../../src/lib/server/logger.js");
@@ -17,11 +28,115 @@ describe("logger redaction", () => {
     expect(typeof (logger as { info?: unknown }).info).toBe("function");
   });
 
-  it.skip("redacts every D-24 path with [REDACTED]", () => {
-    /* Plan 01-04 wires real redaction-path assertions (apiKey, refreshToken, wrappedDek, …) */
+  it("redacts every D-24 path with [REDACTED]", async () => {
+    // Read the canonical list straight from the source so the test mirrors
+    // whatever the runtime logger uses. We don't import the live logger
+    // because it is configured to write to stdout / a transport — feeding it
+    // a synchronous capture stream is simpler with a fresh pino() instance
+    // configured against the same redact list.
+    const loggerSource = await fs.readFile(
+      path.resolve(process.cwd(), "src/lib/server/logger.ts"),
+      "utf8",
+    );
+    const arrayMatch = loggerSource.match(/const REDACT_PATHS\s*=\s*\[([\s\S]*?)\]/);
+    expect(arrayMatch, "REDACT_PATHS array not found in src/lib/server/logger.ts").toBeTruthy();
+    const paths = Array.from(arrayMatch![1]!.matchAll(/"([^"]+)"/g)).map((m) => m[1]!);
+    expect(paths.length).toBeGreaterThan(0);
+
+    // Capture pino's JSON output line-by-line.
+    const lines: string[] = [];
+    const sink = new Writable({
+      write(chunk, _enc, cb) {
+        lines.push(String(chunk));
+        cb();
+      },
+    });
+    const testLogger = pino(
+      { redact: { paths, censor: "[REDACTED]" }, base: null, timestamp: false },
+      sink,
+    );
+
+    // For each path, build an object that populates exactly that path with a
+    // distinctive sentinel value, log it, then assert the emitted JSON
+    // contains "[REDACTED]" instead of the sentinel.
+    const SENTINEL = "PLAINTEXT_LEAK_SENTINEL_VALUE_DO_NOT_LOG";
+    for (const p of paths) {
+      lines.length = 0;
+      const obj = buildObjectForPath(p, SENTINEL);
+      testLogger.info(obj, `redact-test path=${p}`);
+      const out = lines.join("");
+      expect(out, `path "${p}" did not produce a log line`).toContain("[REDACTED]");
+      expect(out, `path "${p}" leaked the sentinel value: ${out}`).not.toContain(SENTINEL);
+    }
   });
 
-  it.skip("process.env.* is not accessed outside src/lib/server/config/env.ts", () => {
-    /* Plan 01-07: lint/grep gate so KEK-shaped secrets cannot leak via console.log */
+  it("process.env.* is not accessed outside src/lib/server/config/env.ts", async () => {
+    // Static-grep tripwire (D-24 / PITFALL P2). The ESLint contract is
+    // configured separately, but a runtime guard catches the case where the
+    // lint config drifts or a future contributor disables the rule with
+    // `// eslint-disable-next-line` and forgets to revert.
+    const root = path.resolve(process.cwd(), "src");
+    const allowed = path.normalize(path.join("server", "config", "env.ts"));
+    const offenders: { file: string; line: number; text: string }[] = [];
+
+    async function walk(dir: string): Promise<void> {
+      const entries = await fs.readdir(dir, { withFileTypes: true });
+      for (const ent of entries) {
+        const full = path.join(dir, ent.name);
+        if (ent.isDirectory()) {
+          if (ent.name === "paraglide") continue;
+          await walk(full);
+          continue;
+        }
+        if (!/\.(ts|tsx|svelte|js|mjs|cjs)$/.test(ent.name)) continue;
+        const rel = path.relative(root, full);
+        if (rel.endsWith(allowed)) continue;
+        const src = await fs.readFile(full, "utf8");
+        const lines = src.split(/\r?\n/);
+        for (let i = 0; i < lines.length; i++) {
+          const line = lines[i]!;
+          // Skip comments — the discipline is about runtime reads, not docs.
+          const stripped = line.replace(/\/\/.*$/, "").replace(/\/\*[\s\S]*?\*\//g, "");
+          if (/\bprocess\.env\b/.test(stripped)) {
+            offenders.push({ file: rel, line: i + 1, text: line.trim() });
+          }
+        }
+      }
+    }
+    await walk(root);
+
+    if (offenders.length > 0) {
+      const detail = offenders.map((o) => `  ${o.file}:${o.line}  ${o.text}`).join("\n");
+      throw new Error(
+        `process.env access found outside src/lib/server/config/env.ts:\n${detail}`,
+      );
+    }
   });
 });
+
+/**
+ * Build a nested object so that the value at the given pino redact path is the
+ * sentinel. Supports the `*.foo` glob (single segment) and `req.headers.x` style
+ * dotted paths. Wildcard-segments are materialized as `wild`.
+ */
+function buildObjectForPath(p: string, value: string): Record<string, unknown> {
+  // pino redact paths support `*` as a leading segment (glob over top-level keys)
+  // and bracketed keys, but our REDACT_PATHS use simple `*.foo` / `a.b.c` shapes.
+  // Anything starting with `*.` we materialize under a top-level key called `obj`.
+  // `*.encrypted_*` (a wildcarded leaf) is materialized with the leaf literal
+  // `encrypted_x` since pino treats `encrypted_*` as a leaf-glob over keys.
+  const segments = p.split(".").map((seg) => {
+    if (seg === "*") return "wild";
+    if (seg.endsWith("_*")) return seg.replace(/_\*$/, "_x");
+    return seg;
+  });
+  const root: Record<string, unknown> = {};
+  let cursor: Record<string, unknown> = root;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const next: Record<string, unknown> = {};
+    cursor[segments[i]!] = next;
+    cursor = next;
+  }
+  cursor[segments[segments.length - 1]!] = value;
+  return root;
+}

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -107,9 +107,7 @@ describe("logger redaction", () => {
 
     if (offenders.length > 0) {
       const detail = offenders.map((o) => `  ${o.file}:${o.line}  ${o.text}`).join("\n");
-      throw new Error(
-        `process.env access found outside src/lib/server/config/env.ts:\n${detail}`,
-      );
+      throw new Error(`process.env access found outside src/lib/server/config/env.ts:\n${detail}`);
     }
   });
 });

--- a/tests/unit/proxy-trust.test.ts
+++ b/tests/unit/proxy-trust.test.ts
@@ -6,8 +6,8 @@ import { randomBytes } from "node:crypto";
 process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
 process.env.BETTER_AUTH_URL ??= "http://localhost:3000";
 process.env.BETTER_AUTH_SECRET ??= "x".repeat(40);
-process.env.GOOGLE_CLIENT_ID ??= "test";
-process.env.GOOGLE_CLIENT_SECRET ??= "test";
+process.env.OAUTH_CLIENT_ID ??= "test";
+process.env.OAUTH_CLIENT_SECRET ??= "test";
 process.env.APP_KEK_BASE64 ??= randomBytes(32).toString("base64");
 // Trusted CIDRs for these tests: private LAN, loopback, IPv6 loopback,
 // and a real Cloudflare IPv6 prefix (PT4).


### PR DESCRIPTION
Closes #5. P0/P1 fixes from the post-Phase-1 senior review + author follow-up rename.

## Summary

- **P0 — Smoke dashboard-render fatal again.** Two-step root-cause fix:
  - Bumped zod ^3 → ^4 + @hono/zod-validator ^0.4 → ^0.7 because Better Auth 1.6.x emits zod-v4 syntax that broke the SvelteKit bundle.
  - Chained `paraglide:compile && svelte-kit sync` into the `build` script so a fresh Docker build populates `.svelte-kit/` and produces a route manifest in `handler.js`.
  - Deferred the KEK scrub from process.env via `scrubKekFromEnv()` called per-role AFTER bundles load — the auto-scrub was racing the dynamic `import("handler.js")` whose bundled copy of env.ts re-parsed process.env. ZodError → fallback 404 stub → 404 dashboard.
  - Hardened the Hono ↔ SvelteKit handoff in `src/roles/app.ts` so `outgoing.finish` resolves an empty Response that `@hono/node-server`'s `writableEnded` check skips, eliminating ERR_HTTP_HEADERS_SENT.
  - Smoke `(4)` flips back to fatal on miss.
- **P0 — Logger redaction + process.env tripwire tests activated.** `tests/unit/logger.test.ts` exercises every `REDACT_PATHS` shape against pino with a captured stream + walks `src/` for stray `process.env` references. Caught a real bug — `*.encrypted_*` was silently unredacted (pino's fast-redact wildcard only honors `*` as a full path segment); replaced with explicit names.
- **P0 — `01-10-SUMMARY.md` written** with INFO I2 / D-13 / dashboard-render restoration arc + Self-Check footer.
- **P1 — OAuth tokens envelope-encrypted at rest.** `src/lib/server/auth-adapter.ts` wraps the official `drizzleAdapter` and intercepts create/update/findOne/findMany on the `account` model to envelope-encrypt `accessToken`/`refreshToken`/`idToken`. JSON-encoded with `ev1:` prefix → fits in existing `text` column, no schema migration. 8 unit tests assert ciphertext-at-rest, idempotency, legacy-plaintext fallback.
- **P1 — D-08 sign-out-from-all-devices wired.** New `POST /api/me/sessions/all` route behind `tenantScope`; button in `+page.svelte`. Integration test asserts both sessions vanish AND the caller's own cookie 401s afterwards.
- **P1 — `migrate.ts` reorder.** `pg_advisory_unlock` now runs before flipping `migrationsApplied.current = true`, with a defensive `try { unlock } catch { warn }` retained in `finally`.
- **Author follow-up — `GOOGLE_*` env vars renamed to `OAUTH_*` + `OAUTH_PROVIDER_ID`.** `GOOGLE_DISCOVERY_URL` pointing at Keycloak looks wrong, and hardcoding `providerId: "google"` in auth.ts means a self-host operator on a non-Google IdP gets account rows mislabelled. Renamed `GOOGLE_CLIENT_ID/SECRET/DISCOVERY_URL` → `OAUTH_CLIENT_ID/SECRET/DISCOVERY_URL`; added `OAUTH_PROVIDER_ID` (default `"google"`) which feeds both the `account.providerId` column and the genericOAuth plugin's `providerId`. SaaS doesn't override anything (defaults serve Google). Self-host docs (`.env.example`) document the override as unsupported / advanced and warn that `OAUTH_DISCOVERY_URL` and `OAUTH_PROVIDER_ID` MUST move together.

## Self-review (per AGENTS.md Validation section)

**Constraints compliance:**
- Auth: SaaS still serves Google only via OAUTH_* defaults; self-host override is documented unsupported. ✓
- Privacy: All new code behind `tenantScope`; no public surface added. ✓
- Secrets at rest: refreshToken/accessToken/idToken now envelope-encrypted. ✓
- Open-source / self-host parity: smoke gate restored to fatal. ✓
- Identical SaaS / self-host behavior: SaaS uses OAUTH_* defaults (Google); self-host can override at own risk. ✓

**Philosophy compliance:**
- Simplicity for an outsider: env var names now self-describe (`OAUTH_*` doesn't lie about Keycloak); `auth.ts` header explains the SaaS-vs-self-host support contract.
- Modularity: ✓ no internal-reach.
- No premature abstraction: minor — `auth-adapter.ts:160` `model === "account" || "accounts"` plural check; cosmetic.
- Security as floor: Fix 4 + Fix 2 add and verify floors.

**Practices compliance:**
- Atomic PRs: drift acknowledged — bundles 6 P0/P1 fixes + rename per author follow-up. Justified by single review-fix scope.
- Tests with feature: every fix lands with a test. ✓
- One env source: tripwire enforces. ✓
- Self-host parity is a CI gate: RESTORED + smoke now exercises the OAUTH_* env names that self-host docs use. ✓
- Locked stack versions: drift — zod 3 → 4 + hono/zod-validator 0.4 → 0.7. Rationale in commit `2b1c134` (Better Auth 1.6.x bundle-time syntax).

**Documentation drift:** `.env.example`, `docker-compose.selfhost.yml`, smoke harness all consistent. `.planning/...` historical artifacts intentionally NOT rewritten (they record the state at decision time; the new env names show up in active files only).

## Test plan

- [x] `pnpm typecheck` green
- [x] `pnpm test:unit` 41/41 green
- [x] `pnpm build` produces both `build/handler.js` and `build/server.js`
- [x] `pnpm lint` green
- [x] CI `lint-typecheck` job — green
- [x] CI `unit-integration` job — green
- [x] CI `smoke` job — green: production Docker image renders dashboard, OAuth dance succeeds, /api/me + cross-tenant + anonymous-401 + no SaaS-only env all pass

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)