### PR TITLE
docs(02.2): capture ship-to-prod phase context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ src/lib/paraglide/
 .env.local
 coverage/
 .DS_Store
+.claude/
+*.stackdump

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -73,6 +73,16 @@ Decimal phases appear between their surrounding integers in numeric order.
 **UI hint**: yes
 **Phase 2 closure note (2026-04-28)**: phase verdict `gaps_found`. UAT surfaced 4 P0 architectural redesigns (data_sources unified abstraction / 3-view feed-first IA / auto-import inbox flow / unified events table with author_is_me) plus 1 P0 functional gap (rename + add-Steam UI missing on `/games/[id]`). Closure delegated to Phase 2.1 (INSERTED below); see PROJECT.md "Architecture" section + 4 todos in `.planning/todos/pending/2026-04-28-{data-sources-unified-model,three-views-feed-sources-games,channel-to-inbox-auto-import-flow,rethink-items-vs-events-architecture}.md`.
 
+### Phase 02.2: ship-to-prod (INSERTED)
+
+**Goal:** [Urgent work - to be planned]
+**Requirements**: TBD
+**Depends on:** Phase 2
+**Plans:** 0 plans
+
+Plans:
+- [ ] TBD (run /gsd:plan-phase 02.2 to break down)
+
 ### Phase 2.1: Architecture Realignment
 *INSERTED — gap closure from Phase 2 UAT (2026-04-28)*
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -105,6 +105,10 @@ Plan: Not started
 
 ## Accumulated Context
 
+### Roadmap Evolution
+
+- Phase 02.2 inserted after Phase 02 (chronologically after 02.1): ship-to-prod (URGENT) — pre-Phase-3 deploy work so user can dogfood the SaaS before polling pipeline lands
+
 ### Decisions
 
 Decisions are logged in PROJECT.md Key Decisions table.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,11 +3,11 @@ gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
 status: Ready to plan
-stopped_at: Completed 02.1-38-PLAN.md
-last_updated: "2026-04-30T14:57:03.769Z"
+stopped_at: Phase 02.2 context gathered
+last_updated: "2026-05-01T07:23:28.345Z"
 last_activity: 2026-04-30
 progress:
-  total_phases: 7
+  total_phases: 8
   completed_phases: 3
   total_plans: 60
   completed_plans: 60
@@ -335,8 +335,8 @@ Recent decisions affecting current work:
 
 ## Session Continuity
 
-Last session: 2026-04-30T06:00:16.812Z
+Last session: 2026-05-01T07:23:28.334Z
 Last Activity: 2026-04-30
-Stopped at: Completed 02.1-38-PLAN.md
-Resume file: None
+Stopped at: Phase 02.2 context gathered
+Resume file: .planning/phases/02.2-ship-to-prod/02.2-CONTEXT.md
 Resume command: see end-of-session message — start with `/clear`, then update PROJECT.md

--- a/.planning/phases/02.2-ship-to-prod/02.2-CONTEXT.md
+++ b/.planning/phases/02.2-ship-to-prod/02.2-CONTEXT.md
@@ -295,6 +295,79 @@ THIRD_PARTY_LICENSES generation, dashboards).
     restriction limiting to the deploy script
   - nginx basic rate-limit (10 req/sec per IP) on auth endpoints
 
+### Manual prerequisites — operator-side, NOT plan tasks
+
+- **D-PRE:** **Phase 2.2 delivers code + docs + scripts; physical
+  infrastructure provisioning is a separate manual operator task done
+  AFTER Phase 2.2 is signed off.** The author confirmed during context
+  review (2026-05-01): "Домен и VPS ещё не куплены. Это отдельная
+  ручная задача, после того как ты всё сделаешь и подготовишь."
+  
+  **Phase 2.2 plans MUST deliver (so the manual step is small and
+  reproducible):**
+  - All application code (account export/delete services + endpoints,
+    per-user quotas, /privacy + /terms + /settings/account UI,
+    `SUPPORT_EMAIL` env var)
+  - `docker-compose.prod.yml` template
+  - `nginx.conf` template (with `${DOMAIN}` placeholder)
+  - `scripts/backup.sh` + `scripts/deploy.sh`
+  - `docs/deploy/install.md` — step-by-step deploy runbook
+  - `docs/self-host/backups.md` — opt-in backup setup
+  - Updated `.env.example` documenting every var
+  - GitHub Actions workflow building + pushing to GHCR
+  
+  **Phase 2.2 plans MUST NOT include as plan tasks:**
+  - Buying / provisioning the aeza VPS
+  - Registering the domain through CF Registrar
+  - Configuring CF DNS A-record + orange cloud
+  - Creating the production Google OAuth Client ID in Cloud Console
+  - Generating production secrets (`APP_KEK_BASE64`,
+    `POSTGRES_PASSWORD`, `BETTER_AUTH_SECRET`)
+  - Configuring rclone interactively for R2
+  - Adding the crontab entry on the VPS
+  - Submitting the OAuth verification request to Google
+  
+  These all become **checklist items in `docs/deploy/install.md`** that
+  the operator (author) executes manually AFTER Phase 2.2 ships. CI
+  remains unaffected (continues to use OAuth mock + ephemeral test KEK
+  + Postgres service container per Phase 1 — no production-secrets
+  dependency).
+  
+  **Verification gate:** Phase 2.2 VALIDATION.md sign-off does NOT
+  require a live production deploy. It requires "the runbook walks
+  cleanly when read top-to-bottom" + smoke gate continues green +
+  manual UAT against the CI smoke image. Live deploy is a post-2.2
+  operator task with its own success criteria.
+
+### Sanity-check confirmations (final review)
+
+- **D-S1:** **GHCR image is public** (repo is public; image inherits).
+  Confirmed: matches D-21 OSS self-host story — self-host operators do
+  `docker pull ghcr.io/d954mas/neotolis-diary:latest` without auth.
+- **D-S2:** **`docker-compose.prod.yml` lives in the repo as a template**,
+  alongside `docker-compose.selfhost.yml`. The compose file is structural
+  (image refs, port maps, healthchecks, restart policy, volume names,
+  `env_file: .env` references) — contains NO secrets. All real secret
+  values (KEK, OAuth client secret, R2 tokens) live in `.env` on the VPS
+  (gitignored). Self-host parity (D-31) preserved: `selfhost.yml` stays
+  the canonical CI-tested file; `prod.yml` is a documented template
+  variant operators (including author) adapt. Disaster recovery: VPS
+  loss → new VPS → `git clone` → `docker compose up -d`. Domain-specific
+  values use `${DOMAIN}` / `${SUPPORT_EMAIL}` substitution, not
+  hardcodes.
+- **D-S3:** **Account-delete confirm dialog uses "Type DELETE" pattern**
+  — extends the Phase 2.1 event-delete confirm-dialog component (already
+  in `src/lib/components/ConfirmDialog.svelte` or equivalent). Industry
+  standard for irrecoverable-within-window actions (GitHub repo delete,
+  Discord server delete). Combined with the 60-day grace period
+  (D-15/D-16) gives two layers of mistake protection.
+- **D-S4:** **`SUPPORT_EMAIL` is an env var** in `env.ts` zod schema,
+  default empty (self-host operator must configure; CI can inject test
+  value). Author's prod sets `SUPPORT_EMAIL=neotolis.games@gmail.com`.
+  Privacy / ToS / footer / OAuth-Console-owner-email all read this
+  value dynamically at render time. Preserves self-host parity (D-31)
+  and avoids SaaS-leak grep tripwire (D-30) on hardcoded literals.
+
 ### Self-review compliance hooks (AGENTS.md)
 
 - **D-29:** **Constraints compliance** — Phase 2.2 introduces no new

