### PR TITLE
fix(03.0.1): backfill-channel writes youtube_videos cache

### DIFF
--- a/src/lib/sources/youtube/server/handlers/backfill-channel.ts
+++ b/src/lib/sources/youtube/server/handlers/backfill-channel.ts
@@ -42,6 +42,7 @@ import { and, eq, isNotNull, isNull, sql, inArray } from "drizzle-orm";
 import { db } from "$lib/server/db/client.js";
 import { dataSources } from "$lib/server/db/schema/data-sources.js";
 import { events } from "$lib/server/db/schema/events.js";
+import { youtubeVideos as youtubeVideosTable } from "../schema/index.js";
 import { logger } from "$lib/server/logger.js";
 import { writeAuditStrict } from "$lib/server/audit.js";
 import { markSourceNeedsReconnect } from "$lib/server/services/data-sources.js";
@@ -289,7 +290,46 @@ export async function handleBackfillChannel(job: BackfillChannelJob): Promise<vo
     }
   }
 
-  // 8. Fan-out INSERT loop. Per (event × subscriber):
+  // 8. youtube_videos cache UPSERT for every fetched event. Phase 03.0.1
+  //    Wave 4 (post-UAT 2026-05-10) — without this the channel-scoped
+  //    polling path INSERTed events but left youtube_videos cache empty
+  //    for those video_ids. PollingBadge tier resolver reads
+  //    youtube_videos.publishedAt; missing → tier=pending → "Pending ·
+  //    fetching video info…" badge with no stats forever (until manual
+  //    refresh-poll click hit the user). channel-context-backfill DOES
+  //    write the cache, but that path runs only at onSourceCreated for
+  //    a single backfill window — it doesn't re-fire for cron walks or
+  //    refresh-content clicks that walk past the original window.
+  //
+  //    UPSERT on video_id PK — public-data, no userId scope. Only writes
+  //    snippet fields we have from pollContent (title, publishedAt,
+  //    channelId). Stats land separately via active/cold poll workers
+  //    (which read this row to compute tier).
+  for (const ev of pollResult.events) {
+    if (!ev.externalId) continue;
+    const evChannelId =
+      typeof ev.metadata?.channelId === "string" ? ev.metadata.channelId : channelKey;
+    await db
+      .insert(youtubeVideosTable)
+      .values({
+        videoId: ev.externalId,
+        title: ev.title,
+        channelId: evChannelId,
+        publishedAt: ev.occurredAt,
+        fetchedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: youtubeVideosTable.videoId,
+        set: {
+          title: ev.title,
+          channelId: evChannelId,
+          publishedAt: ev.occurredAt,
+          updatedAt: new Date(),
+        },
+      });
+  }
+
+  // 9. Fan-out INSERT loop. Per (event × subscriber):
   //    - skip if event.publishedAt < subscriber.target_since
   //    - skip if auto_passive flow AND subscriber.auto_import == false
   //      (cron passive cache hydration only — but we don't hydrate cache

--- a/tests/integration/end-to-end-catch-up.test.ts
+++ b/tests/integration/end-to-end-catch-up.test.ts
@@ -201,6 +201,39 @@ describe("end-to-end channel-scoped catch-up flow", () => {
     const titles = eventRows.map((r) => r.title).sort();
     expect(titles).toEqual(["A", "B", "C"]);
 
+    // Phase 03.0.1 Wave 4 (post-UAT prod hotfix) — backfill-channel
+    // populates youtube_videos cache for every fetched event. Pre-fix
+    // the channel-scoped polling path INSERTed events but left the cache
+    // empty, so PollingBadge tier resolution returned 'pending' and
+    // poll-active/poll-cold cron skipped the videos forever (no stats
+    // ever landed). Assert the cache is populated post-walk so a
+    // regression dropping the UPSERT block is caught.
+    const externalIds = eventRows
+      .map((r) => r.externalId)
+      .filter((x): x is string => typeof x === "string");
+    expect(externalIds.length).toBe(3);
+    const cacheRows = await db
+      .select()
+      .from((await import("../../src/lib/sources/youtube/server/schema/index.js")).youtubeVideos)
+      .where(
+        (await import("drizzle-orm")).inArray(
+          (await import("../../src/lib/sources/youtube/server/schema/index.js")).youtubeVideos
+            .videoId,
+          externalIds,
+        ),
+      );
+    expect(cacheRows.length).toBe(3);
+    for (const row of cacheRows) {
+      expect(row.publishedAt).not.toBeNull();
+      expect(row.title).toBeTruthy();
+      expect(row.channelId).toBe(channelId);
+      // last_polled_at intentionally NULL — backfill-channel only
+      // populates cache (snippet); poll-active/poll-cold cron will fetch
+      // stats and stamp last_polled_at. Distinguishes from the
+      // channel-context-backfill seed path which DOES stamp it.
+      expect(row.lastPolledAt).toBeNull();
+    }
+
     // Channel state advanced.
     const channelState = await getChannelState("youtube_channel", channelId);
     expect(channelState).toBeDefined();


### PR DESCRIPTION
## Summary

UAT 2026-05-10 prod hotfix. After Phase 03.0.1 deploy, user added a YouTube source and saw events imported but PollingBadge stuck on "Pending · fetching video info…" with no view/like counts. Wave 2's `backfill-channel` handler was INSERTing events from the playlistItems walk without UPSERTing the `youtube_videos` cache → tier resolution returned `pending` → poll-active/poll-cold cron explicitly skips pending → stats never landed.

Fix: `backfill-channel.ts` now UPSERTs `youtube_videos` for every fetched event (title, channelId, publishedAt) parallel to the events INSERT loop. ON CONFLICT DO UPDATE handles concurrent writes from `channel-context-backfill` (the original cache seeder). `last_polled_at` left NULL so the next poll cycle fetches stats.

Recovery SQL for already-orphaned events on prod is in the commit body.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `pnpm test:unit` 324/324 pass
- [x] `tests/integration/end-to-end-catch-up.test.ts` extended with cache-state assertions; 2/2 pass against local Postgres
- [ ] CI green
- [ ] After merge + redeploy: prod walks (cron + refresh-content) populate cache automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)