--- a/.planning/phases/02.2-ship-to-prod/02.2-CONTEXT.md
+++ b/.planning/phases/02.2-ship-to-prod/02.2-CONTEXT.md
@@ -190,6 +190,57 @@ THIRD_PARTY_LICENSES generation, dashboards).
   VPS), admin (lives on author's local machine for monthly cleanup).
   CF R2 free tier = 10GB storage + 1M class-A ops/month — well below the
   ~1.5GB/month projected backup volume.
+
+- **D-25a:** **Backups are opt-in server-level cron, NOT bundled into
+  docker-compose.** The shipping artifacts are:
+  - `scripts/backup.sh` — reusable shell script (~30 lines), reads from
+    rclone config, idempotent, exits 0 on lock-held to avoid duplicate
+    runs. Works against any S3-compatible storage (CF R2, Backblaze B2,
+    Wasabi, MinIO, AWS S3) via `rclone` remote configuration.
+  - `docs/self-host/backups.md` — runbook with examples for R2 / B2 /
+    MinIO / local-only setups.
+  - **No backup service in `docker-compose.selfhost.yml` or
+    `docker-compose.prod.yml`.** Author's-instance setup includes a
+    one-time `crontab -e` step (documented in the deploy runbook); the
+    same script works for self-host operators who want backups, and
+    self-host operators who don't want them simply skip the cron step
+    — the app runs identically with or without.
+  - Self-host parity preserved: smoke gate boots `selfhost.yml` with no
+    backup-related env vars; no dependency on R2 / S3 / rclone in the
+    application code path.
+  - The application has zero awareness of backups — `env.ts` introduces
+    no R2 / backup env vars; rclone reads its own config from
+    `~/.config/rclone/rclone.conf`.
+
+- **D-25b:** **Backup invocation contract** — daily cron, idempotent,
+  flock-locked, date-only filename:
+  - **Schedule:** `0 3 * * *` (3 AM server-time daily). Documented in
+    `docs/self-host/backups.md`; operators may pick a different time.
+  - **Concurrency safety:** `flock -n /var/lock/diary-backup.lock` at
+    the top of the script. If another instance holds the lock (cron
+    misfire, slow backup overlapping next cron, admin manual run while
+    cron is firing), the second instance exits 0 silently. No duplicate
+    runs, no error noise.
+  - **Filename:** `$(date +%Y-%m-%d).sql.gz` — date-only, one logical
+    backup per day. Multiple runs the same day overwrite the same key
+    in R2; R2 versioning under Object Lock preserves the prior version
+    in history (no data loss). Practically harmless because the data
+    delta within a single day is small.
+  - **NOT linked to deploys:** `pnpm deploy` (D-22) does NOT trigger
+    backups; `backup.sh` does NOT trigger redeploys. Two independent
+    cycles (deploys are rare and code-shaped; backups are regular and
+    data-shaped). Coupling them would create failure cascades and slow
+    deploys; AGENTS.md "Modularity" principle.
+  - **First-deploy bootstrap:** the deploy runbook contains a one-time
+    section "Set up backups (optional)" — copy script to
+    `/usr/local/bin/diary-backup`, configure rclone interactively for
+    the chosen S3 remote, add crontab line. After bootstrap, deploys
+    and backups run independently forever.
+  - **Failure visibility:** backup failures do NOT page the operator
+    (UptimeRobot pings `/healthz`, not backup status). Phase 6 may add
+    a backup-status dashboard if needed; Phase 2.2 baseline is "check
+    R2 manually monthly to confirm backups are landing", documented
+    in the runbook.
 - **D-26:** **Uptime monitoring = UptimeRobot free.** 5-minute ping on
   `https://<domain>/healthz`, alerts via Telegram + email when 2 consecutive
   checks fail. Free tier covers 50 monitors. Mandatory for open-signup

--- a/.planning/phases/02.2-ship-to-prod/02.2-CONTEXT.md
+++ b/.planning/phases/02.2-ship-to-prod/02.2-CONTEXT.md
@@ -1,0 +1,508 @@
+# Phase 02.2: ship-to-prod — Context
+
+**Gathered:** 2026-05-01
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Get the Phase 2.1 codebase running on the author's production infrastructure
+(aeza VPS) so the author can use it as the canonical SaaS instance and dogfood
+his own diary while Phase 3 (polling pipeline) is being built. Open signup —
+any Google account can register from day one — therefore Privacy/ToS/abuse
+limits/in-app GDPR controls land in this phase.
+
+This is **author's-instance-live + minimum public-SaaS surface** —
+NOT the OSS-ready self-host polish for arbitrary self-hosters
+(that remains Phase 6: DEPLOY-01..04, PRIV-03/04, KEK runbook rehearsal,
+THIRD_PARTY_LICENSES generation, dashboards).
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Hosting + TLS + Postgres
+
+- **D-01:** **VPS = aeza** (per PROJECT.md "Hosting" constraint). Reuse the
+  pattern from `C:\projects\game_idea_founder` (`/opt/diary` install path,
+  rsync deploy via SSH). Author already has aeza account.
+- **D-02:** **Postgres lives in `docker-compose.prod.yml`** on the same VPS
+  (single failure domain, but matches indie-budget "free tier or VPS"
+  constraint). Not Neon / not Supabase — pg-boss connection pool drift on
+  managed providers + free-tier auto-suspend + AGENTS.md "all infra runs on
+  free tier or VPS" constraint.
+- **D-03:** **`POSTGRES_PASSWORD` generated** (`openssl rand -base64 32`)
+  and stored in `.env` on VPS. NOT the `postgres/postgres` default from
+  `docker-compose.selfhost.yml`. Even though Postgres listens only on the
+  internal docker network (no `ports:` exposure), default-password is
+  unacceptable hygiene for prod.
+- **D-04:** **TLS strategy = Cloudflare proxy (orange cloud) + nginx on VPS**
+  (Variant A from discussion). DNS A-record points at VPS, CF terminates TLS
+  on :443, forwards plain HTTP to VPS:80, nginx reverse-proxies to
+  `app:3000`. Matches the `game_idea_founder` nginx pattern; CF Free gives
+  TLS cert + DDoS-shield + WAF + edge-cache for free; the existing
+  `src/lib/server/proxy-trust.ts` module already supports `CF-Connecting-IP`
+  trusted-proxy header walking.
+- **D-05:** **`TRUSTED_PROXY_CIDR` = Cloudflare published IP ranges**
+  (https://www.cloudflare.com/ips-v4/, https://www.cloudflare.com/ips-v6/).
+  Documented as a sourcing step in the deploy runbook; refresh quarterly.
+- **D-06:** **Cloudflare Tunnel NOT used** in Phase 2.2. Origin IP exposure
+  acceptable for personal-instance threat model; CF proxy already provides
+  DDoS shield. Tunnel can be added later as a sidecar in compose if a real
+  DDoS materializes.
+- **D-07:** **New domain registered through Cloudflare Registrar** (CF
+  account already owned by author). Domain choice deferred to planning
+  (researcher will surface available `.app`/`.dev`/`.me` options consistent
+  with project name; OSS-ready domain since PROJECT.md positions this as the
+  canonical SaaS instance).
+
+### Tenancy at launch
+
+- **D-08:** **Open signup** — any Google account can register. NOT email
+  allowlist, NOT invite codes. The author chose this knowing the
+  Privacy/ToS/abuse-limits cost. The codebase is already multi-tenant
+  (Phase 1 + 2.1 invariants) — open signup is just removing the
+  configuration gate.
+- **D-09:** **Privacy Policy page at `/privacy`** — static SvelteKit route
+  with templated copy covering: data we collect (email, IP, audit, content),
+  retention (active forever, soft-deleted 60 days, backups 30 days),
+  processors (Cloudflare for CDN/TLS, R2 for backups), user rights
+  (Art. 15/16/17), contact email. ~150-line boilerplate adapted to project
+  specifics.
+- **D-10:** **Terms of Service page at `/terms`** — early-access disclaimer,
+  no-warranty boilerplate, acceptable-use clause. ~100-line boilerplate.
+- **D-11:** **Per-user abuse limits** in service layer (Claude's discretion
+  on exact numbers — researcher proposes; planner locks):
+  - max active `games` per user (~50 default)
+  - max active `data_sources` per user (~20 default)
+  - max `events` created per user per day (~500 default)
+  - Implemented as service-layer guards throwing `AppError` 429 when
+    exceeded; counts query `WHERE deleted_at IS NULL`; soft-deleted rows
+    don't count.
+- **D-12:** **`/login` disclaimer** — visible copy: "Early access. Auto-import
+  from registered sources arrives in a future release; manual paste works
+  now." Prevents the "I added a YouTube channel and nothing happened"
+  confusion that would otherwise hit every new user pre-Phase-3.
+- **D-13:** **per-page `<meta name="robots" content="noindex,nofollow">`**
+  via SvelteKit `+layout.svelte` in auth-gated route groups. Public pages
+  (`/login`, future `/privacy`, `/terms`, future `/about`) inherit no
+  noindex by default. `robots.txt` stays empty / permissive — public
+  pages auto-indexable when they appear.
+
+### GDPR / Privacy compliance
+
+- **D-14:** **Contact email = `neotolis.games@gmail.com`** (project-specific
+  Gmail; user explicitly chose). Documented in: Privacy Policy contact
+  section, ToS, public-page footer, Google Cloud Console as OAuth client
+  owner email.
+- **D-15:** **Retention model documented + implemented:**
+  - `active`: stored as long as the user account is alive (no hard-coded
+    retention on active rows)
+  - `soft-deleted`: 60 days (existing `RETENTION_DAYS=60`); UI hides
+    `deleted_at IS NOT NULL`; restoration path exists for 60 days
+  - `purged`: hard-deleted by Phase 3 purge-worker after 60 days; this
+    phase ships the SQL contract but not the worker (the worker is Phase 3
+    plumbing — runs once Phase 3 lands; until then soft-deleted rows
+    accumulate, which is fine for personal scale)
+  - `backups`: R2 retention 30 days (Object Lock); a row deleted today
+    survives in backups for up to 30 days, then expires
+  - **Worst-case latency to physical disappearance: ~90 days** (60 active
+    + 30 backup). Documented in Privacy Policy verbatim.
+- **D-16:** **In-app account deletion + export — bring forward from Phase 6
+  PRIV-03/04 to Phase 2.2.** Open signup makes email-only GDPR runbook
+  awkward; in-app buttons are cleaner and Phase 6 was going to build them
+  anyway. Phase 2.2 ships baseline, Phase 6 polishes (CSV-per-table, full
+  export-restore, etc.).
+  - `GET /api/me/export` — SQL SELECT across all user-owned tables, run
+    through DTO projections (strips secrets per AGENTS.md invariant 5),
+    streams JSON response with `Content-Disposition: attachment;
+    filename="diary-export-YYYY-MM-DD.json"`. No file written to disk.
+  - `DELETE /api/me/account` — soft-delete user row, cascade soft-delete
+    games / events / data_sources / api_keys_steam, sign out all sessions,
+    audit-event `account.deleted`. Returns 200; user redirected to /login.
+  - `POST /api/me/account/restore` — within 60 days, un-set `deleted_at`
+    on user + cascade restore (only children whose `deleted_at ===
+    user.deleted_at`, matching the existing soft-cascade pattern from
+    Phase 2 D-23). Audit-event `account.restored`.
+  - `/settings/account` page hosts both buttons + 60-day-grace explainer
+    + (when `deleted_at IS NOT NULL` on session reconnect) a banner
+    "Account scheduled for deletion in N days. [Restore] [Permanently
+    delete now]"
+  - Confirm-dialog pattern reused from existing event-delete dialog
+    (Phase 2.1) — "Type DELETE to confirm"
+- **D-17:** **No email double-confirmation** for account deletion in
+  Phase 2.2. 60-day grace + Google-OAuth-verifies-email-on-file =
+  sufficient reasonable diligence. Email infrastructure (SMTP / Resend
+  free tier) deferred to Phase 3 (quota-alerts may want it) or Phase 6
+  (PRIV-04 polish). If real abuse cases surface, add then.
+
+### Auth (clarified — already locked in Phase 1, no new decisions)
+
+- **D-18:** **Better Auth = library inside the Node.js app**, not a separate
+  service. NO Keycloak / Authentik / Auth0 sidecar to deploy. The same
+  `src/lib/auth.ts` from Phase 1 handles OAuth flow, sessions in Postgres,
+  Google as IdP.
+- **D-19:** **Production OAuth client setup** — author creates real OAuth
+  2.0 Client ID in Google Cloud Console, sets Authorized Redirect URI to
+  `https://<prod-domain>/api/auth/callback/google`, places `OAUTH_CLIENT_ID`
+  + `OAUTH_CLIENT_SECRET` in prod `.env`. The existing `OAUTH_DISCOVERY_URL`
+  default (`https://accounts.google.com/.well-known/openid-configuration`)
+  picks up real Google automatically.
+- **D-20:** **Google OAuth verification submission** — Privacy Policy URL +
+  ToS URL + author email become the inputs for Google's OAuth verification
+  flow. Until Google verifies, users see "unverified app" warning (allowed
+  for <100 users; mandatory verification before broad public). Submission
+  is documented in the deploy runbook but completion is async (Google
+  takes 1-6 weeks); Phase 2.2 ships with unverified-app warning visible.
+
+### Deploy automation
+
+- **D-21:** **Build pipeline = GitHub Actions → public GHCR.** New CI job
+  `docker-build-publish` triggers on `push to master` after lint-typecheck
+  + unit-integration + smoke + browser-tests gates pass. Builds image,
+  tags with `git-sha` + `master` + `latest`, pushes to
+  `ghcr.io/d954mas/neotolis-diary:<tag>`. Image is **public** (matches
+  the OSS self-host story baked in since Phase 1). Self-host users
+  pull the same image the author runs in prod.
+- **D-22:** **Deploy trigger = manual `pnpm deploy` from local.** The
+  script SSHes to `root@aeza` (or whatever user), `cd /opt/diary`,
+  `docker compose pull && docker compose up -d`. NOT auto-deploy on push
+  (control over deploy moment + ability to catch broken master before
+  users see it for solo-developer reality). Author is comfortable with
+  this pattern from `game_idea_founder/deploy.sh`.
+- **D-23:** **Migrations = auto on boot** (already implemented Phase 1,
+  Plan 01-03). `runMigrations()` under advisory lock before any role
+  starts. `/readyz` only flips green after migrations apply. No manual
+  `pnpm db:migrate` step in deploy flow.
+- **D-24:** **Image tags include git-sha** (`ghcr.io/.../neotolis-diary:8967231`).
+  Rollback = `docker compose pull <previous-sha> && up -d` (~30s
+  downtime). Documented in deploy runbook.
+
+### Operational basics
+
+- **D-25:** **Backups = pg_dump cron + R2 push with write-only token +
+  30-day Object Lock** (immutability). Bucket `neotolis-diary-backups`,
+  retention via Object Lock prevents ransomware / compromised-root from
+  wiping backup history. Daily cron on VPS: `pg_dump -Fc | gzip | rclone
+  rcat r2:diary-backups/$(date +%Y-%m-%d).sql.gz`. R2 bucket lifecycle
+  rule expires objects >30 days. Two API tokens: write-only (lives on
+  VPS), admin (lives on author's local machine for monthly cleanup).
+  CF R2 free tier = 10GB storage + 1M class-A ops/month — well below the
+  ~1.5GB/month projected backup volume.
+- **D-26:** **Uptime monitoring = UptimeRobot free.** 5-minute ping on
+  `https://<domain>/healthz`, alerts via Telegram + email when 2 consecutive
+  checks fail. Free tier covers 50 monitors. Mandatory for open-signup
+  launch (502 → user gone forever).
+- **D-27:** **Logs = `docker logs` + `journalctl`** (Phase 2.2 baseline).
+  Pino → stdout already implemented (Phase 1). Docker daemon
+  `daemon.json` log-rotation: `max-size=10m, max-file=3`. Centralized
+  log search (Grafana Cloud Loki / BetterStack) deferred to Phase 6 or
+  later when traffic warrants.
+- **D-28:** **VPS hardening** (Claude's discretion on exact recipe;
+  researcher proposes, planner locks):
+  - SSH key-only auth (`PasswordAuthentication no`)
+  - UFW firewall: allow 22/SSH (rate-limited), 80, 443; deny everything else
+  - fail2ban with default SSH jail
+  - Non-root deploy user (`deploy` group) with `command="..."` SSH key
+    restriction limiting to the deploy script
+  - nginx basic rate-limit (10 req/sec per IP) on auth endpoints
+
+### Self-review compliance hooks (AGENTS.md)
+
+- **D-29:** **Constraints compliance** — Phase 2.2 introduces no new
+  `process.env` reads outside `src/lib/server/config/env.ts` (new env vars
+  added via the existing zod schema): R2 credentials, optional notification
+  webhook URL if used, etc.
+- **D-30:** **SaaS-leak grep extension** — the existing CI grep for
+  `analytics.neotolis` / `admin@neotolis` / `CF-Connecting-IP` outside
+  `proxy-trust` stays. Phase 2.2 must not introduce hard-coded
+  `neotolis.games@gmail.com` strings outside the privacy/ToS pages and
+  config (operator-configurable via `SUPPORT_EMAIL` env var so a self-host
+  operator overrides cleanly).
+- **D-31:** **Self-host parity preserved** — `docker-compose.selfhost.yml`
+  remains the published self-host file; `docker-compose.prod.yml` is an
+  internal author-instance variant that adds: env_file `.env` (vs literal
+  inline values), nginx service, `restart: unless-stopped`, log driver
+  config, R2-backup sidecar (or cron), and image-from-GHCR rather than
+  build-from-source. The smoke gate keeps using selfhost.yml as the
+  trust signal.
+- **D-32:** **`SUPPORT_EMAIL` env var added to `env.ts` zod schema** so
+  Privacy / ToS / footer reads it dynamically. Default: empty string with
+  a clear "self-host operator must configure" note in `.env.example`.
+  Author's prod sets `SUPPORT_EMAIL=neotolis.games@gmail.com`. Self-host
+  parity invariant preserved.
+
+### Claude's Discretion
+
+- Exact per-user quota numbers (D-11) — researcher proposes, planner locks.
+- nginx.conf shape (combine `game_idea_founder` pattern with HTTPS-aware
+  config + `TRUSTED_PROXY_CIDR` + per-endpoint rate limits).
+- VPS hardening recipe (D-28) — UFW rules, fail2ban jail, SSH key
+  restrictions, rate-limit values.
+- Domain choice (`.app` / `.dev` / `.me` / something project-themed).
+- `pnpm deploy` script shape (bash + ssh, possibly using `Justfile` or
+  similar).
+- Privacy/ToS exact wording (use a permissive-licensed template,
+  adapt to project specifics).
+- `daemon.json` log-rotation file location and ensure-on-boot mechanism.
+- Whether to ship a separate `/about` page in Phase 2.2 (probably yes,
+  thin — links to GitHub repo + brief explanation; defaults to indexable).
+
+### Folded Todos
+
+(none folded — the 22 pending todos are either Phase-2.1 polish already closed
+or out-of-scope for ship-to-prod. The cross-reference matched on phase keywords
+but content review confirmed no overlap with this phase's domain.)
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Project-level contracts
+- `AGENTS.md` — Privacy & multi-tenancy invariants (8 numbered, sections 1-8);
+  Practices section ("Atomic PRs", "Tests land with the feature",
+  "Migrations forward-only, run at boot", "One source of truth for env",
+  "Self-host parity is a CI gate", "No secrets in logs"); Validation
+  checklist (Constraints / Philosophy / Practices / CI gate honesty /
+  Documentation drift); Architecture section (data abstractions, three
+  views over events).
+- `.planning/PROJECT.md` — Constraints (auth = Google OAuth only; privacy;
+  envelope encryption; TLS 1.3 + HSTS; budget = free tier + small VPS;
+  hosting = aeza + Cloudflare Free + optional Tunnel; license = MIT).
+- `.planning/REQUIREMENTS.md` — DEPLOY-01..05 (Phase 6 owns DEPLOY-01..04;
+  DEPLOY-05 already shipped Phase 1); PRIV-01..04 (Phase 6 owns PRIV-03/04
+  but Phase 2.2 brings forward in-app deletion/export baseline);
+  AUTH-01..03 (Phase 1 shipped); QUOTA-01/02 (Phase 6).
+- `.planning/STATE.md` — Phase 02.2 inserted after Phase 02 (chronologically
+  after 02.1): "ship-to-prod (URGENT) — pre-Phase-3 deploy work so user
+  can dogfood the SaaS before polling pipeline lands".
+
+### Phase 1 (foundation) — already-shipped contracts to preserve
+- `src/lib/server/config/env.ts` — SOLE `process.env` reader (D-24);
+  Phase 2.2 extends the zod schema, never reads `process.env` from new code.
+- `src/lib/server/proxy-trust.ts` — trusted-proxy header walking (D-19/D-20
+  + CVE-2026-27700 mitigation); Phase 2.2 sets `TRUSTED_PROXY_CIDR` to
+  CF ranges; the module is already in place.
+- `src/lib/server/audit.ts` — INSERT-only audit log; Phase 2.2 audit-events:
+  `account.deleted`, `account.restored`, `account.exported`, `quota.limit_hit`.
+- `src/lib/server/services/errors.ts` — `NotFoundError` (cross-tenant 404
+  contract), new error code `account_deletion_pending` (returned on login
+  when `deleted_at IS NOT NULL` to drive the Restore banner UX).
+- `Dockerfile` — multi-stage build (deps / build / runtime) with non-root
+  UID 10001, HEALTHCHECK on `/readyz`, `ENTRYPOINT ["node", "build/server.js"]`
+  with APP_ROLE dispatch. Phase 2.2 reuses verbatim; the GH Actions job
+  builds this same Dockerfile.
+- `docker-compose.selfhost.yml` — three-service template (app/worker/scheduler
+  + Postgres). Phase 2.2 ships `docker-compose.prod.yml` as a variant
+  (image from GHCR, nginx, restart: unless-stopped, log driver, env_file,
+  optional R2-backup sidecar) WITHOUT modifying selfhost.yml — selfhost.yml
+  remains the smoke-gated trust signal.
+- `.github/workflows/ci.yml` — three jobs (lint-typecheck / unit-integration /
+  smoke / browser-tests). Phase 2.2 adds a fifth `docker-build-publish` job
+  conditioned on master push + all gates green; Phase 2.2 must not weaken
+  any existing assertion.
+
+### Phase 2 + 2.1 — soft-delete pattern + DTO contracts
+- `src/lib/server/services/games.ts` (and similar in `events.ts`,
+  `data-sources.ts`, `api-keys-steam.ts`) — soft-cascade transactional
+  pattern (Phase 2 Plan 02-04, D-23). Phase 2.2 account-deletion follows
+  the same pattern: capture `Date` once, apply to user + cascade to
+  user-owned children, restore reverses ONLY children whose `deleted_at
+  === user.deleted_at`.
+- `src/lib/server/dto.ts` — every entity has `to<Entity>Dto` projection
+  function. Phase 2.2 export endpoint MUST use these projections (AGENTS.md
+  invariant 5) — ciphertext columns never appear in export JSON. New
+  behavioural test in `tests/unit/dto.test.ts` asserts the export envelope
+  carries no `secret_ct` / `wrapped_dek` / `kek_version` / etc.
+- `tests/integration/anonymous-401.test.ts` — `MUST_BE_PROTECTED` allowlist;
+  Phase 2.2 adds the new `/api/me/export`, `DELETE /api/me/account`,
+  `POST /api/me/account/restore` routes to the allowlist (vacuous-pass
+  guard).
+- `tests/integration/tenant-scope.test.ts` — cross-tenant 404 matrix;
+  Phase 2.2 extends with: User A cannot DELETE User B's account;
+  User A's export does not contain User B's rows.
+
+### External docs (consulted at planning time)
+- Cloudflare published IP ranges: https://www.cloudflare.com/ips-v4/ and
+  https://www.cloudflare.com/ips-v6/ — sourced into `TRUSTED_PROXY_CIDR`
+  and refreshed quarterly per deploy runbook.
+- Cloudflare R2 docs (bucket creation, Object Lock, API tokens):
+  https://developers.cloudflare.com/r2/
+- UptimeRobot API + Telegram notification setup:
+  https://uptimerobot.com/api/
+- GDPR Article 15 (Right of Access), Article 17 (Right to Erasure),
+  Article 20 (Right to Data Portability) — referenced in Privacy Policy
+  template adaptation.
+- Google Cloud OAuth verification process:
+  https://support.google.com/cloud/answer/13463073
+- `C:\projects\game_idea_founder\` — author's prior aeza-deploy pattern;
+  reference for `deploy.sh` structure, nginx.conf, docker-compose.prod
+  shape. Diary upgrades the pattern to add HTTPS via CF, image-from-registry
+  rather than build-on-server, and migration-on-boot.
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+
+- **`src/lib/server/config/env.ts`** — extend the zod schema with new env vars:
+  `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`,
+  `R2_BUCKET_BACKUPS`, `SUPPORT_EMAIL`, `LIMIT_GAMES_PER_USER`,
+  `LIMIT_SOURCES_PER_USER`, `LIMIT_EVENTS_PER_DAY`. All optional with
+  documented defaults so self-host operators inherit sensible values.
+- **`src/lib/server/proxy-trust.ts`** — already supports `CF-Connecting-IP`;
+  Phase 2.2 sets `TRUSTED_PROXY_CIDR` to CF ranges in prod `.env`.
+- **`src/lib/server/audit.ts`** — `writeAudit` for `account.deleted`,
+  `account.restored`, `account.exported`. Audit_action enum extends
+  (forward-only migration `0007_add_account_audit_actions`).
+- **`src/lib/server/services/<entity>.ts`** soft-cascade pattern — clone for
+  `account.ts` service: `softDeleteAccount(userId)` captures `Date`, marks
+  `user.deleted_at = d` + cascade to all 5+ user-owned tables, returns the
+  captured timestamp. `restoreAccount(userId, deletedAt)` reverses
+  children whose `deleted_at === deletedAt`.
+- **`src/lib/server/dto.ts`** — every projection function is the runtime
+  barrier; export endpoint composes `toUserDto + toGameDto[] +
+  toDataSourceDto[] + toEventDto[] + toAuditEntryDto[] + toApiKeySteamDto[]`
+  into the final JSON envelope.
+- **`tests/integration/anonymous-401.test.ts` `MUST_BE_PROTECTED`** —
+  3 new routes added: `/api/me/export`, `DELETE /api/me/account`,
+  `POST /api/me/account/restore`.
+- **Existing confirm-dialog component** (Phase 2.1, used for event delete) —
+  reuse for account-delete with "Type DELETE" pattern.
+- **`Dockerfile` + `docker-compose.selfhost.yml`** — image and base topology
+  stay verbatim; new `docker-compose.prod.yml` extends with nginx/env_file/
+  restart-policy/log-driver/optional-backup-sidecar.
+
+### Established Patterns
+
+- **AGENTS.md Privacy & multi-tenancy invariants 1-8** (cross-tenant 404,
+  service-layer userId-first scoping, INSERT-only audit, DTO projection
+  strips secrets, redact paths, no-public-pages, self-host parity) — every
+  Phase 2.2 endpoint passes these through unmodified.
+- **Forward-only migrations** (no downs) under advisory lock, run on boot.
+- **Squash-merge PR-only on master** (`delete_branch_on_merge: true`).
+- **Conventional Commits** (`feat(02.2): ...`, `docs(02.2): ...`).
+- **Phase-prefixed plan numbering** (`02.2-NN-PLAN.md`).
+- **Wave 0 placeholder tests** (every later task ships into a test that
+  already exists per Phase 1 D-41 / Phase 2 Plan 02-01 pattern).
+- **`PUTOFFS / DEFERRALS` comments** carry the plan number that closes them.
+
+### Integration Points
+
+- New SvelteKit routes: `/privacy`, `/terms`, `/about` (optional thin),
+  `/settings/account` (extends existing `/settings`).
+- New Hono sub-router: `/api/me/account/*` (alongside existing `/api/me`).
+- New CI job in `.github/workflows/ci.yml`: `docker-build-publish`
+  conditioned on `if: github.ref == 'refs/heads/master' && success()`,
+  needs `[lint-typecheck, unit-integration, smoke, browser-tests]`.
+- New service file: `src/lib/server/services/account.ts`
+  (softDeleteAccount, restoreAccount, exportAccountJson).
+- Extended deploy artifacts in repo root: `docker-compose.prod.yml`,
+  `nginx.conf` (prod variant), `scripts/deploy.sh` or `pnpm deploy` task,
+  `scripts/backup.sh` (pg_dump → rclone → R2), `.env.example` with new
+  variables documented.
+- New Drizzle migration `0007_add_account_audit_actions` adding
+  `account.deleted` / `account.restored` / `account.exported` /
+  `quota.limit_hit` to audit_action enum.
+- Existing `src/lib/server/db/schema/user.ts` already has `deleted_at`
+  (Better Auth schema is hand-authored per Phase 1 Plan 01-03; verify
+  during planning). If not present, the migration adds it.
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- **Author's prior pattern reference**: `C:\projects\game_idea_founder\` for
+  deploy.sh / nginx.conf / docker-compose.prod.yml shape. Diary's
+  Phase 2.2 deploy upgrades the pattern (add HTTPS via CF, image-from-GHCR
+  rather than build-on-server, migration-on-boot, R2 backups), but the
+  rsync-replaced-by-`docker compose pull` flow + ssh-based trigger
+  remains analogous.
+- **Author's CF account already exists** — domain registration via CF
+  Registrar is the path of least friction.
+- **Russian-speaking author** preference for technical conversations:
+  Phase 2.2 plans / VALIDATION human-verify steps presented in Russian
+  step-by-step (consistent with prior phases — see USER memory file).
+- **Open-signup awareness**: author understands the cost (Privacy/ToS/
+  abuse-limits/admin-runbooks) and explicitly chose to pay it for "real
+  SaaS from day one". Researcher / planner should not relitigate this
+  decision; instead, design for the smallest credible compliance surface.
+- **Email infrastructure deferred** until Phase 3 (quota alerts) or
+  Phase 6 (PRIV-04 polish). Phase 2.2 must not introduce any SMTP
+  client / Resend SDK / nodemailer dependency. Better Auth's optional
+  email-verification / password-reset flows stay disabled (Google OAuth
+  is the only auth method).
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+(Captured during Phase 2.2 discussion; route to future phases or backlog.)
+
+### Phase 6 territory (do not pull forward without explicit gating)
+- **OSS-ready self-host README** for arbitrary self-hosters (DEPLOY-01..04
+  per REQUIREMENTS.md): nginx / Caddy / Cloudflare Tunnel coverage matrix,
+  per-IdP swap docs, full env.example walkthrough.
+- **KEK-rotation runbook rehearsal** against staging dataset (DEPLOY-04
+  / PITFALLS P20).
+- **`THIRD_PARTY_LICENSES.md` generation from `npm ls --prod`** + AGPL-3.0
+  CI gate.
+- **Quota dashboard UI** (QUOTA-01 / 02) — surface YouTube / Reddit / Steam
+  quota remaining per-user.
+- **Account deletion / export polish** — CSV-per-table export in addition
+  to JSON; restore-from-backup flow; the soft-deleted "scheduled for
+  deletion" banner gets full per-entity restoration UX.
+- **Email double-confirmation for account deletion** (Phase 2.2 ships
+  60-day-grace-only; Phase 6 may add SMTP-based email-confirm if abuse
+  cases arise).
+
+### Milestone v1.1 territory
+- **File uploads infrastructure** (game icons, screenshots) — todo
+  `2026-04-30-files-and-uploads-infrastructure.md`. Requires its own
+  S3 abstraction, separate R2 bucket (`diary-uploads` distinct from
+  `diary-backups`), MinIO local dev, sharp for image processing. NOT
+  in Phase 2.2.
+
+### Phase 3 alongside polling
+- **Email infrastructure** (transactional SMTP / Resend free tier /
+  nodemailer) — Phase 3 quota-alerts may want email notifications when
+  YouTube quota hits 80% threshold. Phase 2.2 does NOT introduce any
+  email client; if Phase 3 needs it, add then.
+- **Purge worker for soft-deleted rows** (60-day RETENTION_DAYS sweep) —
+  Phase 3 purge worker handles user-account-level deletion alongside
+  per-entity sweeps.
+
+### Operational polish (later, when traffic warrants)
+- **Centralized log search**: Grafana Cloud free tier + promtail-sidecar
+  in compose, or BetterStack free, or Loki self-hosted. Phase 2.2 stays
+  on `docker logs` + `journalctl`.
+- **Prometheus + Grafana dashboards** — CPU / RAM / req-per-sec / DB
+  query latency. Phase 6+ when scale demands.
+- **Automated production smoke test** — CI smoke gate already runs
+  the same image; Phase 2.2 manual smoke after deploy is sufficient.
+- **Auto-deploy on push-to-master** — currently manual. Add a
+  `gh workflow run` trigger or auto-deploy job in CI later if comfort
+  with CI gate is high.
+
+### Reviewed Todos (not folded)
+- `2026-04-28-redirect-dashboard-to-games.md` — already addressed in
+  Phase 2.1 (root redirects to `/feed`).
+- `2026-04-30-files-and-uploads-infrastructure.md` — milestone v1.1, not
+  Phase 2.2.
+- 22 other pending todos — Phase 2.1 polish already closed by round-6
+  iterations, OR UI items unrelated to ship-to-prod scope.
+
+</deferred>
+
+---
+
+*Phase: 02.2-ship-to-prod*
+*Context gathered: 2026-05-01*

--- a/.planning/phases/02.2-ship-to-prod/02.2-CONTEXT.md
+++ b/.planning/phases/02.2-ship-to-prod/02.2-CONTEXT.md
@@ -171,6 +171,42 @@ THIRD_PARTY_LICENSES generation, dashboards).
   (control over deploy moment + ability to catch broken master before
   users see it for solo-developer reality). Author is comfortable with
   this pattern from `game_idea_founder/deploy.sh`.
+
+- **D-22a:** **Auto-recovery on VPS reboot is mandatory and explicit.**
+  After an unexpected VPS reboot (host hardware failure, aeza maintenance,
+  power loss), the entire stack — app, worker, scheduler, postgres,
+  AND the backup cron — must come back **without any human action**.
+  Concrete requirements:
+  - `restart: unless-stopped` on EVERY service in
+    `docker-compose.prod.yml` (postgres, app, worker, scheduler, nginx).
+    Selfhost.yml currently has no `restart:` directive — prod variant
+    adds it. `unless-stopped` chosen over `always` so a deliberate
+    `docker compose stop` survives a host reboot (operator intent
+    preserved).
+  - `systemctl enable docker` + `systemctl enable cron` documented as
+    one-time install-runbook steps. Default on Ubuntu 24.04 / Debian 12,
+    but explicit verification is in the runbook checklist (`systemctl
+    is-enabled docker` + `is-enabled cron`).
+  - Postgres data on **named volume** `pg_data` (already in selfhost.yml),
+    NOT a bind mount. Named volumes survive `docker compose down`
+    (without `-v`) and host reboots. Bind mounts to host paths would
+    couple to host filesystem layout — avoided.
+  - Migrations are idempotent (D-23, advisory-lock + drizzle-kit's
+    `__drizzle_migrations` tracking) — running `runMigrations()` after
+    every reboot is safe.
+  - pg-boss queue state lives in Postgres (Phase 1 D-15) — workers
+    recover in-flight jobs from durable queue state on restart, no
+    work is lost.
+  - flock state is in-memory (`/var/lock/diary-backup.lock` is a 0-byte
+    sentinel; lock release is automatic when process dies, including
+    via reboot) — first cron after reboot proceeds normally.
+  - Verification step in deploy runbook: simulate reboot via
+    `sudo reboot`, confirm everything comes back within 60 seconds
+    (UptimeRobot will paint the timeline).
+  - Failure modes documented in runbook: VPS deletion → restore from
+    R2 + git clone (~30 min); CF outage → no VPS action needed; deploy
+    interrupted → re-run `pnpm deploy`; data corruption → restore from
+    R2 backup via admin-token (~15 min manual procedure).
 - **D-23:** **Migrations = auto on boot** (already implemented Phase 1,
   Plan 01-03). `runMigrations()` under advisory lock before any role
   starts. `/readyz` only flips green after migrations apply. No manual

--- a/.planning/phases/02.2-ship-to-prod/02.2-DISCUSSION-LOG.md
+++ b/.planning/phases/02.2-ship-to-prod/02.2-DISCUSSION-LOG.md
@@ -1,0 +1,287 @@
+# Phase 02.2: ship-to-prod — Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-05-01
+**Phase:** 02.2-ship-to-prod
+**Areas discussed:** Hosting + TLS + Postgres, Tenancy at launch, Deploy automation, Backups + monitoring + logs, GDPR / Privacy compliance (deep-dive)
+
+**Language:** Russian (per user request "на русском" at gray-area-selection step; consistent with USER memory `feedback_uat_walkthrough.md`).
+
+---
+
+## Gray Areas Selected
+
+User selected ALL FOUR offered areas plus added a Russian-language preference.
+
+| Area | Description | Selected |
+|---|---|---|
+| Hosting + TLS + Postgres | VPS + DB + TLS strategy + domain | ✓ |
+| Tenancy at launch | Open signup vs allowlist vs invite | ✓ |
+| Deploy automation | Build + trigger + image registry | ✓ |
+| Backups + monitoring + logs | pg_dump + uptime + log destination | ✓ |
+
+---
+
+## Area 1: Hosting + TLS + Postgres
+
+### Q1.1: Где разворачиваем VPS?
+
+| Option | Description | Selected |
+|---|---|---|
+| aeza | Per PROJECT.md "Hosting" constraint; user has aeza account | ✓ |
+| Hetzner CX22 | EU jurisdiction, €4.5/mo, card/PayPal payment | |
+| User has VPS already | Reuse existing infrastructure | |
+
+**User's choice:** aeza
+**Notes:** Confirmed with prior `game_idea_founder` deployment pattern at root@aeza:/opt/gif.
+
+### Q1.2: Где Postgres?
+
+| Option | Description | Selected |
+|---|---|---|
+| Same VPS via docker-compose | Already in docker-compose.selfhost.yml; matches indie-budget | ✓ |
+| Neon free tier | Managed but pg-boss connection issues + auto-suspend | |
+| Supabase free tier | PgBouncer breaks pg-boss prepared statements | |
+
+**User's choice:** Same VPS via docker-compose
+
+### Q1.3: TLS strategy?
+
+| Option | Description | Selected |
+|---|---|---|
+| CF proxy (orange cloud) + nginx | Variant A — matches game_idea_founder + free TLS from CF | ✓ |
+| Caddy без CF | Variant B — single component, IP visible | |
+| CF Tunnel (origin hidden) | Variant C — max security, +20min setup | |
+
+**User's choice:** CF proxy + nginx (Variant A)
+**Notes:** User initially asked "не понимаю, объясни" — provided detailed explanation of three TLS options with their game_idea_founder context. User's response "Так я же делаю хостинг на cf, насколько я помню сертификат они тоже дают" confirmed CF proxy was intuitively the choice. User also asked clarification "Не понял а вот туннель, он мне нужен?" — explained tunnel is overkill for personal-instance with static-IP VPS where DDoS risk is low; CF proxy already provides DDoS protection.
+
+### Q1.4: Domain?
+
+| Option | Description | Selected |
+|---|---|---|
+| Existing domain | Use what user has | |
+| Register new via CF Registrar | At-cost pricing, CF account already owned | ✓ |
+| Subdomain of existing | No registration, but awkward at OSS-release | |
+
+**User's choice:** Register new via CF Registrar
+
+### Q1.5: CF account?
+
+| Option | Description | Selected |
+|---|---|---|
+| Yes, have CF account | Use for new domain + DNS zone | ✓ |
+| Need to register | 5 minutes, free | |
+| Register elsewhere | Move NS to CF later | |
+
+**User's choice:** Yes, have CF account
+
+---
+
+## Area 2: Tenancy at launch
+
+### Q2.1: Кто сможет залогиниться на старте?
+
+| Option | Description | Selected |
+|---|---|---|
+| Email allowlist (only you) | Safest; ALLOWED_EMAILS env; flip to open later | |
+| Open signup | Real SaaS day one; needs Privacy/ToS/abuse-limits | ✓ (initially) |
+| Invite codes | Middle path; controlled access via codes | |
+
+**User's initial choice:** Open signup
+**Follow-up:** After Claude explained the cost (Privacy/ToS mandatory for Google OAuth, abuse limits required, GDPR deletion-by-hand, "early access" disclaimer), user reconfirmed: **"Да, открытый старт (включая Privacy/ToS/limits)"**.
+
+### Q2.2: robots.txt + noindex?
+
+| Option | Description | Selected |
+|---|---|---|
+| robots.txt: Disallow / + meta noindex | Private-tool default | ✓ (refined) |
+| Open to Google | Landing visible | |
+
+**User's question:** "так, а сейчас же нет публичных страниц? вообще позже будет какой-то about, и news. публичные страницы"
+**Discussion:** Refined to: per-page `<meta name="robots" content="noindex,nofollow">` via SvelteKit auth-gated layout (cleaner pattern — public pages auto-indexable). robots.txt stays empty / permissive.
+**Final decision:** per-page meta noindex + permissive robots.txt.
+
+### Q2.3: Reconfirm open signup with full cost?
+
+| Option | Description | Selected |
+|---|---|---|
+| Yes, open with Privacy/ToS/limits | +3-5 dop. plans, real SaaS | ✓ |
+| Invite codes now, open in Phase 6 | Smaller Phase 2.2 | |
+| Email allowlist (only you) | Smallest scope | |
+
+**User's choice:** Open signup with full Privacy/ToS/limits.
+
+---
+
+## Area 3: Deploy automation
+
+### Q3.1: Где собираем Docker-образ?
+
+| Option | Description | Selected |
+|---|---|---|
+| На сервере (как в game_idea_founder) | rsync + docker compose up --build; familiar | |
+| GH Actions → GHCR → docker compose pull | Fast, audited, free | ✓ |
+| Local docker save → ssh | Bypass everything | |
+
+**User's question:** "почему ты рекомендуешь брать готовый, а не собирать?"
+**Discussion:** Explained six reasons (RAM on aeza VPS / speed / CI gate / audit trail / reproducibility / self-host parity).
+**User's follow-up:** "правильно ли я понял. Github собирает готовый образ? я или другой разработчик может просто скачать образ и запустить где захочет? локально или на сервере? все нужные ключи лежат на сервере и в гите их не видно?"
+**Discussion:** Confirmed all three: yes GH Actions builds; yes anyone can pull the public GHCR image (this IS the OSS self-host story); yes secrets live in `.env` on the VPS, never in repo. Explained code/image/secrets separation table.
+**Final decision:** GH Actions → public GHCR with git-sha tag.
+
+### Q3.2: Как запускается deploy?
+
+| Option | Description | Selected |
+|---|---|---|
+| Manual `pnpm deploy` from local | Control over moment, matches game_idea_founder | ✓ |
+| Auto-deploy on push to master | Nothing to forget; less control | |
+| Watchtower auto-pull | Zero touch, unpredictable timing | |
+
+**User's question:** "давай обсудим, есть ли минусы чтобы гитхаб сам собирал и заливал, насколько это безопасно?"
+**Discussion:** Walked through 6 attack vectors (GH Actions credential theft, fork PR secrets, broken master in prod, npm dep compromise, account theft, GH outage) with mitigations for each. Concluded auto-deploy is safer than build-on-server but introduces less control over deploy moment.
+**Final decision:** GH Actions builds + manual `pnpm deploy` trigger.
+
+### Q3.3: Миграции БД?
+
+| Option | Description | Selected |
+|---|---|---|
+| Auto on boot (already implemented) | runMigrations under advisory lock | ✓ |
+| Manual `pnpm db:migrate` before boot | Control point | |
+
+**User's choice:** Auto on boot.
+
+---
+
+## Area 4: Backups + monitoring + logs
+
+### Q4.1: Backup destination?
+
+| Option | Description | Selected |
+|---|---|---|
+| pg_dump cron → R2 | Offsite, 10GB free | ✓ (refined) |
+| Local-only volumes | Lost if VPS dies | |
+| Other S3 (B2 / Wasabi) | Alternative if not CF | |
+
+**User's question:** "Так смотри. Я уже буду хранить файлы в s3 верно? (для иконок и тд). Еще у меня будет другой бакет для бекапов верно? насколько это надежно? сервер только сохраняет туда не может удалить?"
+**Discussion:** Clarified that file uploads (icons/screenshots) are deferred to milestone v1.1 — Phase 2.2 only needs backup bucket. Explained R2 reliability (3+ data centers), free tier (10GB / 1M ops), write-only token + Object Lock for immutability. User asked specifically about "server can save but not delete" — explained two-token pattern (write-only on VPS + admin local) + Object Lock 30-day retention prevents ransomware / compromised-root from wiping backup history.
+**Final decision:** R2 + write-only token + 30-day Object Lock.
+
+### Q4.2: Uptime monitoring?
+
+| Option | Description | Selected |
+|---|---|---|
+| UptimeRobot free | 5-min ping + Telegram alert | ✓ |
+| CF Health Checks | Pro+ only ($20/mo) | |
+| No monitoring | OK for personal, bad for open-signup | |
+
+**User's question:** "Что это? еще один сервис? он мне отправляет ошибки если что-то упало?"
+**Discussion:** Explained UptimeRobot is a free third-party service that pings /healthz every 5 min and emails/Telegrams alerts. Mandatory for open signup.
+**Final decision:** UptimeRobot free + Telegram alerts.
+
+### Q4.3: Logs destination?
+
+| Option | Description | Selected |
+|---|---|---|
+| docker logs + journalctl | Baseline, lost on restart >30MB | ✓ |
+| Grafana Cloud + Promtail | Search history, dashboards | (deferred) |
+| BetterStack free | Logs + uptime + status page | |
+
+**User's question:** "Так давай начнем просто с докер логов. Графана это что? это еще один сервис, где я могу смотреть статус по сервису и логи? Мне наверное будет потом нужен дашборд какой-то чтобы смотреть нагрузку и тд?"
+**Discussion:** Confirmed docker logs is correct for Phase 2.2. Explained Grafana = web dashboards + log search + alerts; Phase 2.2 doesn't need it; defer to Phase 6 or later when scale warrants.
+**Final decision:** docker logs + journalctl baseline; Grafana / centralized logs deferred.
+
+### Q4.4: POSTGRES_PASSWORD?
+
+| Option | Description | Selected |
+|---|---|---|
+| Generate via openssl, store in .env | Basic hygiene | ✓ |
+| Keep postgres/postgres default | Internal docker-network only | |
+
+**User's choice:** Generate and store in .env.
+
+---
+
+## GDPR Deep-Dive (added during discussion)
+
+User asked four follow-up questions about GDPR / authorization that warranted separate exploration.
+
+### Q5.1: "Про авторизацию я не совсем понял. Мой сервер обращается к сервису авторизации? его я поднимаю отдельно из готового?"
+
+**Explanation:** Better Auth is a library inside the Node.js app, NOT a separate service. Google OAuth is Google's own service (no deploy). Walked through the 4-step OAuth flow: app generates state token → redirect browser to accounts.google.com → Google redirects back with code → app exchanges code for tokens server-to-server → app creates session in own Postgres. Self-host operators may override `OAUTH_DISCOVERY_URL` to point at Keycloak/Authentik but that's optional — default is Google for both SaaS and self-host.
+
+### Q5.2: "Вот я про гугл не понимаю. Оно же может работать локально и через гугл? получается есть 2 версии"
+
+**Explanation:** ONE codebase, configured differently via env. Local dev / CI tests use `oauth2-mock-server` (configured via `OAUTH_DISCOVERY_URL=http://localhost:9090/...`). Production uses real Google (default `OAUTH_DISCOVERY_URL=https://accounts.google.com/...`). Both go through the same Better Auth code path; only the authority URL differs.
+
+### Q5.3: "Вот про gdpr давай подробнее. Как это работает? через настройки пользователь может попросить все его данные? и я обязан их скинуть? И так-же пользователь может попросить удалить все его данные?"
+
+**Explanation:** GDPR Articles 15 (access), 17 (erasure), 20 (portability) require:
+- Provide data export within 30 days of request
+- Delete data within 30 days of request (with verification)
+- Allow corrections through normal UI
+
+Phase 2.2 minimum: Privacy Policy on /privacy, ToS on /terms, contact email, manual SQL runbook for export/delete (or in-app buttons).
+
+### Q5.4: "Пользователь пишет тебе на email? так а насколько это надежно, можно ли доверять почте?"
+
+**Explanation:** Email is acceptable for GDPR if combined with reasonable identity verification. Industry-standard pattern: user emails request → app does SQL lookup by email → sends confirmation to email-on-file (NOT sender) → user replies YES from real account email → app acts. This protects against sender-spoofing and resolves Article 12(6) "additional information necessary to confirm identity".
+
+### Q5.5: "Так а вот если я могу сделать это кнопкой, то нужно ли через email?"
+
+**Decision branch:** User pushed back on email-based GDPR. Discussion concluded that in-app buttons are strictly better when scope allows — identity verified by-construction (user is logged in), no manual work for operator, faster for user, Phase 6 was going to build them anyway. User chose in-app buttons.
+
+### Q5.6: Account deletion + export — buttons or email?
+
+| Option | Description | Selected |
+|---|---|---|
+| In-app buttons + email fallback | Pull forward Phase 6 PRIV-03/04 | ✓ |
+| Email-only + admin runbook | Minimum | |
+| Email in 2.2, buttons in Phase 6 | Same as #2 different label | |
+
+**User's choice:** In-app buttons.
+
+### Q5.7: "Вот про данные, мы же храним их всегда? 60 дней мы храним удаленные данные? И вот про почту используем вот neotolis.games@gmail.com И это простая и понятная задача, нужная для privacy?"
+
+**Explanation:** Walked through three retention levels (active / soft-deleted 60 days / purged) + backups (30 days). Confirmed contact email = `neotolis.games@gmail.com`. Answered "yes, this is a concrete task" — listed 5 deliverables (Privacy page, ToS page, contact email everywhere, in-app export/delete buttons OR runbook, retention text in Privacy).
+
+### Q5.8: "Так а пользователь может восстановить себя, если передумал? и может удаление все таки сделать с двойным подтверждением через почту? получить данные ок, и как мы отдаем данные? просто готовим файл?"
+
+**Explanation:**
+1. **Restore flow:** soft-delete on click → 60-day grace → login banner with [Restore] button → un-set deleted_at + cascade restore. Standard pattern (Discord/GitHub/Apple).
+2. **Email double-confirm:** belt-and-suspenders; requires SMTP infrastructure (Resend/Mailgun) which adds +1 plan to Phase 2.2. With 60-day grace + Google-OAuth-verifies-email, redundant. Defer email infra to Phase 3 (quota alerts) or Phase 6 polish.
+3. **Export delivery:** HTTP response with `Content-Disposition: attachment` header — browser downloads JSON file. No file written to disk on server.
+
+### Q5.9: Email double-confirm in Phase 2.2?
+
+| Option | Description | Selected |
+|---|---|---|
+| No — confirm dialog + 60-day grace + Restore | Sufficient reasonable diligence | ✓ |
+| Yes — +SMTP infra + email confirm | Belt and suspenders | |
+
+**User's choice:** No email double-confirm. Email infra deferred.
+
+---
+
+## Closing
+
+**Date completed:** 2026-05-01
+**Total questions asked:** ~25 across 5 areas (Hosting/Tenancy/Deploy/Ops/GDPR)
+**Style:** Conversational, Russian, with several user clarifying questions answered with extended technical explanations (TLS topology, GH Actions security, GDPR mechanics, retention model). User demonstrated active engagement — pushing back on email-based GDPR, asking why-prebuilt-image, asking about Cloudflare Tunnel necessity. Each pushback led to a better decision.
+
+## Claude's Discretion (areas where user said "you decide" or deferred)
+
+- Exact per-user quota numbers (max games / sources / events-per-day)
+- nginx.conf shape (HTTPS-aware variant of game_idea_founder pattern)
+- VPS hardening recipe (UFW + fail2ban + SSH restrictions + rate-limits)
+- Domain choice (.app / .dev / .me — researcher proposes available options)
+- `pnpm deploy` script shape (bash + ssh details)
+- Privacy/ToS exact wording (template-based, project-adapted)
+- Whether to ship a thin `/about` page in Phase 2.2
+
+## Deferred Ideas
+
+(captured in CONTEXT.md `<deferred>` section — Phase 6 territory, milestone
+v1.1 territory, Phase 3 alongside polling, operational polish later)


### PR DESCRIPTION
## Summary

- Captures Phase 02.2 ship-to-prod context after a deep `discuss-phase` pass: 32 numbered decisions across hosting/tenancy/auth/deploy/ops/GDPR.
- Phase 02.2 is the deploy-canonical-instance phase (between 2.1 and 3): ship the Phase 2.1 codebase to author's aeza VPS so he can dogfood while Phase 3 polling is being built. Open signup from day one therefore brings forward Privacy / ToS / abuse-limits / in-app GDPR controls (account export + delete pulled from Phase 6 PRIV-03/04 baseline).
- Adds `.claude/` and `*.stackdump` to `.gitignore` (Claude Code runtime state + Windows bash crash dumps — surfaced as untracked while doing this PR).

## Test plan

- [x] `02.2-CONTEXT.md` renders cleanly with all sections (`<domain>`, `<decisions>`, `<canonical_refs>`, `<code_context>`, `<specifics>`, `<deferred>`)
- [x] `02.2-DISCUSSION-LOG.md` preserves Q&A audit trail (no decision content drift vs CONTEXT.md)
- [x] No code changes outside `.gitignore` and `.planning/phases/02.2-ship-to-prod/*` — pure docs PR
- [x] CI gates remain unchanged (no new ESLint rules, no migrations, no new routes)
- [x] `git status` clean after `.gitignore` update — `.claude/` and `bash.exe.stackdump` (now gone) no longer surface

## Self-review

- **Constraints:** ✓ no new env reads, no new at-rest secrets, no SaaS/self-host divergence (CONTEXT D-31 + D-32 explicitly preserve self-host parity invariant — `docker-compose.selfhost.yml` stays untouched as smoke-gate trust signal; new `docker-compose.prod.yml` is the author-instance variant)
- **Philosophy:** ✓ simplicity (docs only, no abstraction), SaaS/self-host parity (CONTEXT D-31), modularity (each new endpoint is a clean addition), no premature abstraction (per-user limits are simple service-layer guards), security-as-floor (every Phase 1+2.1 invariant carried forward)
- **Practices:** ✓ atomic (two atomic commits — docs + gitignore), tests-with-feature (deferred to next PRs), forward-only migrations (D-23), env-discipline (D-29), self-host parity (D-31), no secrets in logs (already enforced), comments only WHY (CONTEXT comments explain rationale, not what), Conventional Commits, versions pinned (no new deps)
- **CI gate honesty:** ✓ no test softening; this is a docs-only PR
- **Documentation drift:** ✓ no drift — this PR ESTABLISHES the docs that the code will be checked against in subsequent PRs

## Self-review (second pass)

This is a docs-only PR with no code changes; second-pass code review surface is minimal. The substantive risks are in the *next* PRs (RESEARCH / PLAN / implementation) where decisions captured here will be relitigated against the actual codebase. Notable items for downstream agents to challenge:

- D-11 per-user quota numbers are placeholders (Claude's discretion) — researcher should benchmark against indie-scale realistic counts before locking
- D-25 R2 write-only token + Object Lock is a strong claim — researcher should verify the specific R2 API token scope (`Object:Write` without `Object:Delete`) actually exists and document in deploy runbook
- D-16 brings forward Phase 6 PRIV-03/04 work; planner should confirm scope creep is acceptable vs. just shipping email-runbook in 2.2 and the full UI in 6
- D-20 Google OAuth verification submission timing — Phase 2.2 ships with unverified-app warning visible (acceptable per Google's <100-user policy); Phase 6 submits for full verification

Refs #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)