### PR TITLE
fix(03.0.3): YouTube refresh-content quota burn + feed enrichment (#29)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,18 @@ nginx/certs/origin.key
 
 # Local scratch — `git diff > diff.txt` for ad-hoc review, never committed.
 diff.txt
+
+# Developer-personal dev helpers — each developer ships their own local
+# .dev-*.ts/.mjs scripts (e.g. .dev-worker.ts to run the worker handler
+# bypassing migrate-at-boot; .dev-oauth-mock.mjs to spin up the OAuth
+# mock for interactive sign-in testing; .dev-probe-youtube.ts to drive
+# the YouTube adapter directly for diagnostics). These are intentionally
+# OUT of source control — they pin a single developer's machine setup
+# (admin user_id, API key paths, queue names) and are not portable. The
+# canonical scripts (e.g. scripts/dev-mock-oauth.mjs) live under
+# scripts/ and ARE committed. Phase 03.0.3 P3 deferred-items.md cites
+# .dev-oauth-mock.mjs as an example of why this exclusion matters
+# (process.env reads outside config/env.ts are intentional in standalone
+# Node scripts; ESLint would otherwise flag every developer's helper).
+.dev-*.ts
+.dev-*.mjs

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -248,6 +248,17 @@ Plans:
 - [x] 03.0.2-09-PLAN.md — Drizzle pair refresh — no major on latest (Path A) (Commit 9)
 - [ ] 03.0.2-10-PLAN.md — Bump better-auth 1.6.9→1.6.10 + open phase PR (Commit 10) (D-07 OAuth smoke)
 
+### Phase 03.0.3: YouTube Feed Fixes (INSERTED)
+
+**Goal:** Fix two related YouTube feed gaps discovered during 03.0.2 manual testing — both pre-existing, not regressions. (1) refresh-content walks the full playlist on every click when `backfill_target_since` is epoch (e.g., "all-history" users or seed data), burning per-user cap (110/100 units) on 8 channels with zero new videos; «incremental» flow is labelled but not implemented. (2) `GET /api/events` cursor pagination skips the snapshot + channelTitle enrichment that `/feed/+page.server.ts` does inline at SSR — scroll-loaded YouTube cards lose stats and channel chip. Tracked in #29.
+
+**Requirements**: N/A (bug fix + performance — no new user-facing requirements)
+**Depends on:** Phase 03.0.2 (relies on its dependency refresh shape; no schema migration needed for this phase)
+**Plans:** 1/2 plans executed
+
+Plans:
+- (to be planned via `/gsd:plan-phase 03.0.3`)
+
 ### Phase 3.1: Reddit Adapter
 *DECIMAL SPLIT — scope split decided during /gsd:discuss-phase 03 on 2026-05-05.*
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -254,7 +254,7 @@ Plans:
 
 **Requirements**: N/A (bug fix + performance — no new user-facing requirements)
 **Depends on:** Phase 03.0.2 (relies on its dependency refresh shape; no schema migration needed for this phase)
-**Plans:** 1/2 plans executed
+**Plans:** 2/2 plans complete
 
 Plans:
 - (to be planned via `/gsd:plan-phase 03.0.3`)

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
-status: Ready to plan
-stopped_at: Phase 03.0.3 context gathered
-last_updated: "2026-05-11T10:54:16.505Z"
+status: Ready to execute
+stopped_at: Completed 03.0.3-01-PLAN.md
+last_updated: "2026-05-11T13:43:18.729Z"
 last_activity: 2026-05-11
 progress:
   total_phases: 13
   completed_phases: 7
-  total_plans: 103
-  completed_plans: 104
+  total_plans: 105
+  completed_plans: 105
 ---
 
 # Project State
@@ -20,12 +20,12 @@ progress:
 See: .planning/PROJECT.md (updated 2026-04-27)
 
 **Core value:** Replace messy Google Sheets / markdown files with a structured, secure, query-friendly diary so an indie developer can see — at a glance — which promotion actions actually moved the needle on wishlists and engagement.
-**Current focus:** Phase 03.0.2 — dependency-refresh-inserted
+**Current focus:** Phase 03.0.3 — youtube-feed-fixes
 
 ## Current Position
 
-Phase: 3.1
-Plan: Not started
+Phase: 03.0.3 (youtube-feed-fixes) — EXECUTING
+Plan: 2 of 2
 
 ## Performance Metrics
 
@@ -144,6 +144,7 @@ Plan: Not started
 | Phase 03.0.2-dependency-refresh-inserted P07 | ~11min | 1 tasks | 2 files |
 | Phase 03.0.2 P08 | 25min | 1 tasks | 2 files |
 | Phase 03.0.2-dependency-refresh-inserted P09 | ~8min | 1 tasks | 2 files |
+| Phase 03.0.3 P01 | 45min | 6 tasks | 11 files |
 
 ## Accumulated Context
 
@@ -424,6 +425,8 @@ Recent decisions affecting current work:
 - [Phase 03.0.2-dependency-refresh-inserted]: Plan 07: @hono/node-server 1.19.14->2.0.2 (EXACT pin preserved, no caret). Zero source changes - v2 public API unchanged per release notes. Sole importer src/roles/app.ts serve() call API-compatible. Smoke CI green (load-bearing gate for production HTTP serve path).
 - [Phase 03.0.2]: Plan 08: TS6 pre-immunization held — zero source-code touches needed for typescript 5.6->6.0.3 bump; tsconfig.json unchanged (D-06)
 - [Phase 03.0.2-dependency-refresh-inserted]: Plan 09: drizzle pair Path A landed — drizzle-orm 0.45.2 re-pin (audit-trail no-op, latest dist-tag still 0.45.2 at commit-time) + drizzle-kit ^0.31.0 -> ^0.31.10 caret patch bump. D-08 forward-only invariant verified via `pnpm db:check` no-diff; zero edits to merged migration files in drizzle/. CI run 25655923896 green on all 4 jobs (unit-integration exercised real drizzle queries against Postgres; smoke ran migration at boot under advisory lock). Trigger condition for follow-up phase: drizzle-orm@latest flips to 1.0.0 stable -> schedule Casing API refactor across src/lib/server/db/schema/*.ts + src/lib/sources/*/server/schema/*.ts.
+- [Phase 03.0.3]: Three-branch since-derivation (exhausted/incremental/deep) in YouTube channel walker drops refresh-content quota burn from ~110 units to <=8 units for admin all-history clicks (issue #29 Part 1)
+- [Phase 03.0.3]: newest-known cursor pattern (MAX(youtube_videos.published_at) by channel) - backdated-upload-safe replacement for last_polled_at; documented in SOURCE-REFERENCE.md S10 for Phase 03.1+ adapters
 
 ### Pending Todos
 
@@ -466,8 +469,8 @@ Recent decisions affecting current work:
 
 ## Session Continuity
 
-Last session: 2026-05-11T10:54:16.501Z
+Last session: 2026-05-11T13:43:13.585Z
 Last Activity: 2026-05-11
-Stopped at: Phase 03.0.3 context gathered
-Resume file: .planning/phases/03.0.3-youtube-feed-fixes/03.0.3-CONTEXT.md
+Stopped at: Completed 03.0.3-01-PLAN.md
+Resume file: None
 Resume command: see end-of-session message — start with `/clear`, then update PROJECT.md

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,11 +3,11 @@ gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
 status: Ready to plan
-stopped_at: "Completed 03.0.2-09-PLAN.md (drizzle pair refresh, Path A: drizzle-orm 0.45.2 re-pin + drizzle-kit ^0.31.10 caret bump, D-08 no-diff); CI green run 25655923896"
-last_updated: "2026-05-11T07:57:51.800Z"
+stopped_at: Phase 03.0.3 context gathered
+last_updated: "2026-05-11T10:54:16.505Z"
 last_activity: 2026-05-11
 progress:
-  total_phases: 12
+  total_phases: 13
   completed_phases: 7
   total_plans: 103
   completed_plans: 104
@@ -151,6 +151,7 @@ Plan: Not started
 
 - Phase 02.2 inserted after Phase 02 (chronologically after 02.1): ship-to-prod (URGENT) — pre-Phase-3 deploy work so user can dogfood the SaaS before polling pipeline lands
 - Phase 03.0.1 inserted after Phase 03.0 (2026-05-08): source plugin architecture — restructure YouTube-prefixed code into `src/lib/server/sources/youtube/` plugin folder + widen DataSourceAdapter contract (registry dispatch, AdapterContext + AdapterCredentials union) so future sources (Reddit/Twitter/Telegram/Discord) drop in as new sub-folders without editing cross-source plumbing. Prerequisite for Phase 3.1 (Reddit Adapter) — without 03.0.1, adding Reddit requires editing 4 worker handlers and copy-pasting the YouTube plumbing pattern. Also ships generic `POST /api/sources/:id/refresh-content` endpoint and SOURCE-REFERENCE.md "how to add a new source" guide.
+- Phase 03.0.3 inserted after Phase 03.0.2 (2026-05-11): YouTube Feed Fixes (URGENT) — fixes two pre-existing gaps discovered during 03.0.2 manual testing: (1) refresh-content burns per-user quota by walking full playlist on every click when `backfill_target_since` is epoch (incremental flow is labelled but not implemented at the walker level — `since=backfillTargetSince` always); (2) `GET /api/events` cursor pagination skips the snapshot+channelTitle enrichment that `/feed/+page.server.ts` does inline at SSR. Both tracked in #29. Branch: `feat/phase-03.0.3-youtube-feed-fixes`. No schema migration — reuses existing `data_source_channel_state` columns; adds `getNewestKnownPublishedAt(kind, channelKey)` helper + `enrichFeedDtos(userId, dtos)` helper.
 
 ### Decisions
 
@@ -465,8 +466,8 @@ Recent decisions affecting current work:
 
 ## Session Continuity
 
-Last session: 2026-05-11T12:21:00.000Z
+Last session: 2026-05-11T10:54:16.501Z
 Last Activity: 2026-05-11
-Stopped at: Completed 03.0.2-09-PLAN.md (drizzle pair refresh, Path A: drizzle-orm 0.45.2 re-pin + drizzle-kit ^0.31.10 caret bump, D-08 no-diff); CI green run 25655923896
-Resume file: None
+Stopped at: Phase 03.0.3 context gathered
+Resume file: .planning/phases/03.0.3-youtube-feed-fixes/03.0.3-CONTEXT.md
 Resume command: see end-of-session message — start with `/clear`, then update PROJECT.md

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
-status: Ready to execute
-stopped_at: Completed 03.0.3-01-PLAN.md
-last_updated: "2026-05-11T13:43:18.729Z"
+status: Phase complete — ready for verification
+stopped_at: Completed 03.0.3-02-PLAN.md
+last_updated: "2026-05-11T14:01:45.459Z"
 last_activity: 2026-05-11
 progress:
   total_phases: 13
-  completed_phases: 7
+  completed_phases: 8
   total_plans: 105
-  completed_plans: 105
+  completed_plans: 106
 ---
 
 # Project State
@@ -145,6 +145,7 @@ Plan: 2 of 2
 | Phase 03.0.2 P08 | 25min | 1 tasks | 2 files |
 | Phase 03.0.2-dependency-refresh-inserted P09 | ~8min | 1 tasks | 2 files |
 | Phase 03.0.3 P01 | 45min | 6 tasks | 11 files |
+| Phase 03.0.3-youtube-feed-fixes P02 | ~15min | 6 tasks | 8 files |
 
 ## Accumulated Context
 
@@ -427,6 +428,8 @@ Recent decisions affecting current work:
 - [Phase 03.0.2-dependency-refresh-inserted]: Plan 09: drizzle pair Path A landed — drizzle-orm 0.45.2 re-pin (audit-trail no-op, latest dist-tag still 0.45.2 at commit-time) + drizzle-kit ^0.31.0 -> ^0.31.10 caret patch bump. D-08 forward-only invariant verified via `pnpm db:check` no-diff; zero edits to merged migration files in drizzle/. CI run 25655923896 green on all 4 jobs (unit-integration exercised real drizzle queries against Postgres; smoke ran migration at boot under advisory lock). Trigger condition for follow-up phase: drizzle-orm@latest flips to 1.0.0 stable -> schedule Casing API refactor across src/lib/server/db/schema/*.ts + src/lib/sources/*/server/schema/*.ts.
 - [Phase 03.0.3]: Three-branch since-derivation (exhausted/incremental/deep) in YouTube channel walker drops refresh-content quota burn from ~110 units to <=8 units for admin all-history clicks (issue #29 Part 1)
 - [Phase 03.0.3]: newest-known cursor pattern (MAX(youtube_videos.published_at) by channel) - backdated-upload-safe replacement for last_polled_at; documented in SOURCE-REFERENCE.md S10 for Phase 03.1+ adapters
+- [Phase 03.0.3-youtube-feed-fixes]: Plan 02: enrichFeedDtos lives on DataSourceAdapter as optional method; type-only EventDto import preserves layering boundary; barrel spread propagates impl automatically (no explicit override needed).
+- [Phase 03.0.3-youtube-feed-fixes]: Plan 02: GET /api/events/deleted carries load-bearing WHY comment (deliberate skip — DeletedEventsPanel compact view); second of two such comments in Phase 03.0.3 alongside Plan 01's updateSource lazy-deep-walk reference.
 
 ### Pending Todos
 
@@ -469,8 +472,8 @@ Recent decisions affecting current work:
 
 ## Session Continuity
 
-Last session: 2026-05-11T13:43:13.585Z
+Last session: 2026-05-11T14:01:45.455Z
 Last Activity: 2026-05-11
-Stopped at: Completed 03.0.3-01-PLAN.md
+Stopped at: Completed 03.0.3-02-PLAN.md
 Resume file: None
 Resume command: see end-of-session message — start with `/clear`, then update PROJECT.md

--- a/.planning/phases/03.0.3-youtube-feed-fixes/03.0.3-01-PLAN.md
+++ b/.planning/phases/03.0.3-youtube-feed-fixes/03.0.3-01-PLAN.md
@@ -1,0 +1,898 @@
+---
+phase: 03.0.3-youtube-feed-fixes
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/lib/sources/youtube/server/handlers/backfill-channel.ts
+  - src/lib/sources/youtube/server/handlers/channel-context-backfill.ts
+  - src/lib/sources/youtube/server/newest-known.ts
+  - src/lib/server/services/channel-state.ts
+  - src/lib/server/services/data-sources.ts
+  - src/lib/server/http/routes/sources.ts
+  - tests/integration/refresh-content-quota.test.ts
+  - tests/integration/channel-state-helpers.test.ts
+  - tests/integration/end-to-end-catch-up.test.ts
+  - SOURCE-REFERENCE.md
+autonomous: true
+requirements: []
+must_haves:
+  truths:
+    - "An 8-channel `/sources` 'Pull new content' click on a steady-state account burns ≤8 YouTube quota units (down from ~110 pre-fix); verified by integration test (a) in refresh-content-quota.test.ts and by manual UAT on prod."
+    - "Backdated YouTube uploads (publishedAt earlier than newestKnown but newer than the user's prior session) are collected on the next refresh-content click; verified by integration test (b)."
+    - "Widening `backfillTargetSince` (e.g. 30d → epoch) via `PATCH /api/sources/:id` triggers a deep walk on the next refresh-content click — no eager state reset required; verified by integration test (c)."
+    - "Onboarding context backfill (channel-context-backfill) writes terminal channel state per `stopReason` so the next cron tick / refresh click sees the correct exhausted/incremental/deep branch and does not double-walk."
+    - "`resetChannelBackfillComplete` is fully removed from src/ and tests/ — the lazy three-branch since-derivation replaces the eager reset; `grep -r 'resetChannelBackfillComplete' src tests` returns 0."
+  artifacts:
+    - path: "src/lib/sources/youtube/server/newest-known.ts"
+      provides: "getNewestKnownPublishedAt(channelKey) — YouTube-internal cursor helper backing the three-branch since-derivation."
+      exports: ["getNewestKnownPublishedAt"]
+    - path: "src/lib/sources/youtube/server/handlers/backfill-channel.ts"
+      provides: "Three-branch since-derivation (exhausted / target>=deepestWalked incremental / deep-walk default) gating channel walks for both ctx.origin user and cron; lastBackfillPageToken cleared when an incremental branch is taken."
+      contains: "since_branch"
+    - path: "src/lib/sources/youtube/server/handlers/channel-context-backfill.ts"
+      provides: "Terminal channel-state writes per stopReason (no_more_pages / hard_cap / cutoff_crossed) — eliminates onboarding double-walk."
+      contains: "stopReason"
+    - path: "src/lib/server/services/channel-state.ts"
+      provides: "Channel-state helpers without resetChannelBackfillComplete."
+    - path: "src/lib/server/services/data-sources.ts"
+      provides: "updateSource carries an inline WHY comment near line 586 documenting that widening backfillTargetSince is handled lazily by the next refresh-content click's since-derivation (no eager reset required)."
+      contains: "widening backfillTargetSince is handled lazily"
+    - path: "src/lib/server/http/routes/sources.ts"
+      provides: "refresh-content route with the resetChannelBackfillComplete call + import removed; no other behavioral changes."
+    - path: "tests/integration/refresh-content-quota.test.ts"
+      provides: "3 behavioural tests covering the quota-burn invariant: steady-state ≤1 page, backdated upload collected, target widening triggers deep walk."
+      min_lines: 100
+    - path: "SOURCE-REFERENCE.md"
+      provides: "New 'Incremental-vs-deep-walk pattern' section documenting newestKnown cursor + three-branch since-derivation for future adapters."
+  key_links:
+    - from: "src/lib/sources/youtube/server/handlers/backfill-channel.ts"
+      to: "src/lib/sources/youtube/server/newest-known.ts"
+      via: "getNewestKnownPublishedAt(channelKey)"
+      pattern: "getNewestKnownPublishedAt"
+    - from: "src/lib/sources/youtube/server/handlers/backfill-channel.ts"
+      to: "src/lib/server/services/channel-state.ts"
+      via: "setChannelBackfillPageToken(kind, channelKey, null) when incremental branch taken"
+      pattern: "setChannelBackfillPageToken\\(.*null\\)"
+    - from: "src/lib/sources/youtube/server/handlers/channel-context-backfill.ts"
+      to: "src/lib/server/services/channel-state.ts"
+      via: "markChannelBackfillComplete / markChannelBackfillFrontier / setChannelBackfillPageToken per stopReason"
+      pattern: "stopReason"
+    - from: "src/lib/server/http/routes/sources.ts"
+      to: "(nothing — call removed)"
+      via: "resetChannelBackfillComplete is gone"
+      pattern: "resetChannelBackfillComplete"
+---
+
+<objective>
+Part 1 of issue #29: fix the refresh-content quota burn. Today, `POST /api/sources/:id/refresh-content` calls the channel walker with `since=backfillTargetSince` unconditionally, so an admin (or any user with `backfillTargetSince=epoch`) re-walks the full uploads playlist on every click — ~110 YouTube quota units across 8 channels with zero new videos.
+
+The fix is a state-driven three-branch `since`-derivation in `backfill-channel`:
+  - `backfill_complete=true` → `since = max(newestKnown, target)` (exhausted, steady state)
+  - `!exhausted && deepestWalked !== null && target >= deepestWalked` → `since = max(newestKnown, target)` (incremental — target shallower than depth)
+  - else → `since = target` (deep walk — no prior walk / target deeper than depth / context-backfill hard-capped channel)
+
+`newestKnown` is `MAX(youtube_videos.published_at) WHERE channel_id=?` (NOT `last_polled_at` — the published_at cursor catches backdated uploads correctly because `walkedPastSince` fires only on videos older than the newest collected video; D-#29-1 locked).
+
+Three supporting changes ship in the same plan:
+  1. `lastBackfillPageToken` is cleared (`setChannelBackfillPageToken(kind, channelKey, null)`) **before** invoking `adapter.pollContent` when since-derivation lands in either incremental branch — without this, a saved-mid-deep-walk page-N pageToken causes `walkedPastSince` to fire immediately on the next incremental click with zero events (D-#29-3).
+  2. `channel-context-backfill` writes terminal channel state per `stopReason` — `no_more_pages` → complete + frontier MIN + token null; `hard_cap` → frontier oldest-seen + token preserved (resume cursor) + not-complete; `cutoff_crossed` → frontier=cutoff + token null + not-complete. Eliminates the typical onboarding double-walk (D-#29-5).
+  3. Full removal of `resetChannelBackfillComplete` — call at sources.ts:390-392, import at sources.ts:34, definition at channel-state.ts:137-149. The lazy three-branch since-derivation replaces the eager belt-and-suspenders. `updateSource` near data-sources.ts:586 gains one WHY comment (D-D1).
+
+Phase has no new REQ-IDs — bug fix + perf tracked in issue #29; requirements: [] is intentional per workflow step 13.
+
+Branch `feat/phase-03.0.3-youtube-feed-fixes` already exists. Intermediate commits use Conventional Commits scope `fix(03.0.3): ...`. One squash-merge PR at end of Part 1 + Part 2.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/03.0.3-youtube-feed-fixes/03.0.3-CONTEXT.md
+@.planning/phases/03.0.1-source-plugin-architecture/03.0.1-CONTEXT.md
+@CLAUDE.md
+@AGENTS.md
+@src/lib/sources/adapter.ts
+@src/lib/sources/youtube/server/adapter.ts
+@src/lib/sources/youtube/server/handlers/backfill-channel.ts
+@src/lib/sources/youtube/server/handlers/channel-context-backfill.ts
+@src/lib/server/services/channel-state.ts
+@src/lib/server/services/data-sources.ts
+@src/lib/server/http/routes/sources.ts
+@tests/integration/api-sources-refresh-content.test.ts
+@tests/integration/auto-backfill-cron-picker.test.ts
+@tests/integration/zero-quota-onboarding.test.ts
+@tests/integration/channel-state-helpers.test.ts
+@SOURCE-REFERENCE.md
+
+<interfaces>
+<!-- Key types / signatures the executor needs. Extracted from codebase. -->
+
+From src/lib/server/services/channel-state.ts (helpers that will be reused or pruned):
+```typescript
+export async function getChannelState(
+  kind: SourceKind,
+  channelKey: string,
+  dbCtx?: DbOrTx,
+): Promise<ChannelStateRow | undefined>;
+
+export async function markChannelLastPolledAt(kind: SourceKind, channelKey: string, dbCtx?: DbOrTx): Promise<void>;
+export async function markChannelBackfillFrontier(kind: SourceKind, channelKey: string, oldestAt: Date, dbCtx?: DbOrTx): Promise<void>;
+export async function markChannelBackfillComplete(kind: SourceKind, channelKey: string, dbCtx?: DbOrTx): Promise<void>;
+export async function setChannelBackfillPageToken(kind: SourceKind, channelKey: string, pageToken: string | null, dbCtx?: DbOrTx): Promise<void>;
+
+// DELETE in this plan (Task 3):
+export async function resetChannelBackfillComplete(kind: SourceKind, channelKey: string, dbCtx?: DbOrTx): Promise<void>;
+
+// ChannelStateRow columns relevant here:
+//   backfillComplete: boolean
+//   backfillOldestAt: Date | null      // deepestWalked
+//   lastPolledAt: Date | null
+//   metadata: { lastBackfillPageToken?: string } | null
+```
+
+New helper to introduce (Task 1):
+```typescript
+// src/lib/sources/youtube/server/newest-known.ts
+/**
+ * Returns MAX(youtube_videos.published_at) WHERE channel_id = $1.
+ * Used by backfill-channel to compute `newestKnown` for the three-branch
+ * since-derivation. Public-data table — no userId filter (already in the
+ * ESLint tenant-scope allowlist for youtube_videos). Returns null when the
+ * channel has no rows in youtube_videos yet (cold start — caller falls back
+ * to target).
+ */
+export async function getNewestKnownPublishedAt(channelKey: string): Promise<Date | null>;
+```
+
+From src/lib/sources/youtube/server/handlers/backfill-channel.ts (current shape — preserve all of step 1-10; only step 3 "Compute since" changes):
+```typescript
+// Step 3 currently:
+const since = new Date(job.data.depthBoundIso);
+// becomes (D-#29-2 verbatim — see Task 2 action):
+//   newestKnown = getNewestKnownPublishedAt(channelKey)
+//   state      = await getChannelState(kind, channelKey)
+//   target     = new Date(depthBoundIso)
+//   deepest    = state?.backfillOldestAt ?? null
+//   branch     = "exhausted" | "incremental" | "deep"
+//   since      = (branch !== "deep") ? max(newestKnown, target) : target
+//   if branch in ("exhausted","incremental"): await setChannelBackfillPageToken(kind, channelKey, null)
+```
+
+From src/lib/sources/youtube/server/handlers/channel-context-backfill.ts (existing `stopReason` variable already lives at line ~437; current handler logs it but writes no state — Task 4 wires state writes):
+```typescript
+let stopReason: "no_more_pages" | "cutoff_crossed" | "hard_cap" = "no_more_pages";
+// ... loop sets stopReason on early exit ...
+// After step 5b (videos.list snapshot inserts) and step 6 (auto-import event creation),
+// add the new state-write block PER stopReason — see Task 4 action verbatim table.
+```
+
+From src/lib/server/http/routes/sources.ts (lines to delete in Task 3):
+```typescript
+// Line 34 (import — delete):
+import { resetChannelBackfillComplete } from "../../services/channel-state.js";
+
+// Lines 390-392 (call — delete the entire `if` block):
+if (source.channelId) {
+  await resetChannelBackfillComplete(source.kind, source.channelId);
+}
+```
+
+From src/lib/server/services/data-sources.ts (near line 586 in updateSource — comment update in Task 3):
+```typescript
+// Current comment (lines 586-592 — replace per D-D1):
+// Phase 03.0.1 Wave 4 — channel-scoped state machine. Per-source
+// backfill_complete column dropped; channel-level state is now
+// shared across subscribers. Widening one user's target_since does
+// NOT reset the channel's complete flag — other subscribers may have
+// narrower targets that are already satisfied. The next refresh-
+// content click by THIS user explicitly resets channel complete via
+// resetChannelBackfillComplete (trust-but-verify).
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: newest-known cursor helper + Wave 0 test scaffolding</name>
+  <files>
+    src/lib/sources/youtube/server/newest-known.ts (new)
+    tests/integration/refresh-content-quota.test.ts (new)
+  </files>
+  <read_first>
+    - .planning/phases/03.0.3-youtube-feed-fixes/03.0.3-CONTEXT.md (decisions D-A2, D-#29-1, D-#29-2, D-C1; "Specifics" §user-explicitly-used-8-channels)
+    - src/lib/sources/youtube/server/adapter.ts (where this helper sits in the YouTube plugin folder; D-A2 file-name guidance)
+    - src/lib/sources/youtube/server/schema/videos.ts OR src/lib/sources/youtube/server/schema/index.ts (locate `youtubeVideos` table — column name `published_at` ↔ `publishedAt`; column name `channel_id` ↔ `channelId`)
+    - src/lib/server/db/schema/index.ts (cross-source barrel — confirm `youtubeVideos` re-export path)
+    - tests/integration/api-sources-refresh-content.test.ts (mock pg-boss + seedUserDirectly + createSource fixture pattern — Task 5 will follow this shape)
+    - tests/integration/zero-quota-onboarding.test.ts (channel-context-backfill + youtube_videos cache seeding pattern — Task 4's tests piggyback similarly)
+    - tests/integration/helpers.ts (createTestUser / seedUserDirectly signatures)
+    - .planning/phases/03.0.1-source-plugin-architecture/SOURCE-REFERENCE.md path is `SOURCE-REFERENCE.md` at repo root (verify with `ls`)
+  </read_first>
+  <behavior>
+    - getNewestKnownPublishedAt("UC_existing_channel") → returns the latest publishedAt Date when ≥1 youtube_videos rows exist for that channel_id.
+    - getNewestKnownPublishedAt("UC_unknown_channel") → returns null when no rows exist for that channel_id.
+    - getNewestKnownPublishedAt called concurrently on two channels returns each channel's own MAX (no cross-channel leakage).
+    - Helper makes ONE SQL query (one round-trip), uses Drizzle's `.select({max: sql<Date>...}).from(youtubeVideos).where(eq(youtubeVideos.channelId, channelKey))`.
+    - tests/integration/refresh-content-quota.test.ts is created with 3 placeholder `it.skip(...)` scaffolds (Wave-0 placeholder pattern from Phase 2.1) named verbatim from CONTEXT D-C1:
+        * `it.skip("(a) repeated click within 5min on a steady-state channel costs ≤1 page (not N/50 pages)", ...)`
+        * `it.skip("(b) backdated upload (publishedAt < newestKnown but > prior session) is collected on the next click", ...)`
+        * `it.skip("(c) widening backfillTargetSince (30d → epoch) triggers deep walk on next refresh-content click", ...)`
+      These flip live in Task 5.
+  </behavior>
+  <action>
+    Step 1 — Create `src/lib/sources/youtube/server/newest-known.ts` per D-A2 (Claude's-discretion file-name choice between `newest-known.ts` separate file vs inlined in `backfill-channel.ts`; this plan picks the separate file for clarity + future Phase 3.1 Reddit adapter pattern-reference).
+
+    Verbatim signature (D-A2 locked):
+    ```typescript
+    /**
+     * Newest-known cursor for the YouTube three-branch since-derivation
+     * (Phase 03.0.3 P1; D-A2 / D-#29-1).
+     *
+     * Returns MAX(youtube_videos.published_at) WHERE channel_id = $1, or null
+     * when the channel has no rows yet (cold start — caller falls back to
+     * `backfillTargetSince`).
+     *
+     * Public-data table (no userId filter); already in the ESLint tenant-scope
+     * allowlist as a non-tenant table.
+     */
+    export async function getNewestKnownPublishedAt(channelKey: string): Promise<Date | null>;
+    ```
+
+    Implementation (Drizzle):
+    ```typescript
+    import { sql, eq } from "drizzle-orm";
+    import { db } from "$lib/server/db/client.js";
+    import { youtubeVideos } from "$lib/server/db/schema/index.js";
+
+    export async function getNewestKnownPublishedAt(channelKey: string): Promise<Date | null> {
+      const [row] = await db
+        .select({ maxPublishedAt: sql<Date | null>`MAX(${youtubeVideos.publishedAt})` })
+        .from(youtubeVideos)
+        .where(eq(youtubeVideos.channelId, channelKey));
+      return row?.maxPublishedAt ?? null;
+    }
+    ```
+
+    Step 2 — Create `tests/integration/refresh-content-quota.test.ts` with the 3 it.skip placeholders verbatim per Behavior. Imports must mirror api-sources-refresh-content.test.ts (vi.mock over queue-client.js with sentJobs accumulator, dynamic imports of db/schemas/createSource/createApp/seedUserDirectly). Empty `it.skip` bodies are fine — Task 5 fills them.
+
+    Step 3 — Commit (intermediate, Conventional Commits scope `fix(03.0.3): ...`):
+    ```
+    git add src/lib/sources/youtube/server/newest-known.ts tests/integration/refresh-content-quota.test.ts
+    git commit -m "fix(03.0.3): add newest-known cursor helper + quota-test scaffold"
+    ```
+
+    Do NOT integrate the helper into backfill-channel.ts yet — Task 2 does that.
+  </action>
+  <verify>
+    <automated>pnpm test tests/integration/refresh-content-quota.test.ts 2>&1 | grep -E "(3 skipped|3 todo|3 pending)"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -n "export async function getNewestKnownPublishedAt" src/lib/sources/youtube/server/newest-known.ts` returns line 1+ with the exact signature `(channelKey: string): Promise<Date | null>`.
+    - `grep -c "channelKey" src/lib/sources/youtube/server/newest-known.ts` returns ≥1 (parameter name preserved verbatim per D-A2).
+    - `grep -E "MAX\\(.+publishedAt\\)" src/lib/sources/youtube/server/newest-known.ts` returns 1 match (the SQL aggregate using Drizzle column).
+    - `grep -c "userId" src/lib/sources/youtube/server/newest-known.ts` returns 0 (public-data table, no tenant filter — per D-#29-1 + AGENTS.md tenant-scope allowlist comment).
+    - `grep -c "it.skip" tests/integration/refresh-content-quota.test.ts` returns exactly 3.
+    - `grep -c "steady-state" tests/integration/refresh-content-quota.test.ts` returns ≥1 (test (a) name).
+    - `grep -c "backdated upload" tests/integration/refresh-content-quota.test.ts` returns ≥1 (test (b) name).
+    - `grep -c "widening backfillTargetSince" tests/integration/refresh-content-quota.test.ts` returns ≥1 (test (c) name).
+    - `pnpm tsc --noEmit 2>&1 | grep newest-known.ts` returns 0 lines (no TypeScript errors in the new file).
+    - `git log --oneline -n 1` shows a commit message starting `fix(03.0.3):`.
+  </acceptance_criteria>
+  <done>
+    Helper file exists with the locked signature; 3-placeholder test file exists; intermediate commit landed on feat/phase-03.0.3-youtube-feed-fixes.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: three-branch since-derivation in backfill-channel + token-clear-on-incremental</name>
+  <files>
+    src/lib/sources/youtube/server/handlers/backfill-channel.ts
+  </files>
+  <read_first>
+    - .planning/phases/03.0.3-youtube-feed-fixes/03.0.3-CONTEXT.md (decisions D-#29-1, D-#29-2, D-#29-3, D-#29-4, D-#29-7 — the locked design tables; "Creative Options" §Token-clear-ordering)
+    - src/lib/sources/youtube/server/handlers/backfill-channel.ts (current step-3 "Compute since" lives at lines ~128-142; preserve all surrounding steps 1, 2, 4-10 unchanged)
+    - src/lib/sources/youtube/server/newest-known.ts (from Task 1 — import target)
+    - src/lib/server/services/channel-state.ts (signatures of getChannelState, setChannelBackfillPageToken)
+    - .planning/phases/03.0.1-source-plugin-architecture/03.0.1-CONTEXT.md (D-01 Thick adapter scope — the new branch logic is YouTube-internal, NOT on the cross-source adapter interface)
+  </read_first>
+  <behavior>
+    - When `channelState.backfillComplete === true` → `branch="exhausted"`; `since = max(newestKnown ?? target, target)`; `incrementalBranchTaken=true`; token cleared before adapter.pollContent.
+    - When `channelState.backfillComplete === false && channelState.backfillOldestAt !== null && target.getTime() >= channelState.backfillOldestAt.getTime()` → `branch="incremental"`; `since = max(newestKnown ?? target, target)`; `incrementalBranchTaken=true`; token cleared before adapter.pollContent.
+    - Otherwise (`channelState undefined` OR `backfillOldestAt === null` OR `target < backfillOldestAt`) → `branch="deep"`; `since = target`; `incrementalBranchTaken=false`; token preserved (current behavior — pollContent reads `metadata.lastBackfillPageToken` from `channelState` and resumes).
+    - Branch logic applies identically to `ctx.origin === "user"` AND `ctx.origin === "cron"` paths — NO origin-gated short-circuit (D-#29-2 locked: "no origin-gated branch").
+    - Audit metadata gains `since_branch: "exhausted" | "incremental" | "deep"` on the existing `writeBackfillAudit({metadata: {...}})` call near line 451 (Claude's-discretion forensics field per CONTEXT "Creative Options"). Add as `since_branch: branch` next to existing `flow` / `requests_used` / `events_inserted` keys.
+    - Existing steps 4-10 (subscriber lookup, AdapterError handling, fan-out INSERT, channel-state writes for endOfPlaylist / walkedPastSince / MAX_PAGES per D-#29-4) preserved unchanged — D-#29-4 explicitly says "existing behavior preserved".
+  </behavior>
+  <action>
+    Edit ONLY step 3 ("Compute since") block in `src/lib/sources/youtube/server/handlers/backfill-channel.ts`. Current shape (lines ~128-142):
+    ```typescript
+    // 3. Compute since.
+    // ...comment block...
+    const since = new Date(job.data.depthBoundIso);
+    if (Number.isNaN(since.getTime())) {
+      logger.warn(...);
+      return;
+    }
+    ```
+
+    Replace with the three-branch logic (D-#29-2 verbatim pseudocode):
+    ```typescript
+    // 3. Compute since — three-branch derivation (Phase 03.0.3 P1; D-#29-2).
+    //
+    // The walker historically used `since = depthBoundIso` unconditionally;
+    // that re-walks the full uploads playlist on every click when the user's
+    // target is epoch (~110 quota units across 8 channels with zero new
+    // videos). The branch logic gates the walk depth using the channel's
+    // newest-known publishedAt cursor + the channel's prior walk frontier.
+    //
+    // Branches (D-#29-2 — applies identically to ctx.origin user AND cron):
+    //   - exhausted   (backfill_complete=true)
+    //                 since = max(newestKnown, target)  — steady state
+    //   - incremental (!complete && deepestWalked !== null && target >= deepestWalked)
+    //                 since = max(newestKnown, target)  — partial walk, target shallower
+    //   - deep        (else)
+    //                 since = target                    — no prior walk OR target deeper
+    //
+    // Token clearing rule (D-#29-3): exhausted + incremental branches CLEAR
+    // metadata.lastBackfillPageToken before adapter.pollContent. Deep branch
+    // preserves it (resume cursor for >MAX_PAGES walks). Without this clear,
+    // a stale page-N cursor from a prior deep walk would cause walkedPastSince
+    // to fire immediately on the incremental click with zero events.
+    const target = new Date(job.data.depthBoundIso);
+    if (Number.isNaN(target.getTime())) {
+      logger.warn(
+        { jobId: job.id, depthBoundIso: job.data.depthBoundIso },
+        "youtube.backfill.channel: invalid depthBoundIso; skipping",
+      );
+      return;
+    }
+    const newestKnown = await getNewestKnownPublishedAt(channelKey);
+    const deepestWalked = channelState?.backfillOldestAt ?? null;
+    let branch: "exhausted" | "incremental" | "deep";
+    if (channelState?.backfillComplete === true) {
+      branch = "exhausted";
+    } else if (deepestWalked !== null && target.getTime() >= deepestWalked.getTime()) {
+      branch = "incremental";
+    } else {
+      branch = "deep";
+    }
+    const since =
+      branch === "deep"
+        ? target
+        : newestKnown !== null && newestKnown.getTime() > target.getTime()
+          ? newestKnown
+          : target;
+    const incrementalBranchTaken = branch !== "deep";
+    if (incrementalBranchTaken) {
+      // D-#29-3 — clear stale resume cursor before incremental walk.
+      await setChannelBackfillPageToken(kind, channelKey, null);
+    }
+    ```
+
+    Add import at top of file (next to existing channel-state imports):
+    ```typescript
+    import { getNewestKnownPublishedAt } from "../newest-known.js";
+    ```
+
+    Wire `since_branch` into the audit metadata. Find the `writeBackfillAudit({...})` calls (there are three: error path ~line 195, empty-result path ~line 229, success path ~line 408). For each, extend the `metadata` object passed to `writeBackfillAudit` with `since_branch: branch`. Update the `writeBackfillAudit` helper signature at line 437 to accept `sinceBranch: "exhausted" | "incremental" | "deep"` and include it in the inner `writeAuditStrict` `metadata` object.
+
+    Tip: the existing `flow` upgrade at line 250 (`flow === "incremental" && ... since.getTime() < channelState.backfillOldestAt.getTime() → flow = "historical"`) needs review. Pre-fix `since` was `depthBoundIso` directly; post-fix `since` is the branch output. The historical-upgrade heuristic still works on the new `since` (it asks "did we go deeper than the recorded frontier?") but verify the boolean still holds in the `deep` branch (where `since = target < deepestWalked` by definition → triggers historical upgrade → correct).
+
+    Commit (intermediate):
+    ```
+    git add src/lib/sources/youtube/server/handlers/backfill-channel.ts
+    git commit -m "fix(03.0.3): three-branch since-derivation in backfill-channel"
+    ```
+
+    Note: this commit leaves the test file's it.skip placeholders skipped — Task 5 flips them after Task 3 (resetChannelBackfillComplete removal) and Task 4 (context-backfill state writes) land. Behavioral preservation of unrelated YouTube flows is still verified via `pnpm test tests/integration/api-sources-refresh-content.test.ts` + `pnpm test tests/integration/auto-backfill-cron-picker.test.ts` passing unchanged.
+  </action>
+  <verify>
+    <automated>pnpm tsc --noEmit 2>&1 | grep -E "backfill-channel.ts" | grep -v "warning" || echo "ok"</automated>
+    <automated>pnpm test tests/integration/api-sources-refresh-content.test.ts</automated>
+    <automated>pnpm test tests/integration/auto-backfill-cron-picker.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -n "branch:" src/lib/sources/youtube/server/handlers/backfill-channel.ts` returns ≥1 line with `let branch:` (the discriminator variable).
+    - `grep -c "branch === \"exhausted\"" src/lib/sources/youtube/server/handlers/backfill-channel.ts` returns ≥1 (assignment OR comparison; loose check — exact `branch === "exhausted"` or `branch = "exhausted"` is fine).
+    - `grep -c "incremental" src/lib/sources/youtube/server/handlers/backfill-channel.ts` returns ≥2 (the branch literal + the flow upgrade).
+    - `grep -n "getNewestKnownPublishedAt" src/lib/sources/youtube/server/handlers/backfill-channel.ts` returns ≥2 lines (import + call).
+    - `grep -n "setChannelBackfillPageToken(kind, channelKey, null)" src/lib/sources/youtube/server/handlers/backfill-channel.ts` returns ≥2 lines (the new pre-pollContent clear in Task 2 AND the existing post-pollContent clear in step 5/9).
+    - `grep -c "since_branch" src/lib/sources/youtube/server/handlers/backfill-channel.ts` returns ≥3 (audit metadata in error path + empty path + success path).
+    - `pnpm test tests/integration/api-sources-refresh-content.test.ts` exits 0 (existing Plan-03.0.1-10 invariants preserved).
+    - `pnpm test tests/integration/auto-backfill-cron-picker.test.ts` exits 0 (cron-picker invariant preserved — D-#29-2 applies identically to cron path).
+    - `git log --oneline -n 1` shows commit message starting `fix(03.0.3):`.
+    - `grep -c "ctx.origin === \"user\"" src/lib/sources/youtube/server/handlers/backfill-channel.ts` returns 0 (D-#29-2: NO origin-gated branch — branch logic must NOT short-circuit on origin).
+  </acceptance_criteria>
+  <done>
+    Three-branch since-derivation lives in backfill-channel.ts; token cleared on incremental branches before pollContent; audit carries since_branch; existing tests still pass; intermediate commit landed.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 3: remove resetChannelBackfillComplete + add updateSource WHY comment</name>
+  <files>
+    src/lib/server/http/routes/sources.ts
+    src/lib/server/services/channel-state.ts
+    src/lib/server/services/data-sources.ts
+    tests/integration/channel-state-helpers.test.ts
+    tests/integration/end-to-end-catch-up.test.ts
+  </files>
+  <read_first>
+    - .planning/phases/03.0.3-youtube-feed-fixes/03.0.3-CONTEXT.md (decisions D-D1, D-#29-6 — the full removal contract; "Specifics" §No backward-compat shim)
+    - src/lib/server/http/routes/sources.ts (lines 34 import + 386-392 the call block — confirm exact surrounding lines before editing)
+    - src/lib/server/services/channel-state.ts (lines 131-149 — the function definition + jsdoc to delete in full)
+    - src/lib/server/services/data-sources.ts (lines 568-593 around updateSource backfillTargetSince patch — locate the existing comment block to replace per D-D1)
+    - tests/integration/channel-state-helpers.test.ts (line 18 imports + line 86-95 the toggle test — to prune)
+    - tests/integration/end-to-end-catch-up.test.ts (header comment line ~14 mentions resetChannelBackfillComplete — update comment if test no longer references the function, otherwise leave as historical narrative)
+    - CLAUDE.md / AGENTS.md ("If unused, delete it completely" + "no half-finished implementations" + "default to no comments" — D-D1 explicitly says the new updateSource comment is the load-bearing WHY)
+  </read_first>
+  <action>
+    Step 1 — Delete the call in `src/lib/server/http/routes/sources.ts`. Lines 386-392 currently read:
+    ```typescript
+    // Phase 03.0.1 Wave 2 — channel-scoped trust-but-verify. Reset
+    // channel-level backfill_complete BEFORE worker enqueue so the
+    // catch-up walk re-checks completeness. Channel state covers ALL
+    // subscribers; one user's refresh can re-open the walk for everyone.
+    if (source.channelId) {
+      await resetChannelBackfillComplete(source.kind, source.channelId);
+    }
+    ```
+    Delete this entire block (comment + if). The next refresh-content click now relies on the three-branch since-derivation in backfill-channel.ts (Task 2) to decide whether to deep-walk or stay incremental.
+
+    Step 2 — Delete the import at sources.ts:34:
+    ```typescript
+    import { resetChannelBackfillComplete } from "../../services/channel-state.js";
+    ```
+
+    Step 3 — Delete the function definition + jsdoc in `src/lib/server/services/channel-state.ts` (lines ~131-149 — the full block starting with the jsdoc `/** Reset backfill_complete=false ...` through the closing `}` of `resetChannelBackfillComplete`).
+
+    Step 4 — Update updateSource WHY comment in `src/lib/server/services/data-sources.ts` near line 586. The existing comment block (lines 586-592) currently reads:
+    ```
+    // Phase 03.0.1 Wave 4 — channel-scoped state machine. Per-source
+    // backfill_complete column dropped; channel-level state is now
+    // shared across subscribers. Widening one user's target_since does
+    // NOT reset the channel's complete flag — other subscribers may have
+    // narrower targets that are already satisfied. The next refresh-
+    // content click by THIS user explicitly resets channel complete via
+    // resetChannelBackfillComplete (trust-but-verify).
+    ```
+    Replace with (D-D1 + D-#29-6 — the WHY a future reader cannot derive from the code):
+    ```
+    // Phase 03.0.3 — widening backfillTargetSince (e.g. 30d → epoch) is
+    // handled LAZILY by the next refresh-content click's three-branch
+    // since-derivation (backfill-channel.ts), NOT by an eager state reset
+    // here. After this UPDATE, `target` becomes deeper than the channel's
+    // recorded `backfillOldestAt`, so the next walk lands in the `deep`
+    // branch: since=target, token preserved, walk resumes from the saved
+    // cursor or restarts. Pre-Phase-03.0.3 this path called
+    // resetChannelBackfillComplete eagerly; the eager reset was redundant
+    // (the three-branch since-derivation covers the same ground) AND
+    // wrong (it re-opened the walk for ALL subscribers on the channel,
+    // not just the user who widened — multi-tenant fairness violation
+    // per D-#29-7).
+    ```
+
+    Also delete the now-stale references at data-sources.ts:781 (a comment line `//   resetSourceBackfillComplete   → resetChannelBackfillComplete` in a historical-narrative comment block — verify with `grep -n resetChannelBackfillComplete src/lib/server/services/data-sources.ts` and remove that one line; rest of the historical narrative stays).
+
+    Step 5 — Prune tests in `tests/integration/channel-state-helpers.test.ts`:
+    - Remove `resetChannelBackfillComplete` from the import list (line 18).
+    - Delete or rewrite the `it("markChannelBackfillComplete + resetChannelBackfillComplete toggle the flag", ...)` test (line 86) — rename to `it("markChannelBackfillComplete sets the flag", ...)` and drop the `await resetChannelBackfillComplete(...)` line + the subsequent assertion that the flag returned to false. Keep the first half (markChannelBackfillComplete sets the flag).
+
+    Step 6 — Update the header narrative in `tests/integration/end-to-end-catch-up.test.ts` line ~14 if it references `resetChannelBackfillComplete` — replace with a sentence pointing at the three-branch since-derivation (or simply delete the bullet; this is a comment, not load-bearing code).
+
+    Step 7 — Verify the removal is complete:
+    ```
+    grep -rn "resetChannelBackfillComplete" src tests
+    # Expected: no output (zero references).
+    ```
+
+    Step 8 — Commit (intermediate):
+    ```
+    git add src/lib/server/http/routes/sources.ts src/lib/server/services/channel-state.ts src/lib/server/services/data-sources.ts tests/integration/channel-state-helpers.test.ts tests/integration/end-to-end-catch-up.test.ts
+    git commit -m "fix(03.0.3): remove resetChannelBackfillComplete (lazy deep-walk replaces eager reset)"
+    ```
+  </action>
+  <verify>
+    <automated>pnpm tsc --noEmit</automated>
+    <automated>pnpm test tests/integration/api-sources-refresh-content.test.ts</automated>
+    <automated>pnpm test tests/integration/channel-state-helpers.test.ts</automated>
+    <automated>pnpm test tests/integration/end-to-end-catch-up.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -rn "resetChannelBackfillComplete" C:/projects/neotolis-game-promotion-diary/src C:/projects/neotolis-game-promotion-diary/tests` returns 0 matches across src/ and tests/ (full removal — D-D1).
+    - `grep -c "widening backfillTargetSince is handled LAZILY" src/lib/server/services/data-sources.ts` returns ≥1 (the new WHY comment).
+    - `grep -c "three-branch since-derivation" src/lib/server/services/data-sources.ts` returns ≥1.
+    - `grep -c "D-#29-7" src/lib/server/services/data-sources.ts` returns ≥1 (decision-ID traceability per AGENTS.md self-review item 1).
+    - `pnpm tsc --noEmit` exits 0 with no compile errors referencing resetChannelBackfillComplete.
+    - `pnpm test tests/integration/api-sources-refresh-content.test.ts` exits 0.
+    - `pnpm test tests/integration/channel-state-helpers.test.ts` exits 0 (the pruned test still passes; remaining assertions intact).
+    - `pnpm test tests/integration/end-to-end-catch-up.test.ts` exits 0 (no resetChannelBackfillComplete call in this test — header comment update is documentation-only).
+    - `git log --oneline -n 1` shows commit message starting `fix(03.0.3): remove resetChannelBackfillComplete`.
+  </acceptance_criteria>
+  <done>
+    resetChannelBackfillComplete is fully gone from src + tests; updateSource carries the load-bearing WHY comment per D-D1; intermediate commit landed; no regression in baseline tests.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 4: channel-context-backfill terminal state writes per stopReason</name>
+  <files>
+    src/lib/sources/youtube/server/handlers/channel-context-backfill.ts
+  </files>
+  <read_first>
+    - .planning/phases/03.0.3-youtube-feed-fixes/03.0.3-CONTEXT.md (decision D-#29-5 — the stopReason → state-write TABLE, locked verbatim; "Specifics" §channel-context-backfill state writes are technically a behavior change)
+    - src/lib/sources/youtube/server/handlers/channel-context-backfill.ts (current handler — locate the `stopReason` variable at line ~437; the existing post-loop block at lines ~692-714 already writes markChannelLastPolledAt + markChannelBackfillFrontier conditionally — extend with backfill_complete + token writes per stopReason)
+    - src/lib/server/services/channel-state.ts (signatures of markChannelBackfillComplete, setChannelBackfillPageToken — both auto-create the row on first call)
+    - tests/integration/zero-quota-onboarding.test.ts (existing channel-context-backfill test surface — the new state writes must not regress the zero-quota onboarding flow)
+  </read_first>
+  <behavior>
+    Verbatim D-#29-5 state-write table (locked — copy into the action below):
+
+    | stopReason            | markChannelBackfillComplete | markChannelBackfillFrontier            | setChannelBackfillPageToken                      |
+    |-----------------------|------------------------------|-----------------------------------------|--------------------------------------------------|
+    | `no_more_pages`       | YES (`complete=true`)        | MIN(oldest seen)                        | null                                             |
+    | `hard_cap`            | NO (stay `false`)            | oldest seen                             | `nextPageToken from last fetched page 20`        |
+    | `cutoff_crossed`      | NO (stay `false`)            | `cutoff` (= now − windowDays)           | null                                             |
+
+    The handler currently sets `stopReason` correctly (line 437) but only writes markChannelLastPolledAt + conditional markChannelBackfillFrontier — never markChannelBackfillComplete, never setChannelBackfillPageToken. Pre-fix this leaves `backfill_complete=false` even on small channels that finished naturally → cron auto-backfill picker re-walks them at 3am Pacific the next day (the typical onboarding double-walk).
+
+    Post-fix the three terminal states are honored, and `lastBackfillPageToken` is preserved on `hard_cap` so the next refresh-content click (or scheduler continuation, if/when it lands — currently deferred per Phase 03.0.1 continuation-backfill todo) can resume from page 21.
+  </behavior>
+  <action>
+    Edit `src/lib/sources/youtube/server/handlers/channel-context-backfill.ts`. The pagination loop (lines ~439-485) already sets `stopReason` and tracks `pageToken` correctly. After the loop, we need a `nextPageTokenFromHardCap` capture — pre-fix the variable goes out of scope when stopReason="hard_cap". Capture it by reading `playlistJson.nextPageToken` at the `page === MAX_PAGES - 1` branch where stopReason is set to "hard_cap":
+
+    Inside the pagination loop, change:
+    ```typescript
+    if (page === MAX_PAGES - 1) {
+      stopReason = "hard_cap";
+      break;
+    }
+    ```
+    to:
+    ```typescript
+    if (page === MAX_PAGES - 1) {
+      stopReason = "hard_cap";
+      // Preserve the cursor at MAX_PAGES so the next refresh-content click
+      // resumes from page 21 instead of restarting the walk (D-#29-5).
+      hardCapResumeToken = playlistJson.nextPageToken ?? null;
+      break;
+    }
+    ```
+    And declare `let hardCapResumeToken: string | null = null;` next to `let pageToken: string | undefined;` at line ~436.
+
+    Then extend the post-loop state-write block at line ~692. The existing block:
+    ```typescript
+    if (sourceId && channelId !== null) {
+      await markChannelLastPolledAt("youtube_channel", channelId);
+      if (videoIds.length > 0) {
+        // ... compute oldest from youtube_videos table ...
+        if (oldest !== null) {
+          await markChannelBackfillFrontier("youtube_channel", channelId, oldest);
+        }
+      }
+    }
+    ```
+
+    Becomes (D-#29-5 verbatim table applied):
+    ```typescript
+    if (sourceId && channelId !== null) {
+      // Phase 03.0.3 P1 — terminal channel-state writes per stopReason
+      // (D-#29-5). Pre-fix the handler set frontier + last_polled_at but
+      // left backfill_complete=false even for channels that finished
+      // naturally (`no_more_pages`), causing the cron auto-backfill picker
+      // to re-walk them the next morning (the typical onboarding double-walk).
+      await markChannelLastPolledAt("youtube_channel", channelId);
+
+      // Frontier write — depends on stopReason:
+      //   - no_more_pages  → MIN(oldest seen)
+      //   - hard_cap       → oldest seen
+      //   - cutoff_crossed → cutoff (NOT oldest seen — frontier represents
+      //                      the walk boundary, which IS the cutoff when
+      //                      we stopped because we crossed it)
+      if (stopReason === "cutoff_crossed" && cutoff !== null) {
+        await markChannelBackfillFrontier("youtube_channel", channelId, cutoff);
+      } else if (videoIds.length > 0) {
+        const oldestRow = await db
+          .select({ at: youtubeVideos.publishedAt })
+          .from(youtubeVideos)
+          .where(
+            sql`${youtubeVideos.videoId} IN (${sql.join(
+              videoIds.map((vid) => sql`${vid}`),
+              sql`, `,
+            )})`,
+          )
+          .orderBy(sql`${youtubeVideos.publishedAt} ASC NULLS LAST`)
+          .limit(1);
+        const oldest = oldestRow[0]?.at ?? null;
+        if (oldest !== null) {
+          await markChannelBackfillFrontier("youtube_channel", channelId, oldest);
+        }
+      }
+
+      // Complete + token writes — depends on stopReason:
+      if (stopReason === "no_more_pages") {
+        await markChannelBackfillComplete("youtube_channel", channelId);
+        await setChannelBackfillPageToken("youtube_channel", channelId, null);
+      } else if (stopReason === "hard_cap") {
+        // Complete stays false; preserve resume cursor for next walk.
+        await setChannelBackfillPageToken("youtube_channel", channelId, hardCapResumeToken);
+      } else {
+        // cutoff_crossed — complete stays false (more history is available
+        // past the cutoff if the user later widens backfillTargetSince);
+        // clear token because we did NOT exhaust pagination, we just stopped
+        // at the window boundary.
+        await setChannelBackfillPageToken("youtube_channel", channelId, null);
+      }
+    }
+    ```
+
+    Add the new import next to existing channel-state imports near line 52:
+    ```typescript
+    import {
+      markChannelLastPolledAt,
+      markChannelBackfillFrontier,
+      markChannelBackfillComplete,         // NEW (Phase 03.0.3 P1)
+      setChannelBackfillPageToken,         // NEW (Phase 03.0.3 P1)
+    } from "$lib/server/services/channel-state.js";
+    ```
+
+    Commit (intermediate):
+    ```
+    git add src/lib/sources/youtube/server/handlers/channel-context-backfill.ts
+    git commit -m "fix(03.0.3): channel-context-backfill writes terminal state per stopReason"
+    ```
+  </action>
+  <verify>
+    <automated>pnpm tsc --noEmit 2>&1 | grep -E "channel-context-backfill.ts" | grep -v warning || echo ok</automated>
+    <automated>pnpm test tests/integration/zero-quota-onboarding.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -c "stopReason ===" src/lib/sources/youtube/server/handlers/channel-context-backfill.ts` returns ≥3 (no_more_pages + hard_cap + cutoff_crossed branches).
+    - `grep -c "markChannelBackfillComplete" src/lib/sources/youtube/server/handlers/channel-context-backfill.ts` returns ≥2 (import + call site for no_more_pages).
+    - `grep -c "setChannelBackfillPageToken" src/lib/sources/youtube/server/handlers/channel-context-backfill.ts` returns ≥3 (import + null call for no_more_pages + token call for hard_cap + null call for cutoff_crossed = ≥3 calls + 1 import).
+    - `grep -c "hardCapResumeToken" src/lib/sources/youtube/server/handlers/channel-context-backfill.ts` returns ≥3 (declaration + capture in loop + write to setChannelBackfillPageToken).
+    - `grep -c "D-#29-5" src/lib/sources/youtube/server/handlers/channel-context-backfill.ts` returns ≥1 (decision-ID traceability).
+    - `pnpm test tests/integration/zero-quota-onboarding.test.ts` exits 0 (existing channel-context-backfill flow not regressed).
+    - `pnpm tsc --noEmit` exits 0.
+    - `git log --oneline -n 1` shows commit message starting `fix(03.0.3): channel-context-backfill`.
+  </acceptance_criteria>
+  <done>
+    channel-context-backfill writes the three terminal channel states per the D-#29-5 table; zero-quota onboarding test still passes; intermediate commit landed.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 5: live behavioural tests — refresh-content-quota.test.ts (a) + (b) + (c)</name>
+  <files>
+    tests/integration/refresh-content-quota.test.ts
+  </files>
+  <read_first>
+    - .planning/phases/03.0.3-youtube-feed-fixes/03.0.3-CONTEXT.md (D-C1 — the 3 behavioural tests verbatim from #29; D-#29-2 + D-#29-3 — branch semantics; D-#29-7 — multi-tenant target conflict invariant)
+    - tests/integration/api-sources-refresh-content.test.ts (the pg-boss vi.mock pattern + sentJobs accumulator + seedYoutubeSource helper — copy-paste with adjustments)
+    - tests/integration/zero-quota-onboarding.test.ts (youtube_videos cache seeding pattern — test (a) needs prior rows so newestKnown ≠ null)
+    - tests/integration/refresh-now.test.ts (pagination/flow test patterns)
+    - src/lib/sources/youtube/server/handlers/backfill-channel.ts (post-Task-2 — the three-branch since-derivation under test)
+    - src/lib/sources/youtube/server/handlers/channel-context-backfill.ts (post-Task-4 — terminal state writes under test indirectly via test (b))
+  </read_first>
+  <behavior>
+    The 3 tests verbatim from CONTEXT D-C1:
+
+    **(a) Repeated click within 5 min on steady-state channel costs ≤1 page (not N/50 pages).**
+    Setup:
+      - Seed user U1 with `backfillTargetSince=epoch` (admin / "all-history" profile).
+      - Seed `youtube_videos` rows for channel `UC_ch1` with publishedAt spread across last 60 days (≥10 rows).
+      - Seed `data_source_channel_state` row with `backfillComplete=true` + `backfillOldestAt=<oldest seeded video.publishedAt>` (simulate prior exhausted walk).
+      - Mock pg-boss `send` to capture the backfill.channel job payload.
+      - Mock the `youtube-adapter` `pollContent` to count invocations + return `{events: [], unitsUsed: 1, endOfPlaylist: false}` (steady-state — no new videos).
+    Action:
+      - POST `/api/sources/<source-id>/refresh-content` as U1.
+      - Have the handler invoke `handleBackfillChannel` synchronously (or via pg-boss mock job dispatch).
+    Assert:
+      - `pollContent` called exactly once.
+      - `pollContent` invocation's `since` parameter `>= seededVideos[0].publishedAt` (newestKnown floor — branch="exhausted").
+      - Audit row has `metadata.since_branch === "exhausted"` + `metadata.requests_used <= 1`.
+
+    **(b) Backdated upload (publishedAt < newestKnown but > prior session) is collected on the next click.**
+    Setup:
+      - Seed U1 with `backfillTargetSince = 90 days ago`.
+      - Seed `youtube_videos` for `UC_ch1` with 3 rows: newest=now, oldest=60 days ago.
+      - Channel state: `backfillComplete=false`, `backfillOldestAt = 60 days ago` (prior partial walk).
+      - Mock `pollContent` to return ONE event with `occurredAt = 30 days ago` (backdated relative to newestKnown=now, but newer than 60-days-ago floor).
+    Action:
+      - POST refresh-content.
+    Assert:
+      - `pollContent` invoked with `since = newestKnown` (= now from the youtube_videos seed) — NOT 90 days ago.
+      - The new event row exists in `events` for U1.
+      - `pollContent.unitsUsed === 1` recorded in audit metadata as `requests_used`.
+      - `metadata.since_branch === "incremental"` (target=90d, deepest=60d, target>=deepest → incremental).
+
+    **(c) Widening backfillTargetSince via PATCH /api/sources/:id triggers deep walk on next refresh-content click.**
+    Setup:
+      - Seed U1 with current `backfillTargetSince = 30 days ago`.
+      - Seed channel state: `backfillComplete=true` + `backfillOldestAt = 30 days ago` (exhausted at the 30-day window).
+      - Seed `youtube_videos` row with publishedAt=now (just one — newestKnown=now).
+    Action:
+      - PATCH `/api/sources/<id>` with `{ backfillTargetSince: "1970-01-01T00:00:00.000Z" }` (epoch).
+      - Then POST `/api/sources/<id>/refresh-content`.
+    Assert:
+      - Channel state row's `backfillComplete` is STILL `true` after the PATCH (no eager reset — D-#29-6).
+      - The subsequent refresh-content click invokes `pollContent` with `since = new Date(0)` (epoch — branch="deep" because target=epoch < deepest=30d-ago).
+      - Audit metadata: `since_branch === "deep"` + `flow === "historical"` (the historical-flow upgrade fires because since < deepestWalked).
+  </behavior>
+  <action>
+    Replace the 3 `it.skip(...)` placeholders from Task 1 with live `it(...)` tests implementing the Behavior block above.
+
+    Test scaffolding to copy from api-sources-refresh-content.test.ts:
+    ```typescript
+    import { describe, it, expect, vi, beforeEach } from "vitest";
+    const sentJobs: Array<{queue: string; data: Record<string, unknown>; options: Record<string, unknown>}> = [];
+    vi.mock("../../src/lib/server/queue-client.js", async (importOriginal) => { /* identical to api-sources-refresh-content.test.ts */ });
+
+    const { db } = await import("../../src/lib/server/db/client.js");
+    const { dataSources } = await import("../../src/lib/server/db/schema/data-sources.js");
+    const { dataSourceChannelState } = await import("../../src/lib/server/db/schema/data-source-channel-state.js");
+    const { youtubeVideos } = await import("../../src/lib/server/db/schema/index.js");
+    const { events } = await import("../../src/lib/server/db/schema/events.js");
+    const { auditLog } = await import("../../src/lib/server/db/schema/audit-log.js");
+    const { createApp } = await import("../../src/lib/server/http/app.js");
+    const { handleBackfillChannel } = await import("../../src/lib/sources/youtube/server/handlers/backfill-channel.js");
+    const { createSource, updateSource } = await import("../../src/lib/server/services/data-sources.js");
+    const { seedUserDirectly } = await import("./helpers.js");
+    ```
+
+    For test (a) — mock the YouTube adapter's `pollContent` via vi.spyOn the imported `youtubeChannelAdapterCore` from `src/lib/sources/youtube/server/adapter.js`. Stub it to return `{events: [], unitsUsed: 1, endOfPlaylist: false}` and capture `since` arg. Seed youtube_videos rows directly via db.insert. Seed channel state via db.insert with `backfillComplete: true` + `backfillOldestAt: <oldestSeededDate>`. Trigger the handler by calling `handleBackfillChannel({id: "j1", data: {kind: "youtube_channel", channelKey: "UC_ch1", triggerUserId: u1.id, depthBoundIso: new Date(0).toISOString(), flow: "incremental"}})`. Assert spy called once + first arg of pollContent has `since.getTime() >= seededNewest.getTime()`. Assert auditLog row exists for u1 with `metadata.since_branch === "exhausted"`.
+
+    For test (b) — same shape but channel state has `backfillComplete=false` + `backfillOldestAt = 60d ago`. Stub pollContent to return one event {externalId: "vid_new", occurredAt: <30d ago>, title: "Backdated video", url: "...", metadata: {channelId: "UC_ch1"}, kind: "youtube_video"}. Trigger handler. Assert pollContent invoked with `since` ≈ seededNewest (now). Assert events table has a row for U1 with externalId="vid_new". Assert audit `since_branch="incremental"`.
+
+    For test (c) — initial channel state `backfillComplete=true` + `backfillOldestAt = 30d ago`. Make a real HTTP PATCH request through createApp() with body `{backfillTargetSince: "1970-01-01T00:00:00.000Z"}`. Then re-read the channel state from DB and assert `backfillComplete` is still `true` (no eager reset). Then trigger handleBackfillChannel with `depthBoundIso: "1970-01-01T00:00:00.000Z"` and stub pollContent. Assert pollContent's `since` arg equals `new Date(0)` (epoch — deep branch). Assert audit `since_branch === "deep"` AND `flow === "historical"`.
+
+    Clean DB between tests with the standard pattern (clean tables of test fixtures, NOT a global truncate — see api-sources-refresh-content.test.ts `beforeEach`).
+
+    Commit (intermediate):
+    ```
+    git add tests/integration/refresh-content-quota.test.ts
+    git commit -m "test(03.0.3): refresh-content-quota.test.ts — 3 behavioural assertions live"
+    ```
+  </action>
+  <verify>
+    <automated>pnpm test tests/integration/refresh-content-quota.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - `pnpm test tests/integration/refresh-content-quota.test.ts` exits 0 with 3 tests passing (no `it.skip`).
+    - `grep -c "it.skip" tests/integration/refresh-content-quota.test.ts` returns 0 (all placeholders flipped to live tests).
+    - `grep -c "since_branch" tests/integration/refresh-content-quota.test.ts` returns ≥3 (one assertion per test for the branch discriminator).
+    - `grep -c "incremental" tests/integration/refresh-content-quota.test.ts` returns ≥1 (test (b) asserts incremental branch).
+    - `grep -c "deep" tests/integration/refresh-content-quota.test.ts` returns ≥1 (test (c) asserts deep branch).
+    - `grep -c "exhausted" tests/integration/refresh-content-quota.test.ts` returns ≥1 (test (a) asserts exhausted branch).
+    - `grep -c "1970-01-01" tests/integration/refresh-content-quota.test.ts` returns ≥1 (test (c) widening target to epoch).
+    - `pnpm test tests/integration/api-sources-refresh-content.test.ts` exits 0 (no regression to baseline).
+    - `git log --oneline -n 1` shows commit message starting `test(03.0.3):` OR `fix(03.0.3):` (test commits follow same scope).
+  </acceptance_criteria>
+  <done>
+    3 live behavioural tests pass; quota-burn invariant + backdated-upload invariant + widening-window invariant all locked in; intermediate commit landed.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 6: SOURCE-REFERENCE.md — Incremental-vs-deep-walk pattern section</name>
+  <files>
+    SOURCE-REFERENCE.md
+  </files>
+  <read_first>
+    - .planning/phases/03.0.3-youtube-feed-fixes/03.0.3-CONTEXT.md (decisions D-A3, D-#29-1, D-#29-2 — the canonical pattern definition)
+    - SOURCE-REFERENCE.md (sections 1-8; locate the right anchor — after the "Polling patterns" section or wherever channel-walker patterns are documented; if no clear anchor exists, append as new section §9 "Incremental-vs-deep-walk pattern (Phase 03.0.3)")
+    - src/lib/sources/youtube/server/newest-known.ts (the reference impl Phase 3.1 Reddit will copy)
+    - src/lib/sources/youtube/server/handlers/backfill-channel.ts (step 3 — the three-branch derivation under documentation)
+  </read_first>
+  <action>
+    Append a new top-level section to `SOURCE-REFERENCE.md` documenting the pattern for future adapter authors. Use the existing doc voice (matter-of-fact, code-first, no marketing). Section content:
+
+    ```markdown
+    ## Incremental-vs-deep-walk pattern
+
+    *Established in Phase 03.0.3 P1 for YouTube; copy-the-pattern for Reddit / Twitter / Telegram / Discord adapters in Phase 03.1+.*
+
+    The channel walker (`handlers/backfill-channel.ts` for YouTube; the analogous walker file for other adapters) computes the `since` argument it passes to `adapter.pollContent` using a three-branch derivation:
+
+    | Channel state                                                                            | Branch        | `since`                              | `lastBackfillPageToken` |
+    |------------------------------------------------------------------------------------------|---------------|--------------------------------------|--------------------------|
+    | `backfill_complete = true`                                                               | `exhausted`   | `max(newestKnown, target)`           | cleared                  |
+    | `!complete && deepestWalked !== null && target >= deepestWalked`                         | `incremental` | `max(newestKnown, target)`           | cleared                  |
+    | else                                                                                     | `deep`        | `target`                             | preserved (resume cursor)|
+
+    Definitions:
+      - **`target`** — the user's `backfill_target_since` for this source. Comes in as `job.data.depthBoundIso`.
+      - **`newestKnown`** — `MAX(<adapter's events table>.published_at) WHERE channel_id = $channelKey`. For YouTube: `getNewestKnownPublishedAt(channelKey)` in `src/lib/sources/youtube/server/newest-known.ts`. Returns `null` on a cold channel (caller falls back to `target`).
+      - **`deepestWalked`** — the channel's prior frontier (`backfill_oldest_at` column on `data_source_channel_state`).
+
+    Why `newestKnown` and not `last_polled_at`: backdated uploads (rare on YouTube, common on Telegram / Discord) have `publishedAt` earlier than the newest collected video. Using `MAX(published_at)` as the cursor means `walkedPastSince` fires only on items older than the newest collected — which is the correct semantic. `last_polled_at` would skip backdated uploads silently.
+
+    Token-clear rule (incremental + exhausted branches): the persistent `lastBackfillPageToken` cursor from a prior deep-walk MUST be cleared before invoking `pollContent` in either incremental branch. Without this, a stale page-N cursor would cause `walkedPastSince` to fire immediately with zero events.
+
+    Lazy widening: when the user widens `backfill_target_since` (e.g. 30d → epoch) via `PATCH /api/sources/:id`, the cross-source `updateSource` service does NOT eagerly reset channel state. The next refresh-content click sees `target < deepestWalked` and falls into the `deep` branch naturally. This avoids the multi-tenant fairness violation where one user's widening would re-open the walk for ALL subscribers on the channel.
+
+    Reference implementation: YouTube — `src/lib/sources/youtube/server/handlers/backfill-channel.ts` step 3.
+    ```
+
+    Commit (intermediate):
+    ```
+    git add SOURCE-REFERENCE.md
+    git commit -m "docs(03.0.3): document incremental-vs-deep-walk pattern in SOURCE-REFERENCE.md"
+    ```
+  </action>
+  <verify>
+    <automated>grep -c "Incremental-vs-deep-walk pattern" SOURCE-REFERENCE.md</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -c "Incremental-vs-deep-walk pattern" SOURCE-REFERENCE.md` returns ≥1.
+    - `grep -c "newestKnown" SOURCE-REFERENCE.md` returns ≥3 (definition + table + token-clear rule).
+    - `grep -c "deepestWalked" SOURCE-REFERENCE.md` returns ≥2.
+    - `grep -c "exhausted" SOURCE-REFERENCE.md` returns ≥1.
+    - `grep -c "deep-walk" SOURCE-REFERENCE.md` returns ≥1.
+    - `grep -c "lastBackfillPageToken" SOURCE-REFERENCE.md` returns ≥2.
+    - `grep -c "newest-known.ts" SOURCE-REFERENCE.md` returns ≥1 (file-name reference for Phase 3.1 Reddit copy).
+    - `git log --oneline -n 1` shows commit message starting `docs(03.0.3):`.
+  </acceptance_criteria>
+  <done>
+    SOURCE-REFERENCE.md documents the pattern; future adapter authors have a copy-the-pattern reference; intermediate commit landed.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+End-of-plan verification (all must pass before declaring Plan 01 done):
+
+1. `pnpm tsc --noEmit` exits 0.
+2. `pnpm test tests/integration/refresh-content-quota.test.ts` exits 0 with 3 tests passing.
+3. `pnpm test tests/integration/api-sources-refresh-content.test.ts` exits 0 (baseline preserved).
+4. `pnpm test tests/integration/auto-backfill-cron-picker.test.ts` exits 0 (cron picker invariant — D-#29-2 cron-path branch).
+5. `pnpm test tests/integration/zero-quota-onboarding.test.ts` exits 0 (channel-context-backfill flow — D-#29-5 terminal writes).
+6. `pnpm test tests/integration/channel-state-helpers.test.ts` exits 0 (pruned tests pass).
+7. `pnpm test tests/integration/end-to-end-catch-up.test.ts` exits 0.
+8. `pnpm test tests/integration/feed.test.ts` exits 0 (SSR feed page unaffected — Part 2 doesn't change semantics, Part 1 doesn't touch /feed).
+9. `pnpm lint` exits 0 (no ESLint regressions).
+10. `grep -rn "resetChannelBackfillComplete" src tests` returns 0 matches (full removal confirmed).
+11. `git log --oneline | head -6` shows 6 intermediate commits with `fix(03.0.3): ...` / `test(03.0.3): ...` / `docs(03.0.3): ...` scopes (one per Task 1-6).
+
+Manual verification (post-merge, on prod): operator clicks `/sources` → "Pull new content" on 8 channels with `backfillTargetSince=epoch` and watches `/admin/quota`. Expected delta: ≤8 quota units burned (one playlistItems.list page per channel). Pre-fix: ~110 units across 8 channels. This is the "what the user gets after the fix" row from issue #29.
+
+CI gate: GitHub Actions `unit-integration` + `smoke` jobs pass on the PR. The smoke gate doesn't directly exercise the quota-burn fix (mock YouTube reverse-proxy doesn't model multi-click sessions), but it asserts no regression in the existing Plan-03.0-14 invariants (cron registration, snapshot write, SIGTERM drain, admin parity).
+
+Self-review per AGENTS.md "Validation" §1-5:
+  - Constraints compliance: no new `process.env` reads outside `src/lib/server/config/env.ts`; no new at-rest secret paths; no SaaS/self-host divergence; no down migrations.
+  - Philosophy compliance: simplicity for outsider (newest-known.ts file name + jsdoc + decision-ID references make the WHY discoverable); SaaS/self-host parity (no APP_MODE branches); modularity (newest-known lives inside the YouTube plugin folder per D-A2, NOT promoted to cross-source); no premature abstraction (`getNewestKnownPublishedAt` stays YouTube-internal until Reddit lands in 03.1 with its own analogous file); security floor (channel state queries are cross-tenant by design with explicit ESLint disable, unchanged; new helper queries youtube_videos which is also in the tenant-scope allowlist).
+  - Practices compliance: atomic PRs (6 intermediate commits on the long-lived branch; one squash PR at end of Part 2); tests land with feature; no migrations (no schema changes); env reads centralized (untouched); secrets redaction unbroken (no new secret-shaped fields).
+</verification>
+
+<success_criteria>
+Plan 01 success when:
+- `resetChannelBackfillComplete` is fully removed from src + tests (D-D1 closed).
+- backfill-channel.ts implements the three-branch since-derivation per D-#29-2 with token-clear-on-incremental per D-#29-3.
+- channel-context-backfill.ts writes terminal channel state per the D-#29-5 stopReason table.
+- 3 live behavioural tests in refresh-content-quota.test.ts (a + b + c) pass.
+- SOURCE-REFERENCE.md documents the pattern for Phase 03.1+ adapters per D-A3.
+- All existing integration tests still pass (api-sources-refresh-content, auto-backfill-cron-picker, zero-quota-onboarding, channel-state-helpers, end-to-end-catch-up, feed).
+- updateSource carries the D-D1 + D-#29-6 + D-#29-7 WHY comment.
+- 6 intermediate commits land on `feat/phase-03.0.3-youtube-feed-fixes` with Conventional Commits `fix(03.0.3)` / `test(03.0.3)` / `docs(03.0.3)` scopes.
+- Quota envelope on a steady-state 8-channel admin click drops from ~110 units to ≤8 units (the user-visible promise from issue #29).
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/03.0.3-youtube-feed-fixes/03.0.3-01-SUMMARY.md` documenting:
+- What landed (3-bullet summary of the three-branch since-derivation + reset removal + context-backfill state writes)
+- Files modified (full list from frontmatter)
+- Test results (3 new behavioural tests passing + existing tests preserved)
+- Branch + commit hashes (6 intermediate commits — `fix(03.0.3): ...` × 4, `test(03.0.3): ...` × 1, `docs(03.0.3): ...` × 1)
+- Decision-ID traceability table (D-A2 / D-A3 / D-B1 step 1-7 / D-C1 / D-D1 / D-#29-1..7) → file:line citations
+- Quota-envelope before/after measurement (≤8 vs ~110 unit baseline from issue #29)
+- Hand-off note to Plan 02 (Part 2 — enrichFeedDtos)
+</output>

--- a/.planning/phases/03.0.3-youtube-feed-fixes/03.0.3-01-SUMMARY.md
+++ b/.planning/phases/03.0.3-youtube-feed-fixes/03.0.3-01-SUMMARY.md
@@ -1,0 +1,182 @@
+---
+phase: 03.0.3-youtube-feed-fixes
+plan: 01
+subsystem: youtube-polling
+tags: [youtube, quota, channel-state, backfill, drizzle, integration-tests]
+
+requires:
+  - phase: 03.0.1-source-plugin-architecture
+    provides: "channel-scoped state machine (data_source_channel_state table; mark/get/setChannelBackfillPageToken helpers); Thick adapter scope (D-01); per-kind queue topology (youtube.backfill.channel)"
+  - phase: 03.0-polling-pipeline-plumbing-youtube
+    provides: "youtube_videos public-data cache with publishedAt cursor; channel-context-backfill onboarding handler"
+provides:
+  - "Three-branch since-derivation in YouTube channel walker (exhausted / incremental / deep) gating refresh-content quota burn"
+  - "newest-known cursor helper (MAX(youtube_videos.published_at) per channel) — backdated-upload-safe replacement for last_polled_at"
+  - "channel-context-backfill terminal state writes per stopReason (no_more_pages / hard_cap / cutoff_crossed) — eliminates onboarding double-walk"
+  - "since_branch forensic discriminator in source.refresh_content_requested audit metadata"
+  - "Pattern documentation in SOURCE-REFERENCE.md §10 for Phase 03.1+ Reddit/Twitter/Telegram/Discord adapters"
+affects:
+  - "phase 03.0.3-02 (Part 2 — enrichFeedDtos): unrelated callsite refactor; this plan does not touch /feed enrichment"
+  - "phase 03.1 (Reddit adapter): copies the newest-known cursor pattern into its own walker"
+  - "phase 06 (continuation-backfill quota reserve): builds on the hard_cap resume-cursor preserved by this plan"
+
+tech-stack:
+  added: []  # no new dependencies; pure refactor + helper + tests
+  patterns:
+    - "Three-branch since-derivation (exhausted / incremental / deep) for cost-bounded channel walks"
+    - "newest-known cursor (MAX(published_at) by channel) as the safe cursor for backdated-upload-aware incremental walks"
+    - "Walk-outcome terminal state writes (complete / frontier / token) keyed on stopReason"
+    - "Defensive Date coercion at the Drizzle <-> handler boundary when sql<T> typing is structural"
+
+key-files:
+  created:
+    - "src/lib/sources/youtube/server/newest-known.ts"
+    - "tests/integration/refresh-content-quota.test.ts"
+    - ".planning/phases/03.0.3-youtube-feed-fixes/deferred-items.md"
+  modified:
+    - "src/lib/sources/youtube/server/handlers/backfill-channel.ts (step 3 'Compute since' replaced with three-branch logic; sinceBranch threaded through writeBackfillAudit)"
+    - "src/lib/sources/youtube/server/handlers/channel-context-backfill.ts (terminal channel-state writes per stopReason; hardCapResumeToken capture)"
+    - "src/lib/server/services/channel-state.ts (resetChannelBackfillComplete deleted; D-D1)"
+    - "src/lib/server/services/data-sources.ts (updateSource WHY comment per D-D1/D-#29-6/D-#29-7; historical narrative pruned)"
+    - "src/lib/server/http/routes/sources.ts (resetChannelBackfillComplete call + import removed)"
+    - "tests/integration/channel-state-helpers.test.ts (toggle test pruned to set-only direction)"
+    - "tests/integration/end-to-end-catch-up.test.ts (narrative header updated)"
+    - "SOURCE-REFERENCE.md (§9.5 reflects lazy widening; new §10 documents the pattern)"
+
+key-decisions:
+  - "PLAN.md test (b) setup re-derived honestly: 'target >= deepestWalked' algebra (D-#29-2) routes 30d-ago target / 60d-ago deepest to incremental (target.getTime() > deepestWalked.getTime() in ms); PLAN.md's example numbers (90d / 60d) were directionally backwards. Test (b) ships with target=60d, deepest=90d so the incremental branch is exercised correctly."
+  - "Defensive Date coercion in getNewestKnownPublishedAt — Drizzle's sql<Date | null> typing is structural; the SELECT MAX aggregate surfaced as a string at runtime, breaking the .getTime() comparison. Auto-fixed (Rule 1)."
+  - "resetChannelBackfillComplete fully deleted (not deprecated, not commented out) — function had no public surface, internal-only, AGENTS.md 'no half-finished implementations' bias toward deletion."
+
+patterns-established:
+  - "Three-branch since-derivation: cost-bounded channel walks that respect both 'exhausted' steady-state and lazy-widening deep walks without eager state resets that would violate multi-tenant fairness (D-#29-7)."
+  - "newest-known cursor: backdated-upload-safe alternative to last_polled_at. Copy the pattern into Phase 03.1+ adapters (Reddit reads MAX(reddit_posts.created_at); Twitter reads MAX(twitter_posts.posted_at); etc)."
+  - "stopReason-driven terminal state writes: walk handlers persist (complete, frontier, token) atomically per exit reason. No more 'left state half-written' bugs after refactors."
+
+requirements-completed: []
+
+duration: ~45 min
+completed: 2026-05-11
+---
+
+# Phase 03.0.3 Plan 01: YouTube refresh-content quota fix Summary
+
+**Three-branch since-derivation in backfill-channel + walk-outcome terminal state writes drop admin/'all-history' refresh cost from ~110 YouTube quota units across 8 channels to ≤8 units, fixing issue #29 Part 1 without schema migration.**
+
+## Performance
+
+- **Duration:** ~45 min
+- **Started:** 2026-05-11T13:25:00Z (approx — first commit a8feb12 at 13:26)
+- **Completed:** 2026-05-11T13:41:29Z
+- **Tasks:** 6
+- **Files modified:** 8 (3 new, 5 changed)
+
+## Accomplishments
+- Three-branch `since`-derivation in `backfill-channel.ts` (exhausted / incremental / deep) with token-clear-on-incremental — addresses issue #29's headline quota-burn invariant.
+- New `newest-known.ts` cursor helper backing the derivation (MAX(youtube_videos.published_at) per channel), backdated-upload-safe per D-#29-1.
+- `channel-context-backfill.ts` writes terminal channel state (`backfill_complete`, `backfill_oldest_at`, `lastBackfillPageToken`) per `stopReason` — eliminates the typical onboarding double-walk.
+- `resetChannelBackfillComplete` fully deleted (function + import + call) — the lazy three-branch derivation replaces the eager belt-and-suspenders without re-opening the walk for OTHER subscribers (multi-tenant fairness restored — D-#29-7).
+- 3 live behavioural tests in `refresh-content-quota.test.ts` lock the invariants from issue #29 (steady-state cap, backdated upload, window widening).
+- SOURCE-REFERENCE.md §10 documents the pattern for Phase 03.1+ adapters.
+
+## Task Commits
+
+Each task was committed atomically on `feat/phase-03.0.3-youtube-feed-fixes`:
+
+1. **Task 1: newest-known cursor helper + quota-test scaffold** — `a8feb12` (fix)
+2. **Task 2: three-branch since-derivation in backfill-channel** — `a97e524` (fix)
+3. **Task 3: remove resetChannelBackfillComplete** — `ea6c6de` (fix)
+4. **Task 4: channel-context-backfill writes terminal state per stopReason** — `6064762` (fix)
+5. **Task 5: refresh-content-quota.test.ts — 3 behavioural assertions live** — `e2a931c` (test; also carries the Rule-1 Date-coercion auto-fix in newest-known.ts)
+6. **Task 6: document incremental-vs-deep-walk pattern in SOURCE-REFERENCE.md** — `94523f2` (docs)
+
+Plan metadata commit lands separately at the end of plan execution (this SUMMARY + STATE.md + ROADMAP.md).
+
+## Files Created/Modified
+- `src/lib/sources/youtube/server/newest-known.ts` — NEW. `getNewestKnownPublishedAt(channelKey)` — MAX(youtube_videos.published_at) scoped by channel_id. Public-data, no userId filter; defensively coerces to Date for caller compatibility.
+- `src/lib/sources/youtube/server/handlers/backfill-channel.ts` — MODIFIED. Replaces step 3 'Compute since' with three-branch logic; threads `sinceBranch` into `writeBackfillAudit` across all 3 paths (error / empty / success); imports `getNewestKnownPublishedAt`.
+- `src/lib/sources/youtube/server/handlers/channel-context-backfill.ts` — MODIFIED. Adds `hardCapResumeToken` capture; appends terminal channel-state writes per `stopReason`; imports `markChannelBackfillComplete` and `setChannelBackfillPageToken`.
+- `src/lib/server/services/channel-state.ts` — MODIFIED. `resetChannelBackfillComplete` function + jsdoc deleted (lines ~131-149 pre-fix).
+- `src/lib/server/services/data-sources.ts` — MODIFIED. `updateSource` block at line ~586 carries the new WHY comment per D-D1 / D-#29-6 / D-#29-7; historical narrative comment at line ~781 pruned of the now-dead helper reference.
+- `src/lib/server/http/routes/sources.ts` — MODIFIED. `resetChannelBackfillComplete` import (line 34 pre-fix) + call block (lines 386-392 pre-fix) deleted; replaced with a short WHY comment.
+- `tests/integration/refresh-content-quota.test.ts` — NEW. 3 live behavioural tests (a / b / c) covering the quota-burn invariants from issue #29.
+- `tests/integration/channel-state-helpers.test.ts` — MODIFIED. Import list trimmed; toggle test reduced to set-only direction (the reset half no longer exists).
+- `tests/integration/end-to-end-catch-up.test.ts` — MODIFIED. Narrative header updated to point at the three-branch since-derivation.
+- `SOURCE-REFERENCE.md` — MODIFIED. §9.5 updated; new §10 "Incremental-vs-deep-walk pattern" appended for Phase 03.1+ adapter authors.
+- `.planning/phases/03.0.3-youtube-feed-fixes/deferred-items.md` — NEW. Logs two pre-existing test failures (`feed.test.ts` static-email collision; `ingest-paste-then-poll.test.ts` poll-active TypeError) confirmed unrelated to this plan via `git diff master..HEAD`.
+
+## Decisions Made
+- **PLAN.md test (b) setup correction.** PLAN.md's behavior block for test (b) had `target=90d-ago, deepest=60d-ago → incremental`, but D-#29-2's locked algebra `target.getTime() >= deepestWalked.getTime()` routes 90d-ago/60d-ago to the deep branch (90d-ago.ms < 60d-ago.ms numerically). Test (b) shipped with target=60d-ago/deepest=90d-ago so the incremental branch is exercised honestly. The behavioural assertion the plan cares about ("backdated upload collected on next click") is preserved.
+- **Defensive Date coercion in `getNewestKnownPublishedAt`.** Auto-fixed (Rule 1) after test (a) threw `newestKnown.getTime is not a function`. Drizzle's `sql<Date | null>` typing is structural; the SELECT-MAX aggregate surfaced as a string at runtime.
+- **Comment-density follow-the-spec.** All decision-ID references (D-D1, D-#29-2..7) embedded in code comments as the load-bearing WHY per AGENTS.md "default to no comments". Helps future readers trace back to the design doc without grepping.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 — Bug] Drizzle sql<Date | null> result not coerced to Date**
+- **Found during:** Task 5 (live behavioural tests).
+- **Issue:** `newestKnown.getTime is not a function` thrown from `backfill-channel.ts:171` because `getNewestKnownPublishedAt` returned a string (node-postgres surfaces a SELECT-MAX aggregate as string when the column tag is lost through the aggregate function).
+- **Fix:** Helper now coerces with `raw instanceof Date ? raw : new Date(raw)` before returning; widened the `sql<>` type to `Date | string | null` to reflect runtime reality.
+- **Files modified:** `src/lib/sources/youtube/server/newest-known.ts`.
+- **Verification:** All 3 behavioural tests in `refresh-content-quota.test.ts` pass after the fix.
+- **Committed in:** `e2a931c` (alongside Task 5's test bodies — they discovered the bug).
+
+**2. [Rule 2 — Missing critical] PLAN.md test (b) algebra correction**
+- **Found during:** Task 5.
+- **Issue:** PLAN.md's test (b) setup (`target=90d-ago, deepest=60d-ago → incremental`) is directionally wrong: 90d-ago has a SMALLER ms-since-epoch than 60d-ago (deeper instants are EARLIER → smaller numbers). The locked D-#29-2 algebra `target.getTime() >= deepestWalked.getTime()` routes 90d-ago to deep, not incremental.
+- **Fix:** Test (b) reframed with `target=60d-ago, deepest=90d-ago`; the assertion that matters ("backdated upload still collected") is preserved. PLAN.md's behavior section retained as historical context.
+- **Files modified:** `tests/integration/refresh-content-quota.test.ts`.
+- **Verification:** Test (b) passes; `since_branch === "incremental"` audit assertion fires correctly.
+- **Committed in:** `e2a931c`.
+
+**3. [Rule 3 — Blocking] feed.test.ts + ingest-paste-then-poll.test.ts pre-existing failures**
+- **Found during:** End-of-plan verification.
+- **Issue:** Two unrelated tests fail (static-email collision in feed.test.ts; handlePollActive TypeError in ingest-paste-then-poll.test.ts).
+- **Fix:** NOT auto-fixed — confirmed pre-existing on master (`git diff master..HEAD` returns empty for both files; running them on `master` reproduces the same failures). Logged to `.planning/phases/03.0.3-youtube-feed-fixes/deferred-items.md` per AGENTS.md scope-boundary rule.
+- **Verification:** Master-branch checkout reproduces both failures.
+- **Committed in:** N/A (deferred — not in plan scope).
+
+---
+
+**Total deviations:** 3 (1 auto-fixed bug, 1 plan-spec correction, 1 deferred pre-existing).
+**Impact on plan:** Auto-fixes were essential for correctness. PLAN.md's test (b) algebra error did not affect the implementation (Task 2's code matches D-#29-2 verbatim); only the test setup needed correction. No scope creep.
+
+## Issues Encountered
+
+- `pollResult.events.length === 0` branch does not run the historical-flow upgrade. Test (c) phase 2 had to seed an event to trigger the historical flow. Documented inline in the test.
+- `createSource` calls `ensureChannelState` which auto-creates a channel_state row, so test fixtures had to use `onConflictDoUpdate` rather than raw INSERT. Updated all three tests.
+
+## User Setup Required
+
+None — no external service configuration required.
+
+## Next Phase Readiness
+
+- Branch `feat/phase-03.0.3-youtube-feed-fixes` has 6 intermediate commits; plan 03.0.3-02 (Part 2 — `enrichFeedDtos`) will land on the same branch; one squash-merge PR at the end of Part 2.
+- Pre-prod manual UAT step (per VALIDATION.md, to be authored): operator clicks `/sources` → "Pull new content" on 8 channels under admin account; watches `/admin/quota`. Expected: ≤8 units burned (one playlistItems.list page per channel). Pre-fix baseline: ~110 units. This is the user-visible promise from issue #29.
+- Plan 03.0.3-02 carries the second half (`GET /api/events` enrichment); does not depend on Plan 01's changes at the code level (different files), but ships on the same branch.
+
+## Known Stubs
+
+None — Plan 01 is a pure bug fix + refactor; no UI surfaces or data wiring changed.
+
+## Self-Check: PASSED
+
+All claimed artifacts verified to exist:
+- `src/lib/sources/youtube/server/newest-known.ts` — FOUND
+- `tests/integration/refresh-content-quota.test.ts` — FOUND
+- All 6 intermediate commits found in `git log feat/phase-03.0.3-youtube-feed-fixes`:
+  - `a8feb12` — FOUND
+  - `a97e524` — FOUND
+  - `ea6c6de` — FOUND
+  - `6064762` — FOUND
+  - `e2a931c` — FOUND
+  - `94523f2` — FOUND
+- All 3 behavioural tests pass (`refresh-content-quota.test.ts`).
+- Zero references to `resetChannelBackfillComplete` in `src/` and `tests/`.
+- All 22 baseline tests in `api-sources-refresh-content`, `auto-backfill-cron-picker`, `zero-quota-onboarding`, `channel-state-helpers`, `end-to-end-catch-up` pass post-change.
+
+---
+*Phase: 03.0.3-youtube-feed-fixes*
+*Completed: 2026-05-11*

--- a/.planning/phases/03.0.3-youtube-feed-fixes/03.0.3-02-PLAN.md
+++ b/.planning/phases/03.0.3-youtube-feed-fixes/03.0.3-02-PLAN.md
@@ -1,0 +1,1038 @@
+---
+phase: 03.0.3-youtube-feed-fixes
+plan: 02
+type: execute
+wave: 2
+depends_on:
+  - "03.0.3-01"
+files_modified:
+  - src/lib/sources/adapter.ts
+  - src/lib/sources/youtube/server/adapter.ts
+  - src/lib/sources/youtube/server/index.ts
+  - src/lib/sources/youtube/server/feed-enrichment.ts
+  - src/routes/feed/+page.server.ts
+  - src/lib/server/http/routes/events.ts
+  - src/routes/games/[gameId]/+page.server.ts
+  - tests/integration/feed-api-enrichment.test.ts
+  - SOURCE-REFERENCE.md
+autonomous: true
+requirements: []
+must_haves:
+  truths:
+    - "Every YouTube card on `/feed` shows view/like/comment line and channel chip — regardless of whether the row came from the SSR first batch or a cursor-paginated API batch."
+    - "Per-game curated view at `/games/[gameId]` shows the same enrichment (stats + channelTitle) as `/feed`."
+    - "`GET /api/events/deleted` deliberately does NOT carry the enrichment — DeletedEventsPanel renders compact view without stats/channel chips; the deliberate-skip is documented inline."
+    - "Future Reddit / Twitter / Telegram / Discord adapters can opt into feed enrichment by implementing `enrichFeedDtos` on their adapter — zero callsite edits required (the cross-source loop already iterates `allAdapters`)."
+  artifacts:
+    - path: "src/lib/sources/adapter.ts"
+      provides: "DataSourceAdapter widened with `enrichFeedDtos(userId: string, dtos: EventDto[]): Promise<void>` method. Mutates dtos in place; default no-op acceptable for future adapters that don't enrich."
+      exports: ["DataSourceAdapter"]
+      contains: "enrichFeedDtos"
+    - path: "src/lib/sources/youtube/server/feed-enrichment.ts"
+      provides: "YouTube's enrichFeedDtos impl — filters dtos to kind=youtube_video, JOINs latest youtube_video_snapshots (DISTINCT ON videoId, latest polledAt) + JOINs youtube_videos for channelTitle. One batched query each; in-place mutation of dto.stats and dto.channelTitle."
+      exports: ["youtubeEnrichFeedDtos"]
+      min_lines: 50
+    - path: "src/lib/sources/youtube/server/adapter.ts"
+      provides: "YouTube adapter exposes enrichFeedDtos via the youtubeChannelAdapterCore composition + barrel export."
+    - path: "src/lib/sources/youtube/server/index.ts"
+      provides: "Barrel composes enrichFeedDtos onto the exported youtubeAdapter alongside existing methods."
+    - path: "src/routes/feed/+page.server.ts"
+      provides: "SSR feed loader replaces lines 162-237 inline JOIN with a single `for (const adapter of allAdapters) await adapter.enrichFeedDtos(userId, rowDtos); for (const adapter of allAdapters) await adapter.enrichFeedDtos(userId, deletedDtos)` — wait, NO: deletedDtos is deliberately NOT enriched per D-B1 step 4. Single call on rowDtos only."
+    - path: "src/lib/server/http/routes/events.ts"
+      provides: "GET /api/events at line ~330 calls enrichFeedDtos via allAdapters iteration after mapEventsToDtos. GET /api/events/deleted at line ~374 explicitly skips the enrichment with an inline WHY comment referencing DeletedEventsPanel.svelte."
+      contains: "enrichFeedDtos"
+    - path: "src/routes/games/[gameId]/+page.server.ts"
+      provides: "Per-game view calls enrichFeedDtos via allAdapters iteration on eventDtos after mapEventsToDtos at line ~74."
+    - path: "tests/integration/feed-api-enrichment.test.ts"
+      provides: "2 behavioural tests: GET /api/events with paginated cursor returns rows with stats + channelTitle; GET /api/events/deleted does NOT carry the enrichment."
+      min_lines: 60
+    - path: "SOURCE-REFERENCE.md"
+      provides: "New 'Feed enrichment pattern' section documenting the adapter.enrichFeedDtos contract method + the three cross-source callsites."
+  key_links:
+    - from: "src/routes/feed/+page.server.ts"
+      to: "src/lib/sources/registry.ts → allAdapters"
+      via: "for (const adapter of allAdapters) await adapter.enrichFeedDtos(userId, rowDtos)"
+      pattern: "allAdapters.*enrichFeedDtos"
+    - from: "src/lib/server/http/routes/events.ts (GET /api/events)"
+      to: "src/lib/sources/registry.ts → allAdapters"
+      via: "for-of allAdapters + adapter.enrichFeedDtos call after mapEventsToDtos"
+      pattern: "enrichFeedDtos"
+    - from: "src/routes/games/[gameId]/+page.server.ts"
+      to: "src/lib/sources/registry.ts → allAdapters"
+      via: "for-of allAdapters + adapter.enrichFeedDtos call on eventDtos"
+      pattern: "enrichFeedDtos"
+    - from: "src/lib/sources/youtube/server/feed-enrichment.ts"
+      to: "youtube_video_snapshots + youtube_videos tables"
+      via: "DISTINCT ON (video_id) ORDER BY polledAt DESC for snapshots + simple SELECT channelTitle for videos"
+      pattern: "youtubeVideoSnapshots"
+    - from: "src/lib/server/http/routes/events.ts (GET /api/events/deleted)"
+      to: "(nothing — deliberate skip)"
+      via: "inline WHY comment referencing DeletedEventsPanel.svelte"
+      pattern: "DeletedEventsPanel"
+---
+
+<objective>
+Part 2 of issue #29: feed enrichment in `GET /api/events` + per-game view. Today, the SSR first batch on `/feed` shows YouTube view/like/comment counts + channelTitle chip (via inline JOIN in `/feed/+page.server.ts:162-237`), but subsequent cursor-paginated batches via `GET /api/events?cursor=...` drop both — the inline enrichment doesn't run on API responses. Result: visually inconsistent feed where cards above the fold show stats and cards below don't.
+
+The fix factors the enrichment into a `DataSourceAdapter.enrichFeedDtos(userId, dtos)` contract method (D-A1 — adapter encapsulation, AGENTS.md philosophy #3 "extensibility through modules"). The YouTube impl moves the existing inline JOINs from `/feed/+page.server.ts:162-237` into `src/lib/sources/youtube/server/feed-enrichment.ts`. Three callsites that render FeedCard call `for (const adapter of allAdapters) await adapter.enrichFeedDtos(userId, dtos)`:
+
+  1. `/feed/+page.server.ts` (SSR — replaces inline JOIN)
+  2. `GET /api/events` in `src/lib/server/http/routes/events.ts:330` (cursor pagination — the gap that this plan fixes)
+  3. `/games/[gameId]/+page.server.ts:74` (per-game curated view)
+
+Deliberate skip: `GET /api/events/deleted` at `events.ts:374`. `DeletedEventsPanel.svelte` renders compact KindIcon + strikethrough title only — enrichment query would be wasted work. The skip is documented with an inline WHY comment (D-B1 step 4 + AGENTS.md "default to no comments" — this is the second of the two load-bearing WHY comments in Phase 03.0.3, alongside the updateSource lazy-deep-walk comment from Plan 01).
+
+Future Reddit / Twitter / Telegram / Discord adapters (Phase 03.1+) implement the same `enrichFeedDtos` method against their own per-kind metadata tables. Zero callsite edits required — the `for-of allAdapters` loop already iterates every registered adapter.
+
+Phase has no new REQ-IDs — bug fix tracked in issue #29; `requirements: []` is intentional per workflow step 13.
+
+Wave assignment + dependency rationale: Part 1 (Plan 01) and Part 2 (this plan) touch disjoint code files for the YouTube-internal work — `wave: 1` parallel would normally apply. HOWEVER, both plans append to `SOURCE-REFERENCE.md` (Plan 01 §"Incremental-vs-deep-walk pattern", this plan §"Feed enrichment pattern"). To avoid a merge conflict on a markdown file with no clear conflict-resolution semantics, this plan is sequenced `wave: 2, depends_on: ["03.0.3-01"]` so SOURCE-REFERENCE.md's two new sections land in deterministic order (P1 first, P2 second, as the default order in CONTEXT D-D1). The actual code work in this plan does NOT depend on Plan 01's code work — if the executor wants to start Plan 02 source-code tasks before Plan 01 finishes, they can; the wave assignment is purely a sequencing guard for the doc append.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/03.0.3-youtube-feed-fixes/03.0.3-CONTEXT.md
+@.planning/phases/03.0.1-source-plugin-architecture/03.0.1-CONTEXT.md
+@CLAUDE.md
+@AGENTS.md
+@src/lib/sources/adapter.ts
+@src/lib/sources/registry.ts
+@src/lib/sources/youtube/server/adapter.ts
+@src/lib/sources/youtube/server/index.ts
+@src/routes/feed/+page.server.ts
+@src/lib/server/http/routes/events.ts
+@src/routes/games/[gameId]/+page.server.ts
+@tests/integration/feed.test.ts
+@SOURCE-REFERENCE.md
+
+<interfaces>
+<!-- Key types / signatures the executor needs. Extracted from codebase. -->
+
+From src/lib/sources/adapter.ts (the contract to widen):
+```typescript
+export interface DataSourceAdapter {
+  readonly kind: SourceKind;
+  // ... existing methods (pollContent, pollStats, parseUrl, observability,
+  //     registerQueues, scheduleCronTicks, backfillSource, canRefreshPoll,
+  //     reconcileRuntimeState?, canonicalizeOnCreate?, onSourceCreated?,
+  //     fetchEventPreviewMetadata?, fetchEventStats?, validateEventInput?,
+  //     fetchPollStateMap?, registerRoutes?) ...
+
+  // NEW (Task 1):
+  /**
+   * Phase 03.0.3 P2 (D-A1) — enrich the supplied feed DTOs in-place with
+   * adapter-specific data (stats, channel/author metadata, anything that
+   * lives in per-kind metadata tables and renders on FeedCard).
+   *
+   * Cross-source callsites (/feed loader, GET /api/events, /games/[id])
+   * iterate allAdapters and call this method per adapter. The adapter
+   * MUST filter internally to its own kind(s) — callers do NOT pre-filter.
+   *
+   * Mutates `dtos` in place; returns void. Errors are swallowed by the
+   * adapter (logged at WARN); a failed enrichment query MUST NOT break
+   * the feed render — the cards just render without the enrichment.
+   *
+   * Future adapters (Reddit / Twitter / Telegram / Discord) implement this
+   * against their own metadata tables. Adapters that have no enrichment
+   * can omit the method entirely (optional via `?:`); the caller's loop
+   * skips undefined methods.
+   */
+  enrichFeedDtos?(userId: string, dtos: EventDto[]): Promise<void>;
+}
+```
+
+From src/lib/server/dto.ts (consumer type — EventDto already carries optional `stats` and `channelTitle` fields from Phase 03.0 post-build; verify before implementation):
+```typescript
+export interface EventDto {
+  id: string;
+  kind: EventKind;
+  externalId: string | null;
+  // ... other fields ...
+  stats?: { viewCount: number; likeCount: number; commentCount: number; polledAt: Date } | null;
+  channelTitle?: string | null;
+}
+```
+
+From src/routes/feed/+page.server.ts:162-237 (the inline JOIN to replace verbatim):
+```typescript
+// Phase 3.0 post-build (UAT 2026-05-06): attach the latest YouTube stats
+// snapshot to each youtube_video event in the feed. Single batched DISTINCT
+// ON query — one DB round-trip regardless of page size. The snapshot table
+// is public-data (no userId scope) so we filter only by external_id; the
+// events list itself is already userId-scoped at listFeedPage.
+const youtubeExternalIds = rowDtos
+  .filter((r) => r.kind === "youtube_video" && r.externalId !== null)
+  .map((r) => r.externalId as string);
+if (youtubeExternalIds.length > 0) {
+  const snapshots = await db
+    .select({ videoId, polledAt, viewCount, likeCount, commentCount })
+    .from(youtubeVideoSnapshots)
+    .where(inArray(youtubeVideoSnapshots.videoId, youtubeExternalIds))
+    .orderBy(youtubeVideoSnapshots.videoId, sql`${youtubeVideoSnapshots.polledAt} DESC`);
+  // ... build latest Map keyed by videoId (first wins per ORDER BY DESC) ...
+  // ... mutate rowDtos[i].stats = latest.get(externalId) ...
+  // ... separate query for youtube_videos.channelTitle ...
+  // ... mutate rowDtos[i].channelTitle = titleByVideo.get(externalId) ?? null ...
+}
+```
+
+From src/lib/server/http/routes/events.ts:325-339 (GET /api/events — the gap that this plan fixes):
+```typescript
+const dtos = await mapEventsToDtos(c.var.userId, page.rows);
+return c.json({ rows: dtos, nextCursor: page.nextCursor });
+// ^ currently dtos lack stats/channelTitle on API responses
+// Task 4 inserts the enrichment between mapEventsToDtos and c.json.
+```
+
+From src/lib/server/http/routes/events.ts:374-387 (GET /api/events/deleted — the deliberate skip):
+```typescript
+eventsRoutes.get("/events/deleted", async (c) => {
+  try {
+    const rows = await listDeletedEvents(c.var.userId);
+    const dtos = await mapEventsToDtos(c.var.userId, rows);
+    return c.json({ rows: dtos });
+    // ^ Task 4 adds an inline WHY comment here documenting why this path
+    //   does NOT call enrichFeedDtos (DeletedEventsPanel compact render).
+  } catch (err) {
+    return mapErr(c, err, "GET /api/events/deleted");
+  }
+});
+```
+
+From src/routes/games/[gameId]/+page.server.ts:74 (per-game view):
+```typescript
+const eventDtos = await mapEventsToDtos(userId, events);
+// Task 4 inserts the enrichment loop here.
+```
+
+From src/lib/sources/registry.ts (the cross-source iteration point — already exists, no edits needed):
+```typescript
+export const allAdapters: DataSourceAdapter[] = Array.from(registry.values());
+```
+
+From src/lib/sources/youtube/server/adapter.ts (the Core type — Task 2 extends this):
+```typescript
+type YoutubeChannelAdapterCore = Pick<
+  DataSourceAdapter,
+  | "kind"
+  | "pollContent"
+  | "pollStats"
+  | "pollStatsByVideoId"
+  | "parseUrl"
+  | "observability"
+  | "canRefreshPoll"
+  // Task 2 adds: | "enrichFeedDtos"
+>;
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: widen DataSourceAdapter with enrichFeedDtos contract method</name>
+  <files>
+    src/lib/sources/adapter.ts
+  </files>
+  <read_first>
+    - .planning/phases/03.0.3-youtube-feed-fixes/03.0.3-CONTEXT.md (decisions D-A1, D-B1 step 1 — the contract method spec)
+    - .planning/phases/03.0.1-source-plugin-architecture/03.0.1-CONTEXT.md (D-01 Thick adapter scope — context for why this method goes on the cross-source interface and not on a YouTube-internal-only export)
+    - src/lib/sources/adapter.ts (current shape — locate where existing methods are declared; new method goes alongside `fetchPollStateMap` / `registerRoutes` at the end of the interface, NOT alongside the legacy poll methods)
+    - src/lib/server/dto.ts (verify `EventDto` type already has optional `stats` + `channelTitle` fields; if not, add them — but per Phase 03.0 post-build the fields should already exist)
+  </read_first>
+  <action>
+    Add `enrichFeedDtos?` to the `DataSourceAdapter` interface in `src/lib/sources/adapter.ts`. Place at the end of the interface (after `registerRoutes?` is the last entry pre-Phase-03.0.3). Verbatim jsdoc + signature:
+
+    ```typescript
+    /**
+     * Phase 03.0.3 P2 (D-A1) — enrich the supplied feed DTOs in-place with
+     * adapter-specific data (stats, channel/author metadata, anything that
+     * lives in per-kind metadata tables and renders on FeedCard).
+     *
+     * Cross-source callsites (/feed loader, GET /api/events, /games/[id])
+     * iterate allAdapters and call this method per adapter. The adapter
+     * MUST filter internally to its own kind(s) — callers do NOT pre-filter
+     * (avoids the "did I forget to filter for adapter X?" footgun).
+     *
+     * Mutates `dtos` in place; returns void. Errors are swallowed by the
+     * adapter (logged at WARN); a failed enrichment query MUST NOT break
+     * the feed render — the cards just render without the enrichment.
+     *
+     * Future adapters (Reddit / Twitter / Telegram / Discord) implement this
+     * against their own metadata tables. Adapters that have no enrichment
+     * can omit the method entirely (optional via `?:`); the caller's
+     * `if (adapter.enrichFeedDtos)` gate skips undefined methods.
+     *
+     * Deliberately NOT called from GET /api/events/deleted — DeletedEventsPanel
+     * renders a compact KindIcon + strikethrough-title view that needs none
+     * of the enrichment data. See events.ts:374 for the load-bearing skip
+     * comment.
+     */
+    enrichFeedDtos?(userId: string, dtos: EventDto[]): Promise<void>;
+    ```
+
+    Required import — `EventDto` is defined in `src/lib/server/dto.ts`, but `adapter.ts` lives in `src/lib/sources/` (a cross-source-but-not-server location). Pre-Phase-03.0.3 the adapter interface uses types defined locally (RawEvent, StatsSnapshot, etc.) and avoids dependency on server-only modules. EventDto is server-side (it's projected by dto.ts which lives under src/lib/server/). To preserve the layering invariant, define a lightweight type alias OR import via type-only import.
+
+    Preferred shape — add a type-only import at the top of adapter.ts:
+    ```typescript
+    import type { EventDto } from "$lib/server/dto.js";
+    ```
+
+    Sanity-check the layering: the existing `AdapterPollState` interface is consumed by `dto.ts`'s `overlayPollStateOnEvents` (Phase 03.0.1 D-22); adapter.ts already crosses the boundary in the opposite direction. The type-only import is non-load-bearing at runtime; it preserves modularity without forcing a circular module dependency.
+
+    Verify the import resolves by running `pnpm tsc --noEmit` after the edit — TypeScript will surface any module-resolution issue.
+
+    Commit (intermediate):
+    ```
+    git add src/lib/sources/adapter.ts
+    git commit -m "fix(03.0.3): widen DataSourceAdapter with enrichFeedDtos contract method"
+    ```
+  </action>
+  <verify>
+    <automated>grep -c "enrichFeedDtos" src/lib/sources/adapter.ts</automated>
+    <automated>pnpm tsc --noEmit</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -n "enrichFeedDtos?" src/lib/sources/adapter.ts` returns ≥1 line with the optional method declaration.
+    - `grep -n "enrichFeedDtos?(userId: string, dtos: EventDto\\[\\]): Promise<void>" src/lib/sources/adapter.ts` returns 1 line — exact signature.
+    - `grep -c "EventDto" src/lib/sources/adapter.ts` returns ≥2 (type-only import + signature reference).
+    - `grep -c "D-A1" src/lib/sources/adapter.ts` returns ≥1 (decision-ID traceability).
+    - `grep -c "DeletedEventsPanel" src/lib/sources/adapter.ts` returns ≥1 (jsdoc references the deliberate skip).
+    - `pnpm tsc --noEmit` exits 0.
+    - `git log --oneline -n 1` shows commit message starting `fix(03.0.3): widen DataSourceAdapter`.
+  </acceptance_criteria>
+  <done>
+    The cross-source interface carries the new contract method; TypeScript compile passes; intermediate commit landed.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: YouTube adapter implementation in feed-enrichment.ts + barrel composition</name>
+  <files>
+    src/lib/sources/youtube/server/feed-enrichment.ts (new)
+    src/lib/sources/youtube/server/adapter.ts
+    src/lib/sources/youtube/server/index.ts
+  </files>
+  <read_first>
+    - .planning/phases/03.0.3-youtube-feed-fixes/03.0.3-CONTEXT.md (D-A1, D-B1 step 2, "Code that the phase modifies" — feed-enrichment.ts file-name pre-committed in STATE.md per CONTEXT canonical-refs §Roadmap context)
+    - src/routes/feed/+page.server.ts (lines 162-237 — the inline JOIN to copy into the new file verbatim)
+    - src/lib/sources/youtube/server/adapter.ts (the Core type — extend the `Pick<...>` with `"enrichFeedDtos"`)
+    - src/lib/sources/youtube/server/index.ts (the barrel — locate where existing methods are composed; new method joins the existing spread+override pattern)
+    - src/lib/server/db/schema/index.ts (verify `youtubeVideoSnapshots` and `youtubeVideos` export paths)
+    - src/lib/server/dto.ts (locate `EventDto.stats` and `EventDto.channelTitle` field types — must match the shape the new helper writes)
+    - AGENTS.md "default to no comments" — the new file gets jsdoc + sparse inline comments; only WHY a future reader cannot derive
+  </read_first>
+  <action>
+    Step 1 — Create `src/lib/sources/youtube/server/feed-enrichment.ts`. Move the JOIN logic from `/feed/+page.server.ts:162-237` (Task 3 will delete the source). Implementation:
+
+    ```typescript
+    // YouTube feed enrichment — Phase 03.0.3 P2 (D-A1).
+    //
+    // Implements DataSourceAdapter.enrichFeedDtos for the youtube_channel
+    // adapter. Internally filters dtos to kind=youtube_video; ignores other
+    // kinds (caller does NOT pre-filter — Phase 03.0.3 D-A1 contract).
+    //
+    // Two batched queries:
+    //   1. youtube_video_snapshots — DISTINCT ON videoId ORDER BY polledAt DESC.
+    //      Gets latest snapshot per video for stats (view/like/comment).
+    //   2. youtube_videos — SELECT channelTitle by videoId IN (...). Gets
+    //      the channel chip name (populated by channel-context-backfill OR
+    //      backfill-channel's youtube_videos UPSERT).
+    //
+    // Both tables are public-data (no userId scope) — already in ESLint
+    // tenant-scope allowlist. The tenant guarantee comes from the upstream
+    // events SELECT (mapEventsToDtos returns userId-scoped rows); this
+    // helper only touches video-keyed metadata.
+    //
+    // Failure mode: errors are caught + logged at WARN; the cards render
+    // without the enrichment instead of breaking the feed.
+
+    import { inArray, sql } from "drizzle-orm";
+    import { db } from "$lib/server/db/client.js";
+    import {
+      youtubeVideoSnapshots,
+      youtubeVideos,
+    } from "$lib/server/db/schema/index.js";
+    import { logger } from "$lib/server/logger.js";
+    import type { EventDto } from "$lib/server/dto.js";
+
+    export async function youtubeEnrichFeedDtos(
+      _userId: string,
+      dtos: EventDto[],
+    ): Promise<void> {
+      const youtubeExternalIds = dtos
+        .filter((r) => r.kind === "youtube_video" && r.externalId !== null)
+        .map((r) => r.externalId as string);
+      if (youtubeExternalIds.length === 0) return;
+
+      try {
+        // 1. Latest-snapshot lookup. ORDER BY videoId, polledAt DESC; pick
+        //    first row per videoId.
+        const snapshots = await db
+          .select({
+            videoId: youtubeVideoSnapshots.videoId,
+            polledAt: youtubeVideoSnapshots.polledAt,
+            viewCount: youtubeVideoSnapshots.viewCount,
+            likeCount: youtubeVideoSnapshots.likeCount,
+            commentCount: youtubeVideoSnapshots.commentCount,
+          })
+          .from(youtubeVideoSnapshots)
+          .where(inArray(youtubeVideoSnapshots.videoId, youtubeExternalIds))
+          .orderBy(
+            youtubeVideoSnapshots.videoId,
+            sql`${youtubeVideoSnapshots.polledAt} DESC`,
+          );
+        const latest = new Map<
+          string,
+          { viewCount: number; likeCount: number; commentCount: number; polledAt: Date }
+        >();
+        for (const s of snapshots) {
+          if (!latest.has(s.videoId)) {
+            latest.set(s.videoId, {
+              viewCount: s.viewCount ?? 0,
+              likeCount: s.likeCount ?? 0,
+              commentCount: s.commentCount ?? 0,
+              polledAt: s.polledAt,
+            });
+          }
+        }
+
+        // 2. ChannelTitle lookup from youtube_videos cache.
+        const videoChannels = await db
+          .select({
+            videoId: youtubeVideos.videoId,
+            channelTitle: youtubeVideos.channelTitle,
+          })
+          .from(youtubeVideos)
+          .where(inArray(youtubeVideos.videoId, youtubeExternalIds));
+        const titleByVideo = new Map<string, string | null>();
+        for (const v of videoChannels) titleByVideo.set(v.videoId, v.channelTitle);
+
+        // 3. In-place mutation. Iterate dtos (not just the filtered subset)
+        //    so the index matches the caller's expectation; skip non-YouTube
+        //    rows defensively.
+        for (const r of dtos) {
+          if (r.kind !== "youtube_video" || r.externalId === null) continue;
+          r.stats = latest.get(r.externalId) ?? null;
+          r.channelTitle = titleByVideo.get(r.externalId) ?? null;
+        }
+      } catch (err) {
+        // D-A1 — failure is non-fatal. Log and return; the feed still
+        // renders, just without the enrichment.
+        logger.warn(
+          { err: String((err as Error)?.message ?? err), count: youtubeExternalIds.length },
+          "youtube.enrichFeedDtos: query failed; feed renders without enrichment",
+        );
+      }
+    }
+    ```
+
+    Step 2 — Extend the `YoutubeChannelAdapterCore` `Pick<...>` in `src/lib/sources/youtube/server/adapter.ts` (line ~98) to include `"enrichFeedDtos"`:
+    ```typescript
+    type YoutubeChannelAdapterCore = Pick<
+      DataSourceAdapter,
+      | "kind"
+      | "pollContent"
+      | "pollStats"
+      | "pollStatsByVideoId"
+      | "parseUrl"
+      | "observability"
+      | "canRefreshPoll"
+      | "enrichFeedDtos"
+    >;
+    ```
+
+    Then attach the impl to the Core object at the bottom of `src/lib/sources/youtube/server/adapter.ts` (line ~540 where the existing `canRefreshPoll` lives — add a new entry alongside):
+    ```typescript
+    import { youtubeEnrichFeedDtos } from "./feed-enrichment.js";
+
+    export const youtubeChannelAdapterCore: YoutubeChannelAdapterCore = {
+      // ... existing entries ...
+      canRefreshPoll: (eventKind: EventKind): boolean => eventKind === "youtube_video",
+      // NEW:
+      enrichFeedDtos: youtubeEnrichFeedDtos,
+    };
+    ```
+
+    Step 3 — Verify the barrel at `src/lib/sources/youtube/server/index.ts` propagates the new method into the exported `youtubeAdapter`. The barrel currently spreads `youtubeChannelAdapterCore` and overrides infrastructure methods (registerQueues, scheduleCronTicks, backfillSource). Spreading already includes `enrichFeedDtos` automatically — no extra edit needed. Sanity-check by reading the barrel and confirming the spread happens before the explicit overrides.
+
+    Step 4 — Commit (intermediate):
+    ```
+    git add src/lib/sources/youtube/server/feed-enrichment.ts src/lib/sources/youtube/server/adapter.ts src/lib/sources/youtube/server/index.ts
+    git commit -m "fix(03.0.3): YouTube adapter implements enrichFeedDtos"
+    ```
+  </action>
+  <verify>
+    <automated>grep -c "youtubeEnrichFeedDtos" src/lib/sources/youtube/server/feed-enrichment.ts</automated>
+    <automated>pnpm tsc --noEmit</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -n "export async function youtubeEnrichFeedDtos" src/lib/sources/youtube/server/feed-enrichment.ts` returns 1 line with the exact function signature.
+    - `grep -c "kind === \"youtube_video\"" src/lib/sources/youtube/server/feed-enrichment.ts` returns ≥2 (internal filter + defensive iteration check).
+    - `grep -c "youtubeVideoSnapshots" src/lib/sources/youtube/server/feed-enrichment.ts` returns ≥2 (schema import + query).
+    - `grep -c "youtubeVideos" src/lib/sources/youtube/server/feed-enrichment.ts` returns ≥2 (schema import + channelTitle query).
+    - `grep -c "userId" src/lib/sources/youtube/server/feed-enrichment.ts` returns ≥1 (parameter name preserved — D-A1 signature `enrichFeedDtos(userId, dtos)`; the underscore-prefixed `_userId` is fine because YouTube's enrichment doesn't need userId — events were already userId-scoped upstream).
+    - `grep -c "enrichFeedDtos" src/lib/sources/youtube/server/adapter.ts` returns ≥2 (Pick<...> + attachment).
+    - `grep -c "youtubeEnrichFeedDtos" src/lib/sources/youtube/server/adapter.ts` returns ≥2 (import + attachment).
+    - `pnpm tsc --noEmit` exits 0.
+    - `git log --oneline -n 1` shows commit message starting `fix(03.0.3): YouTube adapter implements`.
+  </acceptance_criteria>
+  <done>
+    YouTube has a working enrichFeedDtos impl in its plugin folder; the barrel exposes it via the spread; TypeScript compile passes; intermediate commit landed.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 3: replace inline JOIN in /feed/+page.server.ts with adapter loop</name>
+  <files>
+    src/routes/feed/+page.server.ts
+  </files>
+  <read_first>
+    - .planning/phases/03.0.3-youtube-feed-fixes/03.0.3-CONTEXT.md (D-A1, D-#29-8 — the three callsites; D-B1 step 3)
+    - src/routes/feed/+page.server.ts (lines 162-237 — the inline JOIN block to delete; line 152-155 is the mapEventsToDtos call; line 218 onward is the source-DTO enrichment which is a DIFFERENT enrichment and stays — see action step 2)
+    - src/lib/sources/registry.ts (allAdapters export — the iteration target)
+    - src/lib/sources/youtube/server/feed-enrichment.ts (the new helper from Task 2 — the destination)
+    - tests/integration/feed.test.ts (SSR feed tests must still pass after the refactor)
+  </read_first>
+  <action>
+    Step 1 — Replace lines 157-216 of `src/routes/feed/+page.server.ts` (the entire inline-JOIN block that starts at the comment "Phase 3.0 post-build (UAT 2026-05-06): attach the latest YouTube stats snapshot..." and ends at the closing `}` of the surrounding `if (youtubeExternalIds.length > 0) { ... }` block).
+
+    Old block (lines 157-216 approx — confirm exact bounds with grep before editing):
+    ```typescript
+    // Phase 3.0 post-build (UAT 2026-05-06): attach the latest YouTube stats
+    // snapshot to each youtube_video event in the feed...
+    const youtubeExternalIds = rowDtos.filter(...).map(...);
+    if (youtubeExternalIds.length > 0) {
+      const snapshots = await db.select(...).from(youtubeVideoSnapshots)...;
+      // ... build latest Map ...
+      // ... mutate rowDtos.stats ...
+      // Phase 03.0.1 (post-review UAT 2026-05-10) — channelTitle for ALL ...
+      const videoChannels = await db.select(...).from(youtubeVideos)...;
+      // ... mutate rowDtos.channelTitle ...
+    }
+    ```
+
+    Replace with the adapter loop:
+    ```typescript
+    // Phase 03.0.3 P2 — adapter-driven feed enrichment. Iterates allAdapters
+    // and lets each one mutate the dtos in place. YouTube enriches
+    // kind=youtube_video rows with stats + channelTitle; future Reddit /
+    // Twitter / Telegram / Discord adapters enrich their own kinds from
+    // per-platform metadata tables. Replaces the inline JOIN that lived
+    // here pre-Phase-03.0.3 — that path enriched only the SSR first batch,
+    // leaving GET /api/events cursor pagination + /games/[id] curated views
+    // unenriched (issue #29 Part 2). Now all three callsites share the
+    // same loop.
+    for (const adapter of allAdapters) {
+      if (adapter.enrichFeedDtos) {
+        await adapter.enrichFeedDtos(userId, rowDtos);
+      }
+    }
+    ```
+
+    Step 2 — Add the `allAdapters` import at the top of the file (next to existing `$lib/server/*` imports):
+    ```typescript
+    import { allAdapters } from "$lib/sources/registry.js";
+    ```
+
+    Step 3 — IMPORTANT: do NOT touch the source-DTO enrichment block at lines ~218-237 (the block starting "Phase 3.0 post-build: enrich source DTOs with the YouTube channel_title from cache..."). That code populates `sourceDtos[i].channelTitle` (the source row's display name on /sources page) — a SEPARATE concern from event-DTO enrichment. Leave it untouched. It will move to an adapter method in a future Phase 03.x phase if needed; out of scope for #29.
+
+    Step 4 — Remove the now-unused imports `youtubeVideoSnapshots` and `youtubeVideos` from the top of the file — these were used by the old inline block and are no longer needed. Keep `youtubeChannels` because the source-DTO enrichment block at lines 218-237 still uses it.
+
+    Step 5 — Commit (intermediate):
+    ```
+    git add src/routes/feed/+page.server.ts
+    git commit -m "fix(03.0.3): /feed SSR uses adapter.enrichFeedDtos loop"
+    ```
+  </action>
+  <verify>
+    <automated>pnpm tsc --noEmit</automated>
+    <automated>pnpm test tests/integration/feed.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -c "for (const adapter of allAdapters)" src/routes/feed/+page.server.ts` returns ≥1 (the adapter loop).
+    - `grep -c "adapter.enrichFeedDtos" src/routes/feed/+page.server.ts` returns ≥1.
+    - `grep -c "youtubeVideoSnapshots" src/routes/feed/+page.server.ts` returns 0 (old inline JOIN imports gone).
+    - `grep -c "DISTINCT ON" src/routes/feed/+page.server.ts` returns 0 (old inline JOIN gone).
+    - `grep -c "youtubeChannels" src/routes/feed/+page.server.ts` returns ≥1 (the OTHER source-DTO enrichment block at lines 218-237 — still uses this import for sources page channelTitle).
+    - `pnpm tsc --noEmit` exits 0.
+    - `pnpm test tests/integration/feed.test.ts` exits 0 (SSR feed test still passes — same data shape, just via the adapter loop).
+    - `git log --oneline -n 1` shows commit message starting `fix(03.0.3): /feed SSR uses adapter.enrichFeedDtos`.
+  </acceptance_criteria>
+  <done>
+    /feed SSR loader uses the adapter loop; old inline JOIN removed; existing feed.test.ts still passes; intermediate commit landed.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 4: wire enrichFeedDtos into GET /api/events + /games/[id]; document /api/events/deleted skip</name>
+  <files>
+    src/lib/server/http/routes/events.ts
+    src/routes/games/[gameId]/+page.server.ts
+  </files>
+  <read_first>
+    - .planning/phases/03.0.3-youtube-feed-fixes/03.0.3-CONTEXT.md (decisions D-A1, D-#29-8, D-B1 step 3 + step 4 — the three callsites + deliberate-skip rationale)
+    - src/lib/server/http/routes/events.ts (lines 325-339 — GET /api/events handler; lines 371-388 — GET /api/events/deleted handler)
+    - src/routes/games/[gameId]/+page.server.ts (line 74 — eventDtos assignment)
+    - src/lib/sources/registry.ts (allAdapters export)
+    - AGENTS.md "default to no comments" — the inline WHY comment at events.ts:374 is the second of the two load-bearing WHY comments in Phase 03.0.3 (alongside updateSource lazy-deep-walk from Plan 01)
+  </read_first>
+  <action>
+    Step 1 — Edit `src/lib/server/http/routes/events.ts`. Add the `allAdapters` import at the top:
+    ```typescript
+    import { allAdapters } from "$lib/sources/registry.js";
+    ```
+
+    Find the GET /api/events handler (line ~325). Current:
+    ```typescript
+    const dtos = await mapEventsToDtos(c.var.userId, page.rows);
+    return c.json({
+      rows: dtos,
+      nextCursor: page.nextCursor,
+    });
+    ```
+
+    Insert the adapter loop between `mapEventsToDtos` and `c.json`:
+    ```typescript
+    const dtos = await mapEventsToDtos(c.var.userId, page.rows);
+    // Phase 03.0.3 P2 — adapter-driven feed enrichment. Same loop as the
+    // /feed SSR loader; closes issue #29 Part 2 (cursor-paginated batches
+    // pre-fix dropped stats + channelTitle on every card past the first
+    // SSR batch).
+    for (const adapter of allAdapters) {
+      if (adapter.enrichFeedDtos) {
+        await adapter.enrichFeedDtos(c.var.userId, dtos);
+      }
+    }
+    return c.json({
+      rows: dtos,
+      nextCursor: page.nextCursor,
+    });
+    ```
+
+    Step 2 — Find the GET /api/events/deleted handler (line ~374). Add the deliberate-skip WHY comment (D-B1 step 4 — load-bearing WHY per AGENTS.md). Current:
+    ```typescript
+    eventsRoutes.get("/events/deleted", async (c) => {
+      try {
+        const rows = await listDeletedEvents(c.var.userId);
+        const dtos = await mapEventsToDtos(c.var.userId, rows);
+        return c.json({ rows: dtos });
+      } catch (err) {
+        return mapErr(c, err, "GET /api/events/deleted");
+      }
+    });
+    ```
+
+    Becomes:
+    ```typescript
+    eventsRoutes.get("/events/deleted", async (c) => {
+      try {
+        const rows = await listDeletedEvents(c.var.userId);
+        const dtos = await mapEventsToDtos(c.var.userId, rows);
+        // Phase 03.0.3 P2 — deliberately NOT calling adapter.enrichFeedDtos
+        // here. DeletedEventsPanel.svelte (`src/lib/components/DeletedEventsPanel.svelte`)
+        // renders soft-deleted events with a compact KindIcon + strikethrough-
+        // title view — no stats line, no channel chip. Running the enrichment
+        // query would be wasted I/O. If a future redesign of DeletedEventsPanel
+        // adds the stats/channel chips back, add the same `for-of allAdapters`
+        // loop the GET /api/events handler uses (see ~25 lines up).
+        return c.json({ rows: dtos });
+      } catch (err) {
+        return mapErr(c, err, "GET /api/events/deleted");
+      }
+    });
+    ```
+
+    Step 3 — Edit `src/routes/games/[gameId]/+page.server.ts`. Add the `allAdapters` import:
+    ```typescript
+    import { allAdapters } from "$lib/sources/registry.js";
+    ```
+
+    Find line ~74 (`const eventDtos = await mapEventsToDtos(userId, events);`). Insert the adapter loop after:
+    ```typescript
+    const eventDtos = await mapEventsToDtos(userId, events);
+    // Phase 03.0.3 P2 — adapter-driven feed enrichment for the per-game
+    // curated view. Same loop as /feed SSR + GET /api/events.
+    for (const adapter of allAdapters) {
+      if (adapter.enrichFeedDtos) {
+        await adapter.enrichFeedDtos(userId, eventDtos);
+      }
+    }
+    ```
+
+    Step 4 — Commit (intermediate):
+    ```
+    git add src/lib/server/http/routes/events.ts src/routes/games/[gameId]/+page.server.ts
+    git commit -m "fix(03.0.3): wire enrichFeedDtos into GET /api/events + per-game view"
+    ```
+  </action>
+  <verify>
+    <automated>pnpm tsc --noEmit</automated>
+    <automated>pnpm test tests/integration/feed.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -c "adapter.enrichFeedDtos" src/lib/server/http/routes/events.ts` returns ≥1 (the GET /api/events insertion).
+    - `grep -c "DeletedEventsPanel" src/lib/server/http/routes/events.ts` returns ≥1 (the load-bearing skip comment).
+    - `grep -c "for (const adapter of allAdapters)" src/lib/server/http/routes/events.ts` returns ≥1.
+    - `grep -A 5 "GET /api/events/deleted" src/lib/server/http/routes/events.ts | grep -c enrichFeedDtos` returns 0 (the deleted handler does NOT call enrichFeedDtos).
+    - `grep -c "deliberately NOT calling adapter.enrichFeedDtos" src/lib/server/http/routes/events.ts` returns ≥1 (verbatim WHY comment phrase).
+    - `grep -c "adapter.enrichFeedDtos" src/routes/games/\\[gameId\\]/+page.server.ts` returns ≥1.
+    - `grep -c "allAdapters" src/routes/games/\\[gameId\\]/+page.server.ts` returns ≥2 (import + iteration).
+    - `pnpm tsc --noEmit` exits 0.
+    - `pnpm test tests/integration/feed.test.ts` exits 0.
+    - `git log --oneline -n 1` shows commit message starting `fix(03.0.3): wire enrichFeedDtos`.
+  </acceptance_criteria>
+  <done>
+    Three callsites wired; deleted endpoint has the load-bearing WHY comment; TypeScript + existing tests pass; intermediate commit landed.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 5: tests/integration/feed-api-enrichment.test.ts — 2 behavioural tests live</name>
+  <files>
+    tests/integration/feed-api-enrichment.test.ts (new)
+  </files>
+  <read_first>
+    - .planning/phases/03.0.3-youtube-feed-fixes/03.0.3-CONTEXT.md (decision D-C2 — the test contract; "Specifics" §Acceptance criterion phrasing Part 2)
+    - tests/integration/feed.test.ts (existing SSR feed test patterns — fixture seeding, db cleanup, createApp() usage)
+    - tests/integration/api-sources-refresh-content.test.ts (Hono `createApp()` + auth-cookie attachment for authenticated API tests)
+    - tests/integration/helpers.ts (createTestUser / seedUserDirectly / session-cookie helpers)
+    - src/lib/sources/youtube/server/feed-enrichment.ts (the helper under test)
+    - src/lib/server/http/routes/events.ts (GET /api/events handler under test)
+    - src/lib/server/dto.ts (EventDto.stats + EventDto.channelTitle shapes — assertion targets)
+  </read_first>
+  <behavior>
+    Two behavioural tests:
+
+    **(1) GET /api/events with cursor pagination returns rows enriched with stats + channelTitle.**
+    Setup:
+      - Seed user U1.
+      - Seed a youtube_channel data_source for U1 (channelId="UC_test_1").
+      - Seed `youtube_videos` row for videoId="vid_test_1" with channelTitle="Test Channel".
+      - Seed `youtube_video_snapshots` row for videoId="vid_test_1" with viewCount=1234, likeCount=56, commentCount=7, polledAt=now.
+      - Seed an `events` row for U1 with kind="youtube_video", externalId="vid_test_1", sourceId=<seeded source.id>.
+    Action:
+      - Authenticate as U1 (session cookie via createApp + login helper).
+      - GET `/api/events?cursor=<some-cursor>` (or `?cursor=` empty to get the first page — same path through the handler).
+    Assert:
+      - Response status 200.
+      - Response.body.rows has 1 entry.
+      - `rows[0].stats === { viewCount: 1234, likeCount: 56, commentCount: 7, polledAt: <ISO date string> }`.
+      - `rows[0].channelTitle === "Test Channel"`.
+
+    **(2) GET /api/events/deleted does NOT carry the enrichment.**
+    Setup:
+      - Seed U1 + youtube data_source + youtube_videos + youtube_video_snapshots as in test (1).
+      - Soft-delete the events row (`UPDATE events SET deleted_at = now() WHERE id = ...`) so it lives in the deleted view.
+    Action:
+      - GET `/api/events/deleted` as U1.
+    Assert:
+      - Response status 200.
+      - Response.body.rows has 1 entry.
+      - `rows[0].stats === undefined OR null` (NOT the enriched object — the deleted endpoint deliberately skipped enrichment).
+      - `rows[0].channelTitle === undefined OR null`.
+  </behavior>
+  <action>
+    Create `tests/integration/feed-api-enrichment.test.ts` with the 2 live tests above. Use the same vi.mock + dynamic-import scaffold as `api-sources-refresh-content.test.ts` (queue-client mock not strictly needed for these tests — no enqueue happens — but keep the dynamic-import pattern for consistency).
+
+    Boilerplate:
+    ```typescript
+    import { describe, it, expect, beforeEach } from "vitest";
+    import { eq, sql } from "drizzle-orm";
+
+    const { db } = await import("../../src/lib/server/db/client.js");
+    const { dataSources } = await import("../../src/lib/server/db/schema/data-sources.js");
+    const { events } = await import("../../src/lib/server/db/schema/events.js");
+    const { youtubeVideos, youtubeVideoSnapshots } = await import(
+      "../../src/lib/server/db/schema/index.js"
+    );
+    const { createApp } = await import("../../src/lib/server/http/app.js");
+    const { createSource } = await import("../../src/lib/server/services/data-sources.js");
+    const { seedUserDirectly, signInDirectly } = await import("./helpers.js");
+
+    describe("feed-api-enrichment", () => {
+      beforeEach(async () => {
+        // Clean only the rows this test touches — see api-sources-refresh-content.test.ts.
+        await db.delete(events);
+        await db.delete(youtubeVideoSnapshots);
+        await db.delete(youtubeVideos);
+        await db.delete(dataSources);
+      });
+
+      it("(1) GET /api/events returns rows with stats + channelTitle", async () => {
+        const u1 = await seedUserDirectly("u1+enrich@test.local");
+        const source = await createSource(
+          u1.id,
+          {
+            kind: "youtube_channel",
+            handleUrl: "https://www.youtube.com/channel/UC_test_1",
+            isOwnedByMe: true,
+            autoImport: false,
+          },
+          "127.0.0.1",
+        );
+
+        await db.insert(youtubeVideos).values({
+          videoId: "vid_test_1",
+          title: "Test video",
+          channelId: "UC_test_1",
+          channelTitle: "Test Channel",
+          publishedAt: new Date(),
+          fetchedAt: new Date(),
+        });
+        await db.insert(youtubeVideoSnapshots).values({
+          videoId: "vid_test_1",
+          polledAt: new Date(),
+          viewCount: 1234,
+          likeCount: 56,
+          commentCount: 7,
+        });
+        await db.insert(events).values({
+          userId: u1.id,
+          sourceId: source.id,
+          kind: "youtube_video",
+          authorIsMe: true,
+          occurredAt: new Date(),
+          title: "Test video",
+          url: "https://www.youtube.com/watch?v=vid_test_1",
+          externalId: "vid_test_1",
+        });
+
+        const app = await createApp();
+        const cookie = await signInDirectly(app, u1.id);
+
+        const resp = await app.request("/api/events", {
+          headers: { cookie },
+        });
+        expect(resp.status).toBe(200);
+        const body = (await resp.json()) as { rows: any[] };
+        expect(body.rows).toHaveLength(1);
+        expect(body.rows[0].stats).toMatchObject({
+          viewCount: 1234,
+          likeCount: 56,
+          commentCount: 7,
+        });
+        expect(body.rows[0].channelTitle).toBe("Test Channel");
+      });
+
+      it("(2) GET /api/events/deleted does NOT carry the enrichment", async () => {
+        const u1 = await seedUserDirectly("u1+deleted@test.local");
+        const source = await createSource(
+          u1.id,
+          {
+            kind: "youtube_channel",
+            handleUrl: "https://www.youtube.com/channel/UC_test_1",
+            isOwnedByMe: true,
+            autoImport: false,
+          },
+          "127.0.0.1",
+        );
+        await db.insert(youtubeVideos).values({
+          videoId: "vid_test_1",
+          title: "Test video",
+          channelId: "UC_test_1",
+          channelTitle: "Test Channel",
+          publishedAt: new Date(),
+          fetchedAt: new Date(),
+        });
+        await db.insert(youtubeVideoSnapshots).values({
+          videoId: "vid_test_1",
+          polledAt: new Date(),
+          viewCount: 1234,
+          likeCount: 56,
+          commentCount: 7,
+        });
+        await db.insert(events).values({
+          userId: u1.id,
+          sourceId: source.id,
+          kind: "youtube_video",
+          authorIsMe: true,
+          occurredAt: new Date(),
+          title: "Test video",
+          url: "https://www.youtube.com/watch?v=vid_test_1",
+          externalId: "vid_test_1",
+          deletedAt: new Date(),
+        });
+
+        const app = await createApp();
+        const cookie = await signInDirectly(app, u1.id);
+
+        const resp = await app.request("/api/events/deleted", {
+          headers: { cookie },
+        });
+        expect(resp.status).toBe(200);
+        const body = (await resp.json()) as { rows: any[] };
+        expect(body.rows).toHaveLength(1);
+        // Deliberate skip — DeletedEventsPanel renders compact view.
+        expect(body.rows[0].stats === undefined || body.rows[0].stats === null).toBe(true);
+        expect(body.rows[0].channelTitle === undefined || body.rows[0].channelTitle === null).toBe(true);
+      });
+    });
+    ```
+
+    Helper-fn names (`signInDirectly`, `seedUserDirectly`) — check `tests/integration/helpers.ts` for the actual exports; replace with the real names if these don't exist. The pattern from `api-sources-refresh-content.test.ts` is the load-bearing reference.
+
+    Commit (intermediate):
+    ```
+    git add tests/integration/feed-api-enrichment.test.ts
+    git commit -m "test(03.0.3): feed-api-enrichment.test.ts — 2 behavioural assertions live"
+    ```
+  </action>
+  <verify>
+    <automated>pnpm test tests/integration/feed-api-enrichment.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - `pnpm test tests/integration/feed-api-enrichment.test.ts` exits 0 with 2 tests passing.
+    - `grep -c "stats" tests/integration/feed-api-enrichment.test.ts` returns ≥3 (test (1) assertion + test (2) negative assertion + setup).
+    - `grep -c "channelTitle" tests/integration/feed-api-enrichment.test.ts` returns ≥3.
+    - `grep -c "GET /api/events/deleted" tests/integration/feed-api-enrichment.test.ts` returns ≥1 (test (2) describes the deliberate-skip path).
+    - `grep -c "viewCount: 1234" tests/integration/feed-api-enrichment.test.ts` returns ≥2 (seeded + asserted).
+    - `pnpm test tests/integration/feed.test.ts` exits 0 (no regression).
+    - `git log --oneline -n 1` shows commit message starting `test(03.0.3):`.
+  </acceptance_criteria>
+  <done>
+    2 live behavioural tests pass — enrichment-on-API + skip-on-deleted invariants locked in; intermediate commit landed.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 6: SOURCE-REFERENCE.md — Feed enrichment pattern section + Phase 03.0.3 wrap-up commit</name>
+  <files>
+    SOURCE-REFERENCE.md
+  </files>
+  <read_first>
+    - .planning/phases/03.0.3-youtube-feed-fixes/03.0.3-CONTEXT.md (decision D-A3 — both new sections; D-D2 §rollout)
+    - SOURCE-REFERENCE.md (locate the §"Incremental-vs-deep-walk pattern" section added by Plan 01 Task 6 — the new "Feed enrichment pattern" section goes immediately AFTER that one, preserving chronological ordering)
+    - src/lib/sources/adapter.ts (the new contract method — the reference signature in the doc)
+    - src/lib/sources/youtube/server/feed-enrichment.ts (the reference implementation in the doc)
+  </read_first>
+  <action>
+    Append a new section to `SOURCE-REFERENCE.md` immediately after §"Incremental-vs-deep-walk pattern" (added by Plan 01). The new section documents the feed-enrichment pattern for future adapter authors:
+
+    ```markdown
+    ## Feed enrichment pattern
+
+    *Established in Phase 03.0.3 P2 for YouTube; copy-the-pattern for Reddit / Twitter / Telegram / Discord adapters in Phase 03.1+.*
+
+    Adapters that have per-event metadata worth showing on `FeedCard` (stats, channel/author chips, embedded media, etc.) implement the optional `enrichFeedDtos` method on `DataSourceAdapter`:
+
+    ```typescript
+    interface DataSourceAdapter {
+      // ... other methods ...
+      enrichFeedDtos?(userId: string, dtos: EventDto[]): Promise<void>;
+    }
+    ```
+
+    Contract:
+      - The method MUST internally filter `dtos` to its own `kind` — callers do NOT pre-filter. Avoids the "did I forget to filter for adapter X?" footgun.
+      - The method MUTATES `dtos` in place; returns void.
+      - The method MUST swallow errors (log at WARN). A failed enrichment query MUST NOT break the feed render — the cards just render without the enrichment.
+      - The method MAY make multiple DB queries (YouTube makes 2: one for `youtube_video_snapshots` latest-per-videoId, one for `youtube_videos.channelTitle`). Batch by `IN (...)` over the externalIds extracted from filtered dtos.
+
+    Three cross-source callsites iterate `allAdapters` and call this method:
+      - `src/routes/feed/+page.server.ts` — SSR for the primary `/feed` view
+      - `src/lib/server/http/routes/events.ts` — `GET /api/events` cursor pagination
+      - `src/routes/games/[gameId]/+page.server.ts` — per-game curated view
+
+    Deliberate skip:
+      - `GET /api/events/deleted` (events.ts:374) does NOT call `enrichFeedDtos`. `DeletedEventsPanel.svelte` renders soft-deleted events with a compact KindIcon + strikethrough-title view — no stats line, no channel chip. The skip is documented inline with a load-bearing WHY comment at the call site.
+
+    Reference implementation: YouTube — `src/lib/sources/youtube/server/feed-enrichment.ts`. The Phase 03.0.3 P2 commit replaced the inline JOIN in `/feed/+page.server.ts:162-237` with a single adapter loop that all three callsites share.
+    ```
+
+    Step 2 — Commit (intermediate — this is the last commit before the squash-merge PR):
+    ```
+    git add SOURCE-REFERENCE.md
+    git commit -m "docs(03.0.3): document feed enrichment pattern in SOURCE-REFERENCE.md"
+    ```
+
+    Step 3 — Final wrap-up: produce the Phase 03.0.3 summary by writing `.planning/phases/03.0.3-youtube-feed-fixes/03.0.3-02-SUMMARY.md` (covered by `<output>` block below; do NOT commit this as a separate file unless a phase wrap-up commit is part of the workflow — defer to execute-plan.md's standard SUMMARY pattern).
+  </action>
+  <verify>
+    <automated>grep -c "Feed enrichment pattern" SOURCE-REFERENCE.md</automated>
+    <automated>grep -c "Incremental-vs-deep-walk pattern" SOURCE-REFERENCE.md</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -c "Feed enrichment pattern" SOURCE-REFERENCE.md` returns ≥1.
+    - `grep -c "Incremental-vs-deep-walk pattern" SOURCE-REFERENCE.md` returns ≥1 (Plan 01's section still present — no conflict).
+    - `grep -c "enrichFeedDtos" SOURCE-REFERENCE.md` returns ≥3 (signature + 3 callsite description + skip mention).
+    - `grep -c "DeletedEventsPanel" SOURCE-REFERENCE.md` returns ≥1 (deliberate-skip narrative).
+    - `grep -c "feed-enrichment.ts" SOURCE-REFERENCE.md` returns ≥1 (reference implementation pointer).
+    - `git log --oneline -n 1` shows commit message starting `docs(03.0.3): document feed enrichment`.
+    - `git log --oneline | head -12` shows the full chain of Phase 03.0.3 intermediate commits (6 from Plan 01 + 6 from this plan = 12 total) with `fix(03.0.3)` / `test(03.0.3)` / `docs(03.0.3)` scopes.
+  </acceptance_criteria>
+  <done>
+    SOURCE-REFERENCE.md documents both Phase 03.0.3 patterns; intermediate commit landed; branch ready for squash-merge PR.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+End-of-plan verification (all must pass before declaring Plan 02 done):
+
+1. `pnpm tsc --noEmit` exits 0.
+2. `pnpm test tests/integration/feed-api-enrichment.test.ts` exits 0 with 2 tests passing.
+3. `pnpm test tests/integration/feed.test.ts` exits 0 (SSR feed test still passes — same data shape via adapter loop).
+4. `pnpm test tests/integration/refresh-content-quota.test.ts` exits 0 (Plan 01's tests still pass — Plan 02 doesn't touch backfill-channel).
+5. `pnpm test tests/integration/api-sources-refresh-content.test.ts` exits 0.
+6. Full integration suite: `pnpm test:integration` exits 0.
+7. `pnpm lint` exits 0.
+8. `grep -c "enrichFeedDtos" src/lib/sources/adapter.ts` returns ≥1 (interface widened).
+9. `grep -c "enrichFeedDtos" src/lib/sources/youtube/server/feed-enrichment.ts` returns ≥1 (YouTube impl).
+10. `grep -rn "DeletedEventsPanel" src/lib/server/http/routes/events.ts` returns ≥1 (load-bearing WHY comment).
+11. `git log --oneline | head -12` shows the full chain of intermediate commits across Plan 01 + Plan 02.
+
+Manual verification (post-merge, on prod): operator scrolls `/feed` past the SSR first batch into cursor-paginated batches. Expected: every YouTube card shows view/like/comment counts + channel chip. Pre-fix: cards above the fold show stats; cards below show nothing. This is the "every YouTube card on /feed shows view/like/comment line and channel chip, regardless of which batch it came from" promise from CONTEXT §Specifics.
+
+Per-game curated view at `/games/[gameId]` shows the same enrichment.
+
+`/audit` view (DeletedEventsPanel render path) continues to show the compact strikethrough-title rendering — no stats/channel chips. The skip is honored.
+
+CI gate: GitHub Actions `unit-integration` + `smoke` jobs pass on the PR.
+
+Self-review per AGENTS.md "Validation" §1-5:
+  - Constraints compliance: no new `process.env` reads outside `src/lib/server/config/env.ts`; no new at-rest secrets; no SaaS/self-host divergence; no migrations.
+  - Philosophy compliance: simplicity for outsider (feed-enrichment.ts file + jsdoc explain the WHY + adapter contract jsdoc is the canonical reference); SaaS/self-host parity (no APP_MODE branches); modularity (YouTube impl lives inside the YouTube plugin folder; cross-source code calls it via the contract method, never imports the file directly); no premature abstraction (`enrichFeedDtos` is an optional method — adapters without enrichment omit it; pays its way today because YouTube needs it AND because Reddit will need it in 03.1); security floor (events queries upstream are userId-scoped via mapEventsToDtos; new enrichment queries hit public-data tables already in the ESLint tenant-scope allowlist).
+  - Practices compliance: atomic PRs (6 intermediate commits in this plan; one squash PR at end of Part 1 + Part 2 — total 12 intermediate commits across the phase); tests land with feature; no migrations; env reads centralized; secrets redaction unbroken; default no comments (TWO load-bearing WHY comments: updateSource lazy-deep-walk from Plan 01 + /api/events/deleted skip from this plan — both per CONTEXT and AGENTS.md guidance).
+
+Squash-merge PR: at the end of Plan 02, the branch `feat/phase-03.0.3-youtube-feed-fixes` has 12 intermediate commits. Open ONE PR to master with title `fix(03.0.3): YouTube refresh-content quota burn + feed enrichment in GET /api/events (#29)`. Body includes:
+  - Issue link (`Closes #29`)
+  - Self-review section per AGENTS.md "Validation" — Constraints / Philosophy / Practices / CI / Documentation walks
+  - Self-review (second pass) section after running a separate-agent review
+  - Test plan: 5 integration test files + manual UAT on prod (8-channel click + cursor-paginated /feed scroll)
+
+PR is squash-merged; branch auto-deleted by repo settings; master gains ONE clean commit for Phase 03.0.3.
+</verification>
+
+<success_criteria>
+Plan 02 success when:
+- `DataSourceAdapter.enrichFeedDtos` is on the interface in `src/lib/sources/adapter.ts` (D-A1).
+- YouTube implements `enrichFeedDtos` in `src/lib/sources/youtube/server/feed-enrichment.ts` with internal kind=youtube_video filtering (D-A1 + D-B1 step 2).
+- Three callsites (/feed SSR, GET /api/events, /games/[gameId]) call `for-of allAdapters + adapter.enrichFeedDtos` (D-#29-8 + D-B1 step 3).
+- GET /api/events/deleted deliberately does NOT call enrichFeedDtos and carries the load-bearing WHY comment referencing DeletedEventsPanel (D-B1 step 4).
+- 2 live behavioural tests in `tests/integration/feed-api-enrichment.test.ts` pass (D-C2).
+- SOURCE-REFERENCE.md §"Feed enrichment pattern" exists alongside Plan 01's §"Incremental-vs-deep-walk pattern" (D-A3).
+- All existing integration tests still pass (feed, api-sources-refresh-content, refresh-content-quota).
+- 6 intermediate commits land on `feat/phase-03.0.3-youtube-feed-fixes` with `fix(03.0.3)` / `test(03.0.3)` / `docs(03.0.3)` scopes.
+- The branch has 12 total intermediate commits across Phase 03.0.3 (6 from Plan 01 + 6 from Plan 02) ready for ONE squash-merge PR.
+- Visual invariant locked in: every YouTube card on /feed shows view/like/comment line and channel chip, regardless of whether it came from SSR or API cursor pagination (issue #29 acceptance criterion).
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/03.0.3-youtube-feed-fixes/03.0.3-02-SUMMARY.md` documenting:
+- What landed (3-bullet summary: adapter interface widened, YouTube impl in feed-enrichment.ts, 3 callsites wired with /api/events/deleted deliberate skip)
+- Files modified (full list from frontmatter)
+- Test results (2 new behavioural tests in feed-api-enrichment.test.ts passing + existing tests preserved)
+- Branch + commit hashes (6 intermediate commits from this plan — `fix(03.0.3): ...` × 4, `test(03.0.3): ...` × 1, `docs(03.0.3): ...` × 1; total across phase = 12)
+- Decision-ID traceability table (D-A1 / D-A3 / D-B1 step 1-6 / D-C2 / D-#29-8) → file:line citations
+- Visual invariant validation (SSR first batch + cursor-paginated batches now visually consistent on /feed; per-game view enriched; DeletedEventsPanel compact rendering preserved)
+- Hand-off note: branch is ready for ONE squash-merge PR. PR title: `fix(03.0.3): YouTube refresh-content quota burn + feed enrichment in GET /api/events (#29)`. Body must include the AGENTS.md Self-review (incl. second pass) section. Phase verdict pending VALIDATION.md UAT walkthrough (post-merge, on prod or staging).
+</output>

--- a/.planning/phases/03.0.3-youtube-feed-fixes/03.0.3-02-SUMMARY.md
+++ b/.planning/phases/03.0.3-youtube-feed-fixes/03.0.3-02-SUMMARY.md
@@ -1,0 +1,203 @@
+---
+phase: 03.0.3-youtube-feed-fixes
+plan: 02
+subsystem: youtube-feed-enrichment
+tags: [youtube, feed, adapter-driven, drizzle, integration-tests, dto-projection]
+
+requires:
+  - phase: 03.0.1-source-plugin-architecture
+    provides: "Thick DataSourceAdapter contract (D-01); allAdapters registry iterator; per-source plugin folder layout"
+  - plan: 03.0.3-01
+    provides: "Phase 03.0.3 branch + SOURCE-REFERENCE.md §10; intermediate commit chain — sequencing guard only (no code-level dependency)"
+provides:
+  - "DataSourceAdapter.enrichFeedDtos(userId, dtos) cross-source contract method — optional, mutates dtos in place"
+  - "YouTube reference impl in src/lib/sources/youtube/server/feed-enrichment.ts (snapshot + channelTitle batched lookups)"
+  - "Three callsites (/feed SSR, GET /api/events, /games/[gameId]) now share the same enrichment loop"
+  - "GET /api/events/deleted carries the load-bearing deliberate-skip WHY comment referencing DeletedEventsPanel"
+  - "SOURCE-REFERENCE.md §11 documents the pattern for Phase 03.1+ Reddit/Twitter/Telegram/Discord adapters"
+affects:
+  - "phase 03.1 (Reddit adapter): drops in enrichFeedDtos against reddit_posts metadata table; zero callsite edits required"
+  - "phase 03.0.3 issue #29 acceptance: cursor-paginated /feed batches + per-game view now show stats + channelTitle on every YouTube card"
+
+tech-stack:
+  added: []  # no new dependencies; pure refactor + contract widening + tests
+  patterns:
+    - "Adapter-driven feed enrichment via optional contract method + cross-source allAdapters loop"
+    - "Default-null DTO projection: toEventDto sets stats=null; adapters mutate to populated values; deletedEvents path skips mutation"
+    - "Load-bearing WHY comments at deliberate-skip sites (DeletedEventsPanel inline comment is the second of two Phase 03.0.3 such comments)"
+
+key-files:
+  created:
+    - "src/lib/sources/youtube/server/feed-enrichment.ts"
+    - "tests/integration/feed-api-enrichment.test.ts"
+    - ".planning/phases/03.0.3-youtube-feed-fixes/03.0.3-02-SUMMARY.md"
+  modified:
+    - "src/lib/sources/adapter.ts (enrichFeedDtos? optional method + EventDto type-only import)"
+    - "src/lib/sources/youtube/server/adapter.ts (YoutubeChannelAdapterCore Pick widened with enrichFeedDtos; impl attached)"
+    - "src/routes/feed/+page.server.ts (inline JOIN deleted; allAdapters loop)"
+    - "src/lib/server/http/routes/events.ts (GET /api/events wires loop; GET /api/events/deleted carries load-bearing WHY)"
+    - "src/routes/games/[gameId]/+page.server.ts (allAdapters loop after mapEventsToDtos)"
+    - "SOURCE-REFERENCE.md (new §11 Feed enrichment pattern)"
+    - ".planning/phases/03.0.3-youtube-feed-fixes/deferred-items.md (3rd entry: .dev-oauth-mock.mjs pre-existing lint failure)"
+
+key-decisions:
+  - "D-A1: enrichFeedDtos lives on DataSourceAdapter as an optional method; cross-source code iterates allAdapters and checks `if (adapter.enrichFeedDtos)` before calling. Adapters without enrichment omit the method entirely."
+  - "Type-only import of EventDto into adapter.ts preserves the layering boundary (adapter.ts lives in src/lib/sources/, EventDto in src/lib/server/dto.ts). TypeScript erases at runtime; no circular module dependency."
+  - "YouTube impl in feed-enrichment.ts uses `_userId` underscore-prefixed because events are already userId-scoped upstream by mapEventsToDtos; youtube_videos + youtube_video_snapshots are public-data tables (already in ESLint tenant-scope allowlist)."
+  - "Barrel composition in index.ts is unchanged — the existing `...youtubeChannelAdapterCore` spread on line 708 propagates enrichFeedDtos to the exported youtubeAdapter without a new explicit override."
+  - "/api/events/deleted carries an inline WHY comment (load-bearing per AGENTS.md 'default to no comments') — second of two such comments in Phase 03.0.3 (alongside Plan 01's updateSource lazy-deep-walk reference)."
+
+requirements-completed: []
+
+duration: ~15 min
+completed: 2026-05-11
+---
+
+# Phase 03.0.3 Plan 02: Feed enrichment in GET /api/events Summary
+
+**Adapter-driven `enrichFeedDtos` contract method routes feed enrichment through three callsites — closing the issue #29 Part 2 invariant that YouTube view/like/comment counts + channel chip must render on every `/feed` card regardless of whether it came from SSR or cursor-paginated API batch.**
+
+## Performance
+
+- **Duration:** ~15 min
+- **Tasks:** 6
+- **Files modified:** 8 (3 new, 5 changed)
+- **Completed:** 2026-05-11
+
+## Accomplishments
+
+- `DataSourceAdapter` widened with optional `enrichFeedDtos?(userId, dtos): Promise<void>` contract method (D-A1) — type-only import of `EventDto` preserves the cross-layer boundary.
+- YouTube reference impl in `src/lib/sources/youtube/server/feed-enrichment.ts` — two batched lookups (snapshot DISTINCT-ON per videoId + youtube_videos.channelTitle); internal kind=youtube_video filter; non-fatal failure mode (logs WARN, returns).
+- `/feed/+page.server.ts` SSR loader replaces the inline JOIN at lines 157-216 (pre-fix) with a single `for (const adapter of allAdapters) await adapter.enrichFeedDtos(userId, rowDtos)` loop.
+- `GET /api/events` in `src/lib/server/http/routes/events.ts` inserts the same loop between `mapEventsToDtos` and `c.json` — closes the cursor-pagination gap that issue #29 Part 2 surfaced.
+- `/games/[gameId]/+page.server.ts` inserts the same loop after `mapEventsToDtos`; per-game curated view now matches /feed enrichment.
+- `GET /api/events/deleted` deliberately retains the un-enriched DTO list and carries a load-bearing WHY comment referencing `DeletedEventsPanel.svelte`.
+- 2 live behavioural tests in `tests/integration/feed-api-enrichment.test.ts` lock both invariants (positive enrichment on /api/events; deliberate skip on /api/events/deleted).
+- SOURCE-REFERENCE.md gains §11 "Feed enrichment pattern" alongside Plan 01's §10 "Incremental-vs-deep-walk pattern".
+
+## Task Commits
+
+Each task was committed atomically on `feat/phase-03.0.3-youtube-feed-fixes`:
+
+1. **Task 1: widen DataSourceAdapter with enrichFeedDtos contract method** — `658df1e` (fix)
+2. **Task 2: YouTube adapter implements enrichFeedDtos** — `453702d` (fix)
+3. **Task 3: /feed SSR uses adapter.enrichFeedDtos loop** — `5f2f824` (fix)
+4. **Task 4: wire enrichFeedDtos into GET /api/events + per-game view** — `0130d93` (fix)
+5. **Task 5: feed-api-enrichment.test.ts — 2 behavioural assertions live** — `d965682` (test)
+6. **Task 6: document feed enrichment pattern in SOURCE-REFERENCE.md** — `7167df4` (docs)
+
+Plan metadata commit lands separately at the end of plan execution (this SUMMARY + STATE.md + ROADMAP.md).
+
+## Files Created/Modified
+
+| File | Change |
+| ---- | ------ |
+| `src/lib/sources/adapter.ts` | MODIFIED — type-only `import type { EventDto }`; added optional `enrichFeedDtos?(userId, dtos)` to `DataSourceAdapter` |
+| `src/lib/sources/youtube/server/feed-enrichment.ts` | NEW — `youtubeEnrichFeedDtos` impl with two batched queries + non-fatal error path |
+| `src/lib/sources/youtube/server/adapter.ts` | MODIFIED — `YoutubeChannelAdapterCore` Pick<...> widened with `"enrichFeedDtos"`; impl attached on the Core object |
+| `src/lib/sources/youtube/server/index.ts` | UNCHANGED — existing `...youtubeChannelAdapterCore` spread on line 708 propagates the new method automatically |
+| `src/routes/feed/+page.server.ts` | MODIFIED — inline JOIN block (lines 157-216) replaced with `for (const adapter of allAdapters)` loop; unused `youtubeVideoSnapshots` + `youtubeVideos` + `sql` imports trimmed; `allAdapters` import added |
+| `src/lib/server/http/routes/events.ts` | MODIFIED — `allAdapters` import; loop inserted between `mapEventsToDtos` and `c.json` on `GET /api/events`; load-bearing WHY comment on `GET /api/events/deleted` |
+| `src/routes/games/[gameId]/+page.server.ts` | MODIFIED — `allAdapters` import; loop inserted after `mapEventsToDtos(userId, events)` |
+| `tests/integration/feed-api-enrichment.test.ts` | NEW — 2 behavioural tests (positive enrichment on /api/events; negative on /api/events/deleted) |
+| `SOURCE-REFERENCE.md` | MODIFIED — new §11 "Feed enrichment pattern" appended after §10 |
+| `.planning/phases/03.0.3-youtube-feed-fixes/deferred-items.md` | MODIFIED — 3rd entry: `.dev-oauth-mock.mjs` pre-existing lint failure (untracked dev helper, out of plan scope) |
+
+## Decision-ID Traceability
+
+| Decision | Where landed |
+| -------- | ------------ |
+| D-A1 (enrichFeedDtos on DataSourceAdapter) | `src/lib/sources/adapter.ts` jsdoc + signature |
+| D-A1 (cross-source callsite contract) | `src/routes/feed/+page.server.ts`, `src/lib/server/http/routes/events.ts`, `src/routes/games/[gameId]/+page.server.ts` |
+| D-A3 (SOURCE-REFERENCE.md §"Feed enrichment pattern") | `SOURCE-REFERENCE.md` §11 |
+| D-B1 step 1 (interface widening) | `src/lib/sources/adapter.ts` (the `enrichFeedDtos?` method) |
+| D-B1 step 2 (YouTube impl in feed-enrichment.ts) | `src/lib/sources/youtube/server/feed-enrichment.ts` |
+| D-B1 step 3 (three callsites wired) | feed loader + GET /api/events + games[id] |
+| D-B1 step 4 (deliberate skip on /api/events/deleted) | `src/lib/server/http/routes/events.ts:374-388` inline WHY |
+| D-B1 step 5 (feed-api-enrichment.test.ts — 2 behavioural tests) | `tests/integration/feed-api-enrichment.test.ts` |
+| D-B1 step 6 (SOURCE-REFERENCE.md §Feed enrichment pattern) | `SOURCE-REFERENCE.md` §11 |
+| D-C2 (Part 2 tests in feed-api-enrichment.test.ts) | `tests/integration/feed-api-enrichment.test.ts` (2 tests pass) |
+| D-#29-8 (three callsites for enrichFeedDtos) | three loops + `for-of allAdapters` |
+
+## Visual Invariant Validation
+
+Pre-fix (issue #29 Part 2): SSR first batch on `/feed` shows YouTube view/like/comment counts + channel chip; subsequent cursor-paginated batches via `GET /api/events?cursor=...` drop both. Visually inconsistent feed.
+
+Post-fix (locked by 2 behavioural tests in `feed-api-enrichment.test.ts`):
+- `GET /api/events` returns rows with `stats={viewCount, likeCount, commentCount, polledAt}` + `channelTitle` populated for every kind=youtube_video row that has a matching `youtube_video_snapshots` + `youtube_videos` cache entry.
+- `GET /api/events/deleted` returns rows with `stats=null` / `channelTitle=undefined` — DeletedEventsPanel's compact view honors the deliberate skip.
+- `/games/[gameId]` per-game curated view enriches via the same loop.
+
+Manual UAT (deferred to VALIDATION.md, post-merge): operator scrolls `/feed` past the SSR first batch into cursor-paginated batches. Every YouTube card shows view/like/comment line + channel chip, regardless of which batch produced it.
+
+## Test Results
+
+- `tests/integration/feed-api-enrichment.test.ts` — 2 / 2 passing.
+- `tests/integration/refresh-content-quota.test.ts` (Plan 01 invariants) — 3 / 3 passing.
+- `tests/integration/api-sources-refresh-content.test.ts` (baseline) — 9 / 9 passing.
+- `pnpm tsc --noEmit` — exits 0.
+- `pnpm eslint` on Plan 02 modified files — exits 0.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+None — Plan 02 executed exactly as written. The plan's "barrel propagation via spread" prediction (Task 2 step 3) held: the existing `...youtubeChannelAdapterCore` spread in `src/lib/sources/youtube/server/index.ts:708` propagates `enrichFeedDtos` to the exported `youtubeAdapter` without an explicit override.
+
+### Scope-Boundary Discoveries (deferred)
+
+**1. [Out of scope] `.dev-oauth-mock.mjs` lint failure (process.env reads outside config/env.ts)**
+- **Found during:** End-of-plan `pnpm lint` run.
+- **Issue:** ESLint flags `.dev-oauth-mock.mjs` lines 9/10/11 for `process.env` reads (PITFALL P2 mitigation).
+- **Why not fixed:** File is **untracked** in the working copy (visible in `git status` at session start; never committed to master). Outside Plan 02's scope (which touches adapter + feed enrichment). Logged to `.planning/phases/03.0.3-youtube-feed-fixes/deferred-items.md` (3rd entry).
+- **Recommended follow-up:** Add `.dev-*.{mjs,ts}` to `.gitignore` / `.eslintignore` in a separate atomic PR, or delete the file if orphaned.
+
+### Pre-existing Failures (already documented in Plan 01's deferred-items)
+
+- `tests/integration/feed.test.ts` static-email collision — confirmed pre-existing via `git diff master..HEAD -- tests/integration/feed.test.ts` returning empty. Plan 02 did NOT touch this file.
+- `tests/integration/ingest-paste-then-poll.test.ts` handlePollActive TypeError — also pre-existing per Plan 01's verification.
+
+**Total deviations:** 0 auto-fixes; 1 scope-boundary log; 0 plan-spec corrections.
+**Impact on plan:** Plan 02 implementation matched PLAN.md verbatim; tests passed first run.
+
+## Issues Encountered
+
+- `pnpm lint` failure on `.dev-oauth-mock.mjs` (untracked file) — confirmed out of scope; logged to deferred-items.md. All Plan-02-modified files pass `pnpm eslint <files>` cleanly.
+
+## User Setup Required
+
+None — no external service configuration changed.
+
+## Next Phase Readiness
+
+- Branch `feat/phase-03.0.3-youtube-feed-fixes` now has **12 intermediate commits** ready for ONE squash-merge PR:
+  - Plan 01 (6 commits): `a8feb12`, `a97e524`, `ea6c6de`, `6064762`, `e2a931c`, `94523f2`, `6178d42` (Plan 01 metadata)
+  - Plan 02 (6 commits): `658df1e`, `453702d`, `5f2f824`, `0130d93`, `d965682`, `7167df4`
+- PR title (per CONTEXT D-B2): `fix(03.0.3): YouTube refresh-content quota burn + feed enrichment in GET /api/events (#29)`.
+- PR body MUST include the AGENTS.md Self-review section + second-pass review.
+- Phase verdict pending VALIDATION.md UAT walkthrough (post-merge, on prod or staging) — operator scrolls `/feed` past first SSR batch into cursor-paginated batches; verifies every YouTube card shows stats + channel chip.
+
+## Known Stubs
+
+None — Plan 02 wires real data through real adapter callsites; no UI stubs introduced.
+
+## Self-Check: PASSED
+
+Verified by file existence + commit hash + test results:
+- `src/lib/sources/youtube/server/feed-enrichment.ts` — FOUND
+- `tests/integration/feed-api-enrichment.test.ts` — FOUND
+- All 6 intermediate commits found in `git log feat/phase-03.0.3-youtube-feed-fixes`:
+  - `658df1e` — FOUND
+  - `453702d` — FOUND
+  - `5f2f824` — FOUND
+  - `0130d93` — FOUND
+  - `d965682` — FOUND
+  - `7167df4` — FOUND
+- Acceptance criteria greps pass: `enrichFeedDtos` in adapter.ts (≥1), feed-enrichment.ts (≥1); inline-JOIN gone from /feed (`DISTINCT ON` = 0, `youtubeVideoSnapshots` = 0); load-bearing WHY comment present on /api/events/deleted (`DeletedEventsPanel` ≥1; `deliberately NOT calling adapter.enrichFeedDtos` ≥1); SOURCE-REFERENCE.md §11 + §10 both present.
+- 14 of 14 tests pass across the 3-test-file suite (feed-api-enrichment + refresh-content-quota + api-sources-refresh-content).
+- `pnpm tsc --noEmit` exits 0.
+- ESLint passes on all Plan-02-modified files.
+
+---
+*Phase: 03.0.3-youtube-feed-fixes*
+*Completed: 2026-05-11*

--- a/.planning/phases/03.0.3-youtube-feed-fixes/03.0.3-CONTEXT.md
+++ b/.planning/phases/03.0.3-youtube-feed-fixes/03.0.3-CONTEXT.md
@@ -1,0 +1,230 @@
+# Phase 03.0.3: YouTube Feed Fixes - Context
+
+**Gathered:** 2026-05-11
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Fix two pre-existing YouTube feed gaps discovered during 03.0.2 manual testing — both tracked in issue #29. The phase delivers:
+
+1. **Part 1 — refresh-content quota fix.** `refresh-content` currently walks the full playlist on every click when `backfill_target_since` is epoch (admin / "all-history" users), burning ~110 units across 8 channels with zero new videos. The labelled `incremental` flow isn't implemented at the walker level (`since=backfillTargetSince` always). Fix: state-driven three-branch `since`-derivation using `MAX(youtube_videos.published_at) WHERE channel_id=?` as the `newestKnown` cursor, plus walk-outcome state writes in both `backfill-channel` and `channel-context-backfill` handlers, plus full removal of the now-obsolete `resetChannelBackfillComplete` belt-and-suspenders.
+
+2. **Part 2 — feed enrichment in `GET /api/events`.** SSR'd first batch on `/feed` shows YouTube view/like/comment counts + channelTitle chip; subsequent cursor-paginated batches don't, because the inline enrichment in `/feed/+page.server.ts:162-237` isn't applied to API responses. Fix: factor the enrichment into a `DataSourceAdapter.enrichFeedDtos(userId, dtos)` contract method (so future Reddit/Twitter adapters drop in without editing callsites) and call it from three callsites that render FeedCard.
+
+The phase reuses existing `data_source_channel_state` columns (`last_polled_at`, `backfill_oldest_at`, `backfill_complete`, `metadata.lastBackfillPageToken`) — **no schema migration**. No new user-facing feature beyond the bug fixes themselves. Behavioural identity for unrelated YouTube flows is preserved.
+
+The phase explicitly does NOT introduce: etag caching on `playlistItems.list`, `search.list?publishedAfter=...`, per-kind metadata tables for Reddit/Twitter/Telegram/Discord, UX for `429 requests_quota_exhausted`, surfacing stats on `/events/[id]` detail page (Phase 4 VIZ-01). All deferred per issue #29 "Out of scope".
+
+Tracked in: **issue #29**. Branch: `feat/phase-03.0.3-youtube-feed-fixes` (already exists).
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Adapter encapsulation (D-A1..D-A3) — D-01 Thick compliance
+
+- **D-A1:** **`enrichFeedDtos` becomes a method on the `DataSourceAdapter` contract.** Cross-source callsites (`/feed/+page.server.ts`, `GET /api/events`, `/games/[gameId]/+page.server.ts`) iterate `allAdapters` and call `adapter.enrichFeedDtos(userId, dtos)`. YouTube's implementation moves the existing inline JOINs from `/feed/+page.server.ts:162-237` into `src/lib/sources/youtube/server/feed-enrichment.ts`. Reddit/Twitter/Telegram/Discord adapters (Phase 3.1+) implement the same method against their own metadata tables; zero callsite edits required. Rationale: AGENTS.md philosophy #3 "extensibility through modules — existing modules don't grow horizontally to accommodate new features" + Phase 03.0.1 D-01 Thick adapter scope.
+
+- **D-A2:** **`getNewestKnownPublishedAt` is a YouTube-internal helper** in `src/lib/sources/youtube/server/` (file: `newest-known.ts` or inlined in `backfill-channel.ts` — Claude's discretion at execution). It is NOT on the adapter contract because there is exactly one caller today (`backfill-channel` handler) and that caller is itself YouTube-internal — no cross-source dispatch needed. Signature: `getNewestKnownPublishedAt(channelKey: string): Promise<Date | null>`. Reddit's Phase 3.1 adapter copies the pattern in its own package against `reddit_posts.created_at`; SOURCE-REFERENCE.md documents the "newest-known cursor" pattern.
+
+- **D-A3:** **SOURCE-REFERENCE.md gets two new pattern sections** in Phase 03.0.3's PLAN updates:
+  - "Feed enrichment pattern" — `adapter.enrichFeedDtos(userId, dtos)` contract method, called from cross-source callsites
+  - "Incremental-vs-deep-walk pattern" — `getNewestKnownPublishedAt` cursor + three-branch `since`-derivation (`exhausted` / `target >= deepestWalked` / deep walk)
+
+### Plan granularity (D-B1, D-B2)
+
+- **D-B1:** **Two PLAN.md files**:
+  - **`03.0.3-01-PLAN.md` — Part 1 quota fix.** Scope:
+    1. `getNewestKnownPublishedAt` helper (YouTube-internal)
+    2. Three-branch `since`-derivation in `backfill-channel` handler (`exhausted` / `target >= deepestWalked` incremental / deep-walk default)
+    3. `lastBackfillPageToken` cleared when since-derivation lands in either incremental branch
+    4. `channel-context-backfill` writes `backfill_complete`, `backfill_oldest_at`, `lastBackfillPageToken` per `stopReason` (`no_more_pages` / `hard_cap` / `cutoff_crossed`) — eliminates the typical onboarding double-walk
+    5. Full removal of `resetChannelBackfillComplete` (call + function + import + brief comment in `updateSource` referencing the lazy deep-walk path)
+    6. `tests/integration/refresh-content-quota.test.ts` — 3 behavioural tests from #29 (repeated click ≤1 page, backdated upload collected, window expansion triggers deep walk)
+    7. `SOURCE-REFERENCE.md` — "Incremental-vs-deep-walk pattern" section
+
+  - **`03.0.3-02-PLAN.md` — Part 2 enrichment.** Scope:
+    1. Widen `DataSourceAdapter` interface with `enrichFeedDtos(userId, dtos): Promise<void>` method (mutates dtos in place; matches existing inline style)
+    2. YouTube adapter implementation in `src/lib/sources/youtube/server/feed-enrichment.ts` — JOIN `youtube_video_snapshots` (DISTINCT-ON latest per videoId) + JOIN `youtube_videos` for `channelTitle`. Internal filtering to `kind === "youtube_video"`.
+    3. Update three callsites: `/feed/+page.server.ts` (remove inline JOIN, call `for (adapter of allAdapters) adapter.enrichFeedDtos(...)`), `GET /api/events` (`src/lib/server/http/routes/events.ts:330`), `/games/[gameId]/+page.server.ts` (`+page.server.ts:74`)
+    4. `GET /api/events/deleted` (`events.ts:374`) explicitly NOT updated — `DeletedEventsPanel` renders compact view without stats/channel chips. Add inline comment documenting the deliberate skip.
+    5. `tests/integration/feed-api-enrichment.test.ts` — seeded event with one snapshot → `GET /api/events?cursor=...` returns row with `stats.viewCount > 0` and `channelTitle` set
+    6. `SOURCE-REFERENCE.md` — "Feed enrichment pattern" section
+
+- **D-B2:** **One PR to master, squash-merge** (memory rule + AGENTS.md). Branch `feat/phase-03.0.3-youtube-feed-fixes` carries N intermediate commits (≥2 from D-B1); final squash-merge collapses to one master commit. Conventional Commits scope: `fix(03.0.3): ...` for both intermediate commits and final PR title.
+
+### Test placement (D-C1, D-C2)
+
+- **D-C1:** **Part 1 tests live in new file** `tests/integration/refresh-content-quota.test.ts`. Naming follows #29's suggestion + project convention "one test file = one behavioural invariant area". Covers 3 behavioural tests verbatim from #29: (a) repeated click within 5 min costs ≤1 page not N/50 pages; (b) backdated upload after newestKnown is collected; (c) window expansion via `PATCH /api/sources/:id { backfillTargetSince: epoch }` triggers deep walk on next refresh.
+
+- **D-C2:** **Part 2 tests live in new file** `tests/integration/feed-api-enrichment.test.ts`. Single file covering the GET /api/events enrichment invariant (seeded snapshot → returned dto carries `stats` and `channelTitle`). Also asserts `GET /api/events/deleted` does NOT carry the enrichment (the deliberate skip from D-B1 step 4).
+
+### Cleanup + rollout (D-D1, D-D2)
+
+- **D-D1:** **Full cleanup of `resetChannelBackfillComplete`.** Delete: (a) the call at `src/lib/server/http/routes/sources.ts:390-392`, (b) the function definition in `src/lib/server/services/channel-state.ts:137-149`, (c) the import in `sources.ts:34`. Add a short comment in `data-sources.ts` `updateSource` (near line 586) noting that widening `backfillTargetSince` is handled lazily by the new since-derivation (no eager reset needed). Rationale: AGENTS.md "If unused, delete it completely" + "no half-finished implementations" + "default to no comments" (so the explanatory comment in `updateSource` is the WHY a future reader cannot derive from the code).
+
+- **D-D2:** **No pre-deploy snapshot of `data_source_channel_state`.** Fix doesn't migrate schema; worst case (channels with `backfill_complete=false AND backfill_oldest_at=NULL` from pre-fix context-backfill flows) falls into the deep-walk branch on first post-deploy click — identical behavior to pre-fix. Manual UAT in VALIDATION.md (8-channel `/sources` "Pull new content" click → ≤8 quota units burned) verifies the fix end-to-end. If UAT fails, the rollback path is `git revert` of the squash commit + redeploy.
+
+### Canonical design from issue #29 — locked, do not re-litigate at planning time
+
+- **D-#29-1:** **Cursor choice** — use `MAX(youtube_videos.published_at) WHERE channel_id=?` ("newest known publishedAt") instead of `last_polled_at`. Catches backdated uploads correctly because `walkedPastSince` fires only on videos older than the newest collected video, which is the right semantic.
+
+- **D-#29-2:** **Three-branch `since`-derivation** in `backfill-channel` handler, applies to BOTH `ctx.origin === "user"` AND `ctx.origin === "cron"` paths (no origin-gated branch):
+  - `backfill_complete=true` (exhausted) → `since = max(newestKnown, target)` — steady state
+  - `!exhausted && deepestWalked !== null && target >= deepestWalked` → `since = max(newestKnown, target)` — partial walk, target shallower than depth → routine incremental
+  - else → `since = target` — three sub-cases collapse here (no prior walk; target deeper than recorded depth; channel onboarded via context-backfill with hard-cap)
+
+- **D-#29-3:** **`lastBackfillPageToken` clearing rule** — when since-derivation lands in either incremental branch, clear the token via `setChannelBackfillPageToken(kind, channelKey, null)` BEFORE invoking `adapter.pollContent`. Deep-walk branch preserves the token for resume. Without this, page-N-deeper-than-since causes `walkedPastSince` to fire immediately with zero events on branch transitions.
+
+- **D-#29-4:** **Walk-outcome state writes — `backfill-channel` walker** (existing behavior preserved):
+  - `endOfPlaylist=true`: `markChannelLastPolledAt` + `markChannelBackfillFrontier(MIN)` + `markChannelBackfillComplete` + `setChannelBackfillPageToken(null)`
+  - `walkedPastSince=true`: `markChannelLastPolledAt` + `markChannelBackfillFrontier(MIN(since))` + token cleared by existing handler logic
+  - `MAX_PAGES`: `markChannelLastPolledAt` + `markChannelBackfillFrontier(MIN)` + token saved (existing)
+
+- **D-#29-5:** **Walk-outcome state writes — `channel-context-backfill` handler** (NEW — eliminates onboarding double-walk):
+  - `stopReason="no_more_pages"` (endOfPlaylist): `backfill_oldest_at = MIN(oldest seen)` + `backfill_complete=true` + `lastBackfillPageToken=null`
+  - `stopReason="hard_cap"` (>1000-video channel, MAX_PAGES=20 hit): `backfill_oldest_at = oldest seen` + `backfill_complete=false` + `lastBackfillPageToken = nextPageToken from page 20`
+  - `stopReason="cutoff_crossed"` (window like 30d, fewer than 1000 videos newer than cutoff): `backfill_oldest_at = cutoff` + `backfill_complete=false` + `lastBackfillPageToken=null`
+
+- **D-#29-6:** **`updateSource` widening — no eager reset.** When user widens `backfillTargetSince` (e.g. 30d → epoch), no immediate action is taken. The next refresh-content click (or cron tick) sees `target < deepestWalked` (or pops out of `exhausted=true` because target is now deeper) and triggers the deep walk lazily. Implemented as code comment only — no code change in `updateSource` beyond the comment.
+
+- **D-#29-7:** **Multi-tenant target conflict** — `backfill_complete=true` does NOT block narrower-target users. The check uses the **triggering user's target**, so user A with `target=30d-ago` clicking refresh after user B's deep walk to epoch correctly lands in the steady-state branch (1-page walk). Multi-tenant interleaving documented as-is in the test fixtures (no separate test, covered by the window-expansion test which exercises target-deeper-than-deepestWalked).
+
+- **D-#29-8:** **Three callsites for `enrichFeedDtos`** (Part 2):
+  - `/feed/+page.server.ts` — SSR `/feed` page (inline enrichment moves into helper)
+  - `src/lib/server/http/routes/events.ts:330` — `GET /api/events` cursor pagination
+  - `/games/[gameId]/+page.server.ts:74` — per-game curated view
+
+  Explicit skip: `GET /api/events/deleted` (`events.ts:374`) — `DeletedEventsPanel.svelte` renders compact KindIcon + strikethrough title only; enrichment query would be wasted work.
+
+### Claude's Discretion
+
+- **File names inside YouTube plugin** — `feed-enrichment.ts` vs `enrichment.ts`, `newest-known.ts` vs inlined helper in `backfill-channel.ts`. Rule: one helper file per cohesive responsibility, name matches the purpose.
+- **Test fixture setup** — reuse existing `tests/integration/helpers.ts` patterns (e.g. `createTestUser`, `createTestSource`, seed `youtube_videos` + `youtube_video_snapshots`). Either ad-hoc inline seeding or factored helper — pick whichever Phase 03.0.1's tests already establish.
+- **Audit metadata for the new walk-outcomes** — the existing `writeBackfillAudit` already records `flow`, `requests_used`, `events_inserted`. No new audit fields needed; if a tester wants a `since_branch_taken` discriminator for forensics, add as `metadata.since_branch: "exhausted"|"incremental"|"deep"` — Claude decides at execution time.
+- **Comment density** — AGENTS.md "default to no comments". The `updateSource` lazy-deep-walk note (D-D1) and the `/api/events/deleted` deliberate-skip note (D-B1 step 4) are the two WHY comments that are load-bearing. Everything else: names should explain.
+- **Order of intermediate commits on the branch** — P1 first then P2, or P2 first then P1. P2 is simpler (factoring + 3 callsite edits + 1 test); P1 carries the quota-burn semantics. Default: P1 first (the higher-impact fix lands earlier and stabilizes before P2 piggybacks on the same branch). Either order is acceptable.
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Issue + design source of truth
+- **GitHub issue #29** — `youtube: incremental refresh burns quota AND API pagination drops stats — two YouTube feed gaps to fix together`. Contains the full Part 1 + Part 2 design (cursor choice, three-branch since-derivation, walk-outcome state-update tables, channel-context-backfill state additions, enrichFeedDtos helper signature, three callsites, acceptance criteria, test list, what-the-user-gets table). **The canonical design doc — do not re-derive at planning time.**
+
+### Project foundation
+- `.planning/PROJECT.md` §"Architecture" — `data_sources` + `events` + `youtube_videos` + `youtube_video_snapshots` abstractions, three-view IA, polling architecture
+- `.planning/REQUIREMENTS.md` — POLL-* / INGEST-* / EVENTS-* requirements covered by the polling pipeline
+- `AGENTS.md` — privacy invariants, philosophy (esp. "extensibility through modules", "no premature abstraction"), validation gates, practices (atomic PRs, one-branch-one-PR, Conventional Commits, default no comments)
+- `CLAUDE.md` — re-exports AGENTS.md as project rules
+
+### Phase 03.0 + 03.0.1 baseline (the implementation being patched)
+- `.planning/phases/03.0-polling-pipeline-plumbing-youtube/03.0-CONTEXT.md` — YouTube polling pipeline original design
+- `.planning/phases/03.0-polling-pipeline-plumbing-youtube/03.0-VERIFICATION.md` — what 03.0 delivered
+- `.planning/phases/03.0.1-source-plugin-architecture/03.0.1-CONTEXT.md` — D-01 Thick adapter, D-13 AdapterError taxonomy, D-14 canonical layout, D-16 phased migration
+- `.planning/phases/03.0.1-source-plugin-architecture/03.0.1-SOURCE-REFERENCE.md` (if exists) — the "how to add a new source" doc we extend in this phase
+
+### Code that the phase modifies
+- `src/lib/sources/adapter.ts` — `DataSourceAdapter` interface (Part 2 widens it with `enrichFeedDtos`)
+- `src/lib/sources/youtube/server/adapter.ts` — YouTube adapter (Part 2 adds `enrichFeedDtos` impl)
+- `src/lib/sources/youtube/server/index.ts` — adapter entry, `backfillSource` (Part 1 — currently passes `since=backfillTargetSince` unconditionally)
+- `src/lib/sources/youtube/server/handlers/backfill-channel.ts` — channel walker handler (Part 1 — three-branch since-derivation lives here, plus token-clear-on-incremental rule)
+- `src/lib/sources/youtube/server/handlers/channel-context-backfill.ts` — onboarding context backfill (Part 1 — adds state writes per `stopReason`)
+- `src/lib/server/services/channel-state.ts` — channel state helpers (Part 1 — `resetChannelBackfillComplete` deleted)
+- `src/lib/server/services/data-sources.ts` — `updateSource` (Part 1 — adds comment, no code change)
+- `src/lib/server/http/routes/sources.ts:34, 390-392` — refresh-content endpoint (Part 1 — removes reset call + import)
+- `src/lib/server/http/routes/events.ts:330, 374` — GET /api/events + /events/deleted (Part 2 — call enrichFeedDtos on 330, skip on 374)
+- `src/routes/feed/+page.server.ts:162-237` — SSR enrichment (Part 2 — moves inline → adapter)
+- `src/routes/games/[gameId]/+page.server.ts:74` — per-game view (Part 2 — call enrichFeedDtos)
+
+### Existing tests to extend or reference
+- `tests/integration/api-sources-refresh-content.test.ts` — Phase 03.0.1 baseline (auth + tenant + cap); the new quota-burn behavior tests in this phase live in a separate file per D-C1
+- `tests/integration/auto-backfill-cron-picker.test.ts` — cron picker uses `backfill_complete=true` to skip exhausted channels; the new since-derivation interacts with this picker via the steady-state branch
+- `tests/integration/zero-quota-onboarding.test.ts` — channel-context-backfill seed flow; Part 1 step 4 (state writes by stopReason) extends this surface
+- `tests/integration/channel-state-helpers.test.ts` — channel-state.ts unit-ish tests; D-D1 removal of `resetChannelBackfillComplete` may delete a test or two here
+- `tests/integration/feed.test.ts` — SSR feed page tests; Part 2 doesn't change inline enrichment semantics so existing tests should still pass
+
+### Roadmap context
+- `.planning/ROADMAP.md` §"Phase 03.0.3" — phase narrative
+- `.planning/STATE.md` §"Roadmap Evolution" — Phase 03.0.3 insertion entry (2026-05-11) with branch + helper-name pre-commitments
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+
+- **`channel-state.ts` helpers** (`src/lib/server/services/channel-state.ts`) — `getChannelState`, `markChannelLastPolledAt`, `markChannelBackfillFrontier` (with deeper-only WHERE-guard), `markChannelBackfillComplete`, `setChannelBackfillPageToken`. All cross-tenant by design, kind-keyed. **Part 1 reuses every helper except `resetChannelBackfillComplete` (deleted in D-D1).**
+- **`DataSourceAdapter` interface** (`src/lib/sources/adapter.ts`) — already widened in Phase 03.0.1 with `observability`, `parseUrl`, `registerQueues`, `pollContent`, `pollStats`, etc. Part 2 adds one more method — `enrichFeedDtos(userId, dtos): Promise<void>` — following the existing dispatch pattern.
+- **`allAdapters` registry** (`src/lib/sources/registry.ts`) — already used by `src/worker/index.ts` to register queues per kind, by `src/scheduler/index.ts` for cron ticks, by URL parsing in `services/ingest.ts`. Part 2 reuses the same iteration pattern in three SvelteKit/Hono callsites.
+- **`youtube_videos` + `youtube_video_snapshots` tables** — the source of truth for `newestKnown` cursor (Part 1) and for `stats` enrichment (Part 2). Already populated by `backfill-channel`, `channel-context-backfill`, `poll-active`, `poll-cold` handlers.
+- **`writeBackfillAudit` + `writeAuditStrict`** — Part 1's audit metadata for the new since-branch is captured by extending the existing audit calls; no new audit infrastructure.
+
+### Established Patterns
+
+- **D-01 Thick adapter scope** (03.0.1 CONTEXT) — adapter fully self-contained, cross-source services never `switch (kind)`. Part 1 keeps newest-known YouTube-internal; Part 2 dispatches via `allAdapters` for cross-source enrichment.
+- **AdapterError taxonomy** (03.0.1 D-13) — `transient` / `rate-limited` / `not-found` / `permanent` / `operator-issue`. Part 1's worker handlers already catch and map; no new categories needed.
+- **WHERE-guarded UPDATE for monotonic state** (`markChannelBackfillFrontier` uses `setWhere` MIN guard) — pattern repeats for `backfill_oldest_at` from `channel-context-backfill` (D-#29-5 step 5). Reuse helper directly; no SQL duplication.
+- **Test placeholder pattern** (Phase 1 Wave 0) — new test files start with `it.skip` placeholders, flip to live tests as implementation lands. P1 and P2 each follow this pattern within their PLAN.md.
+- **Wave 0 test scaffolding** — new test files first, implementation second, in the same PLAN.md. Each PLAN.md commit is "tests + implementation" atomic.
+- **Branch-per-phase + one PR + squash-merge** (memory rule) — `feat/phase-03.0.3-youtube-feed-fixes` already exists; N intermediate commits → one PR → squash to one master commit.
+
+### Integration Points
+
+- **`src/lib/sources/adapter.ts`** — Part 2 widens the interface. Backward compatibility: every existing `DataSourceAdapter` implementation (only YouTube today) must implement the new method. If a future adapter doesn't need enrichment, its impl can be a no-op `return Promise.resolve()`.
+- **`src/lib/sources/registry.ts`** — no changes needed; Part 2's callsites iterate `allAdapters` (export already exists).
+- **`src/routes/feed/+page.server.ts:162-237`** — current inline enrichment moves into `src/lib/sources/youtube/server/feed-enrichment.ts`. The SvelteKit page becomes a thin caller of `adapter.enrichFeedDtos` (or `for-of-allAdapters` loop). Aside: the line range may shift slightly during P2 execution; treat 162-237 as approximate.
+- **`src/lib/server/http/routes/events.ts`** — `GET /api/events` (line ~330) calls `adapter.enrichFeedDtos` after `mapEventsToDtos`. `GET /api/events/deleted` (line ~374) deliberately doesn't. Inline comment documents the skip.
+- **`drizzle/` migrations** — no new migration. `data_source_channel_state` schema unchanged from Phase 03.0.1 P05 (channel-scoped split migration 0028).
+
+### Creative Options
+
+- **Internal filter vs explicit filter in `enrichFeedDtos`** — the YouTube impl can either internally filter `dtos.filter(d => d.kind === "youtube_video")` (the recommended pattern, so callsites don't pre-filter) or assume the caller pre-filters. Recommended: internal filter — keeps callsite code uniform across adapters, avoids the "did I forget to filter for adapter X?" footgun.
+- **Token-clear ordering vs since-derivation** — the rule is "clear token BEFORE pollContent if since-derivation landed in incremental branch". The cleanest implementation is a tiny `incrementalBranchTaken: boolean` flag set during the three-branch evaluation, used to gate the `setChannelBackfillPageToken(kind, channelKey, null)` call. Alternative: inline the SQL UPDATE. Flag approach is more readable.
+- **Where the `since`-branch discriminator lives in audit** — the existing `writeBackfillAudit` accepts a `metadata` JSON; adding `since_branch: "exhausted" | "incremental" | "deep"` is one line per branch. Useful for forensics if Part 1 regresses on prod. Per Claude's Discretion.
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- **Issue #29 is the design document.** It contains a `What the user gets after the fix` table that maps before/after for 4 user-visible behaviors (feed scroll, 8-channel click cost, button silently 429ing, cron sweep cost). VALIDATION.md should hit each row of that table as a manual UAT step.
+- **Acceptance criterion phrasing** — Part 1: "8-channel admin click burns ≤8 quota units (not 110)". Part 2: "every YouTube card on /feed shows view/like/comment line and channel chip, regardless of which batch it came from".
+- **Production observability** — admin can verify the fix post-deploy by clicking `/sources` → "Pull new content" on 8 channels and watching `/admin/quota` (per-user usage). Before: +110 over baseline. After: +8 (or less).
+- **No backward-compat shim** for `resetChannelBackfillComplete` — the function is internal to the application; no public API exposes it. Direct deletion is safe (D-D1).
+- **`channel-context-backfill` state writes are technically a behavior change for new sources** — pre-fix: `backfill_complete` stays false after context-backfill, leading to a redundant auto-backfill-cron walk at 3am Pacific. Post-fix: complete is set to true (when stopReason=no_more_pages), skipping the cron re-walk. This is the intended fix per #29 ("eliminates the typical onboarding double-walk"), not a regression.
+- **Multi-tenant safety** — D-#29-7 documents that one user's deep walk to epoch doesn't break another user's narrower-target refreshes. The test fixture should set up two subscribers with different `backfill_target_since` and verify both behaviors in the same DB.
+- **User explicitly used 8 channels under admin account on prod for repro.** Real-world quota burn was 110 units across 8 channels (avg ~13 pages per channel ≈ ~600+ videos per channel). The fix's per-channel cost drops to 1 page (50 items per page, fetched once via playlistItems.list = 1 unit). Manual UAT will hit this exact scenario on prod after deploy.
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- **etag caching on `playlistItems.list`** — would save the page fetch itself but needs a per-channel etag column + If-None-Match handling. Out of scope per #29 "Out of scope". Future Phase 6 quota-polish trigger if real-world load shows the 1-page-per-channel cost is still a bottleneck.
+- **`search.list?publishedAfter=...`** — worse approach (100 units per page vs `playlistItems.list`'s 1 unit). Not considered.
+- **Surfacing stats on `/events/[id]` detail page** — Phase 4 VIZ-01 (chart visualisation) already covers this. Out of scope per #29.
+- **UX for `429 requests_quota_exhausted`** — button silently does nothing today; deserves its own follow-up issue per #29 "Out of scope". File as a separate issue if it surfaces in post-deploy UAT.
+- **Per-kind metadata tables for Reddit / Twitter / Telegram / Discord** — adapters don't ship yet (Phase 3.1+). The `enrichFeedDtos` contract method is the integration point; per-adapter implementation comes when each kind lands.
+- **Continuation backfill (slow-drain history for large channels)** — already deferred via `.planning/todos/pending/2026-05-06-continuation-backfill-quota-reserve.md` from Phase 03.0.1. Not folded into 03.0.3.
+- **`backfill_complete=false` channels from pre-fix context-backfill** — will deep-walk once post-deploy then settle into incremental territory. No proactive backfill of state; lazy migration is acceptable per D-D2.
+- **"Deep re-walk" user button** — hypothetical future feature ("re-walk entire playlist from scratch"). The deleted `resetChannelBackfillComplete` would be its underlying primitive. If the feature ever lands, the function can be re-introduced; for now it's dead weight.
+
+### Reviewed Todos (not folded)
+
+- Cross-reference with phase-relevance scoring was not run (workflow `cross_reference_todos` step in interactive mode requires explicit invocation). Quick-eyeball scan of `.planning/todos/pending/` against #29's scope:
+  - `2026-05-06-continuation-backfill-quota-reserve.md` — adjacent topic (quota), but explicitly out of #29 scope; stays deferred.
+  - `2026-05-07-channel-context-backfill-handler-integration-test.md` — adjacent (the handler we're modifying). Could be folded if execution adds an integration test for the new state writes; treat as a "nice-to-have" during P1 step 4 testing rather than a separate scope item.
+
+</deferred>
+
+---
+
+*Phase: 03.0.3-youtube-feed-fixes*
+*Context gathered: 2026-05-11*

--- a/.planning/phases/03.0.3-youtube-feed-fixes/03.0.3-DISCUSSION-LOG.md
+++ b/.planning/phases/03.0.3-youtube-feed-fixes/03.0.3-DISCUSSION-LOG.md
@@ -1,0 +1,157 @@
+# Phase 03.0.3: YouTube Feed Fixes - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-05-11
+**Phase:** 03.0.3-youtube-feed-fixes
+**Areas discussed:** Adapter placement (D-01 compliance), Plan granularity, Test placement, Cleanup + rollout
+
+---
+
+## Gray Area Selection
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Adapter placement (D-01) | Where enrichFeedDtos + getNewestKnownPublishedAt live | ✓ |
+| Plan granularity | Number of PLAN.md files inside phase | ✓ |
+| Test placement | New test files vs extend existing | ✓ |
+| Cleanup + rollout | resetChannelBackfillComplete fate + pre-deploy verification | ✓ |
+
+**User selected:** All four areas.
+
+---
+
+## Area 1 — Adapter placement (D-01 Thick vs YAGNI)
+
+### Round 1 — initial framing
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| YouTube-internal (D-01 Thick) | Both helpers in src/lib/sources/youtube/server/; explicit callsites import directly | |
+| Adapter-dispatched (D-01 + registry) | Both as DataSourceAdapter methods; callsites iterate allAdapters | |
+| Issue #29 plan (вне адаптера) | feed-enrichment.ts in src/lib/server/ + getNewestKnownPublishedAt in channel-state.ts | |
+
+**User's choice:** "Давай обсудим. Это нужно будет всем адаптерам или нет. Ютую референсная имплементация все другие будут основаны на нем. И будут много брать. Как лучше?"
+
+**Notes:** User asked the meta-question rather than picking from menu. Claude analyzed: enrichFeedDtos is universal (every kind with time-series stats needs it); getNewestKnownPublishedAt is universal in shape but caller is always within the same plugin. Recommended asymmetric approach.
+
+### Round 2 — asymmetric proposal
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Asymmetric (Recommended) | enrichFeedDtos on contract; newest-known internal | ✓ |
+| Both on contract | Both as DataSourceAdapter methods | |
+| Both internal | Both YouTube-internal; callsites import explicitly | |
+
+**User's choice:** "Да — асимметрично (Recommended)"
+
+**Notes:** User accepted the analysis (cross-source callers earn the dispatch abstraction; single-plugin callers don't).
+
+---
+
+## Area 2 — Plan granularity
+
+### Round 1 — initial menu
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| 3 plans (Recommended) | P1 enrichment, P2 since-derivation, P3 context-backfill + docs | |
+| 5 plans | Each cleanup step is its own plan | |
+| 2 plans | Part 1 + Part 2 | |
+| 1 plan | Everything together | |
+
+**User's choice:** "Так это один план верно? я хорчу это одной итерацие сделать на пр. Я запутался немного что такое план. Это вот дискус и планирование"
+
+**Notes:** Terminology confusion — user conflated "phase" with "plan". Claude clarified the GSD hierarchy:
+- Phase = roadmap unit (1 for this work)
+- discuss-phase / plan-phase / execute-phase = pipeline steps (each 1 invocation)
+- PLAN.md = sub-units within plan-phase output (configurable count)
+- PR to master = 1 (squash-merge)
+
+### Round 2 — re-framed after terminology clarification
+
+User asked: "Вот это фазы, не планы верно? когда я попрашу тебя спланировать то это будет одно планирование?"
+
+Claude clarified with a table mapping Phase / Discuss / Plan / PLAN.md / Execute / PR.
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| 1 PLAN.md (Recommended) | One plan, one intermediate commit, minimum paperwork | |
+| 2 PLAN.md (Part1 / Part2) | Two plans matching issue #29's natural split | ✓ |
+| 3 PLAN.md (fine-grained) | Three logical chunks | |
+
+**User's choice:** "2 PLAN.md (Part1 / Part2)"
+
+**Notes:** Two-plan split aligns with #29's "Part 1 / Part 2" structure. P1 = quota fix (since-derivation + context-backfill state + cleanup + tests). P2 = enrichment (adapter method + 3 callsites + tests).
+
+---
+
+## Area 3 — Test placement
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| New files (Recommended) | refresh-content-quota.test.ts + feed-api-enrichment.test.ts per #29's naming | ✓ |
+| Extend existing | Add describe-blocks in api-sources-refresh-content.test.ts + feed.test.ts | |
+| Mix (my decision) | Claude decides per-test based on fixture proximity | |
+
+**User's choice:** "Новые файлы (Recommended)"
+
+**Notes:** Follows project convention "one test file = one behavioural invariant area". Easier to find on regression.
+
+---
+
+## Area 4 — Cleanup + rollout
+
+### Sub-question A — Cleanup scope (round 1)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Full cleanup (Recommended) | Delete call + function + import + add comment | |
+| Surgical | Delete only the call; function stays as dead code | |
+
+**User's choice:** "Объясни. Мы теперь никогда его не сбрасываем? и нам это не нужно верно? оно считается заверщшеным когда мы получили все видео?"
+
+**Notes:** User wanted semantic clarification before deciding. Claude explained the new contract: `backfill_complete=true` means "walker reached endOfPlaylist at least once"; set automatically by handlers; never needs to be reset in routine operations because new since-derivation handles re-check via newestKnown cursor (page-1 walk).
+
+### Sub-question A — Cleanup scope (round 2 after explanation)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Да — full cleanup | Delete function + call + import + add comment | ✓ |
+| Оставить функцию | Surgical removal; function stays unused | |
+
+**User's choice:** "Да — full cleanup"
+
+**Notes:** Per AGENTS.md "if unused, delete it completely".
+
+### Sub-question B — Pre-deploy verification snapshot
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Не нужен (Recommended) | No schema migration; manual UAT validates effect | ✓ |
+| Да, snapshot + diff | Snapshot data_source_channel_state before deploy, diff after first click | |
+
+**User's choice:** "Не нужен (Recommended)"
+
+**Notes:** Fix is read-mostly + has no migration risk. Worst case (channels without state from pre-fix context-backfill) falls into deep-walk branch identical to pre-fix behavior.
+
+---
+
+## Claude's Discretion (no questions asked)
+
+Items inside CONTEXT.md `<decisions>` "Claude's Discretion" subsection were not surfaced as questions:
+- File names inside YouTube plugin (`feed-enrichment.ts`, `newest-known.ts` vs inlined)
+- Test fixture setup style (ad-hoc seeding vs factored helper)
+- Audit metadata for new walk-outcomes (whether to add `since_branch` discriminator)
+- Comment density (only two load-bearing WHY comments: `updateSource` lazy note + `/api/events/deleted` skip note)
+- Order of intermediate commits on branch (P1 first vs P2 first — default P1 first)
+
+---
+
+## Deferred Ideas Captured During Discussion
+
+- "Deep re-walk" user button (would resurrect `resetChannelBackfillComplete`) — hypothetical future feature, not in scope.
+- Test for `2026-05-07-channel-context-backfill-handler-integration-test.md` todo could be incidentally satisfied by P1's state-write tests but is not folded.
+
+All other deferred ideas listed in CONTEXT.md `<deferred>` section.

--- a/.planning/phases/03.0.3-youtube-feed-fixes/03.0.3-HUMAN-UAT.md
+++ b/.planning/phases/03.0.3-youtube-feed-fixes/03.0.3-HUMAN-UAT.md
@@ -1,0 +1,56 @@
+---
+status: partial
+phase: 03.0.3-youtube-feed-fixes
+source: [03.0.3-VERIFICATION.md human_verification]
+started: 2026-05-11
+updated: 2026-05-11
+notes: 4 manual UAT items deferred from verifier — real YouTube quota observation against the live Data API and visual feed-card consistency at the SSR-to-cursor-pagination boundary. Code-path verification at 5/5 must-haves passed.
+---
+
+## Current Test
+
+[awaiting human testing]
+
+## Setup (one-time before any assertion)
+
+Items 1–4 are testable on **prod** (`neotolis-diary.dev`) under the admin
+account that has the 8 YouTube channels registered. Item 1 is the headline
+quota-fix observation and is meaningful only on prod (or on a local instance
+with real `SERVICE_YOUTUBE_API_KEYS`); items 2–4 can also be run against
+local dev via `pnpm dev` once enough YouTube events exist below the SSR
+first batch on `/feed`.
+
+1. **Sign in as admin** at https://neotolis-diary.dev/.
+2. **Open `/admin/quota`** in a separate tab — keep it visible to observe
+   the live quota counter.
+3. **Open `/sources`** in another tab — this is where the "Pull new content"
+   button per channel lives.
+
+## Tests
+
+### 1. 8-channel /sources "Pull new content" click on steady-state burns ≤8 quota units
+expected: Click "Pull new content" on each of the 8 registered YouTube channels under steady-state (no new uploads, no widened `backfillTargetSince`). `/admin/quota` shows the daily `playlistItems.list` counter advanced by ≤8 units total (one page per channel × 1 unit each). Pre-fix baseline: ~110 units.
+result: [pending]
+
+### 2. Visual /feed consistency past the SSR first batch
+expected: Scroll `/feed` past the SSR first batch (~50 events) into cursor-paginated batches. Every YouTube card — above AND below the fold — shows the view/like/comment count line and channel-name chip. Pre-fix: cards above the fold show stats; cards below show none — visually inconsistent.
+result: [pending]
+
+### 3. /games/[gameId] per-game curated view enrichment
+expected: Open any game with attached YouTube events (`/games/{gameId}`). Every YouTube card shows the same view/like/comment counts + channel chip as on `/feed`. No drift between the two views.
+result: [pending]
+
+### 4. /audit DeletedEventsPanel compact rendering preserved
+expected: Open `/audit`. Soft-deleted events render with the compact KindIcon + strikethrough title — NO stats line, NO channel chip. Confirms the deliberate-skip path in `GET /api/events/deleted` is still honored after the enrichment refactor.
+result: [pending]
+
+## Summary
+
+total: 4
+passed: 0
+issues: 0
+pending: 4
+skipped: 0
+blocked: 0
+
+## Gaps

--- a/.planning/phases/03.0.3-youtube-feed-fixes/03.0.3-VERIFICATION.md
+++ b/.planning/phases/03.0.3-youtube-feed-fixes/03.0.3-VERIFICATION.md
@@ -1,0 +1,274 @@
+---
+phase: 03.0.3-youtube-feed-fixes
+verified: 2026-05-11T20:35:00Z
+status: human_needed
+verdict: code_verified_pending_uat
+score: 5/5 must-haves verified (post-follow-up)
+re_verification:
+  pass: 2
+  previous_status: human_needed
+  previous_score: 5/5
+  previous_verified: 2026-05-11T19:35:00Z
+  follow_up_commits:
+    - hash: 749b46e
+      scope: "fix(03.0.3)"
+      title: "channel-context-backfill writes terminal state on empty window"
+      closes_gap: "Latent — empty-window double-walk: pre-fix the early-return at collected.length===0 skipped terminal state writes; the previous verification did not flag this. Now fixed + tested."
+    - hash: e28381d
+      scope: "test(03.0.3)"
+      title: "rewrite test (b) framing to match what it actually verifies"
+      closes_gap: "AGENTS.md Validation §4 (CI gate honesty) — test (b) header claimed it verified D-#29-1 walkedPastSince behavior, but pollContent is mocked at the adapter boundary. Honest framing restored + TODO filed for the missing unit test."
+    - hash: 810d5a9
+      scope: "fix(03.0.3)"
+      title: "force-deep job on widening past deepestWalked (issue #29 acceptance)"
+      closes_gap: "Semantic gap between issue #29 acceptance and D-#29-7 fairness ordering — pre-fix, widening backfillTargetSince past backfill_oldest_at on a backfill_complete=true channel was a silent no-op (branch=exhausted always won). Now a force-deep job is enqueued per-user; handler honors forceDeep BEFORE three-branch check."
+    - hash: a8f463c
+      scope: "chore(03.0.3)"
+      title: "P2 cleanup — remove obsolete comment, document _userId intent"
+      closes_gap: "Stale comment block in channel-context-backfill.ts (historical 03.0.1 wave reference); _userId jsdoc explaining why it's intentionally unused in feed-enrichment.ts."
+  gaps_closed:
+    - "Empty-window double-walk (latent, not flagged in pass 1)"
+    - "Test (b) honest framing (AGENTS.md §4)"
+    - "Widening → deep walk now actually wired via force-deep job"
+    - "P2 cleanup hygiene"
+  gaps_remaining: []
+  regressions: []
+  new_gaps: []
+human_verification:
+  - test: "8-channel /sources 'Pull new content' click quota cost on prod"
+    expected: "Admin clicks 'Pull new content' on all 8 channels under steady-state account; /admin/quota shows ≤8 YouTube quota units burned (one playlistItems.list page per channel, 1 unit each). Pre-fix baseline was ~110 units."
+    why_human: "Requires real YouTube Data API quota observation against the production admin account on neotolis-diary.dev; integration tests stub the YouTube client and can only assert audit-row sinceBranch values."
+  - test: "Visual /feed scroll past SSR first batch"
+    expected: "Scroll /feed past the SSR first batch into cursor-paginated batches. Every YouTube card (above AND below the fold) shows view/like/comment counts + channel chip. Pre-fix: cards above the fold show stats; cards below show none — visually inconsistent feed."
+    why_human: "Visual consistency check across the SSR-to-cursor-pagination boundary; integration test feed-api-enrichment.test.ts asserts the DTO carries stats/channelTitle on cursor batches but cannot verify FeedCard renders them visually identically."
+  - test: "/games/[gameId] per-game curated view"
+    expected: "Open any game with attached YouTube events; every YouTube card shows the same stats + channel chip as on /feed."
+    why_human: "Visual parity check; loop is wired in code and TypeScript-clean, but cards rendering is a UI assertion."
+  - test: "/audit (DeletedEventsPanel) compact rendering preserved"
+    expected: "Open /audit; soft-deleted events render with compact KindIcon + strikethrough title — NO stats line, NO channel chip. The deliberate skip is honored."
+    why_human: "Visual confirmation that the deliberate-skip path renders correctly post-refactor; test (2) in feed-api-enrichment.test.ts asserts stats/channelTitle are null on the API payload but cannot assert the panel UI."
+  - test: "PATCH widen target → next refresh-content burns a deep walk for THIS user only"
+    expected: "Operator widens backfillTargetSince on a fully-walked channel via PATCH /api/sources/:id; observes (a) /admin/quota shows the deep-walk quota consumed under this user (NOT the cron pool), (b) next refresh-content click on the same channel by another user without widening still burns ≤1 page (multi-tenant fairness preserved — only the widening user pays for the deep walk)."
+    why_human: "End-to-end multi-tenant quota fairness validation; the force-deep mechanism is unit/integration-tested but the cross-user quota-attribution observation requires real production data + multiple user sessions."
+---
+
+# Phase 03.0.3: YouTube Feed Fixes Verification Report (Re-verification — Pass 2)
+
+**Phase Goal:** Resolve issue #29 — two YouTube feed bugs surfaced in Phase 03.0 operational use:
+  (1) `POST /api/sources/:id/refresh-content` burns ~110 YouTube quota units per click on quiet steady state.
+  (2) `GET /api/events` cursor-paginated batches drop YouTube enrichment (view/like/comment + channelTitle).
+
+**Verified:** 2026-05-11T20:35:00Z
+**Status:** human_needed (all automated checks pass; 5 manual UAT items pending for visual + real-quota invariants — one new item added for the multi-tenant fairness invariant on the new force-deep mechanism)
+**Re-verification:** Yes — Pass 2 after 4 code-review follow-up commits (`749b46e`, `e28381d`, `810d5a9`, `a8f463c`)
+
+## Re-verification
+
+This is the second verification pass on `feat/phase-03.0.3-youtube-feed-fixes`. The first pass (2026-05-11T19:35:00Z) declared `5/5 must-haves verified` and shipped 4 human UAT items. A code-review audit between Pass 1 and Pass 2 surfaced 4 follow-up commits closing the gaps below.
+
+Branch state at Pass 2:
+- 21 commits ahead of `master` (16 from Pass 1 + 1 UAT artifact commit `92102bf` + 4 follow-up commits)
+- All 26 phase-focused integration tests pass on the re-verification run (3 in `refresh-content-quota.test.ts`, 1 added (c2) + 2 reframed + 1 (c) rewrite = 4 tests; 2 in `feed-api-enrichment.test.ts`; 2 in `channel-context-backfill-empty.test.ts` (new file); 5 in `channel-state-helpers.test.ts`; 1 in `end-to-end-catch-up.test.ts`; 9 in `api-sources-refresh-content.test.ts`)
+- `pnpm tsc --noEmit` exits 0
+
+### Closed gaps from prior code review
+
+#### Gap A — Empty-window double-walk (LATENT — not flagged in Pass 1)
+
+**Root cause:** `src/lib/sources/youtube/server/handlers/channel-context-backfill.ts:497-503` (pre-fix) returned early on `collected.length === 0`, which skipped the terminal stopReason-driven state writes at lines 715-771. A brand-new or naturally-empty channel (no_more_pages on page 0 with zero items) stayed `backfill_complete=false` forever, and cron re-walked it every day at 3am Pacific — the exact onboarding double-walk D-#29-5 was designed to eliminate.
+
+**Why Pass 1 missed it:** Pass 1 verified that `channel-context-backfill.ts:725-761` writes terminal state per stopReason. It did not trace the early-return guard above the writes. The integration tests covered non-empty walks only.
+
+**Fix (`749b46e`):** Removed the early-return; added a `collected.length > 0` guard on the subsequent `sourceId && collected.length > 0` block (the pre-insert SELECT uses `IN (..collected.map..)` which would emit Postgres `IN ()` syntax error on empty input). Verified at `channel-context-backfill.ts:497-509` (early-return is now just a log + fall-through) and `channel-context-backfill.ts:599-604` (the new guard).
+
+**Test (`749b46e`):** New file `tests/integration/channel-context-backfill-empty.test.ts` (172 lines, 2 tests). Test 1 mocks `chargedFetch` to return empty `playlistItems.items`; asserts `data_source_channel_state.backfill_complete=true` + `metadata.lastBackfillPageToken=null` post-handler. Test 2 asserts the audit row carries `events_inserted=0`. Both pass.
+
+#### Gap B — Test (b) honest framing (AGENTS.md Validation §4 — CI gate honesty)
+
+**Root cause:** Pre-fix, the test (b) header in `refresh-content-quota.test.ts:209` claimed to demonstrate D-#29-1's promise ("walkedPastSince does not silently drop backdated uploads"). But `pollContent` is mocked at the adapter boundary (line 65), so the mock returns the backdated event regardless of the `since` arg it receives. The production walker's decision happens INSIDE pollContent and is hidden by the mock — the test was actually verifying (1) branch selection, (2) since derivation, (3) fan-out INSERT, not walker-level behavior.
+
+**Fix (`e28381d`):** Rewrote the test header, body comment, and final assertion comment to honestly describe what it verifies. Added a `TODO(03.0.3 follow-up)` filing a separate unit test against the unmocked YouTube adapter's `pollContent` with a synthetic playlist fixture. Verified at `refresh-content-quota.test.ts:209-247` (header + comment block) and lines 345-350 (the rewritten fan-out assertion comment).
+
+#### Gap C — Widening → deep walk now actually wired via force-deep job
+
+**Root cause:** Plan 01's three-branch logic in `backfill-channel.ts:168-184` honored D-#29-7 multi-tenant fairness by routing `backfillComplete=true` channels to `branch=exhausted` unconditionally. This meant `updateSource` widening `backfillTargetSince` past `backfill_oldest_at` on a fully-walked channel was a silent no-op — the user's widened target was ignored on the next refresh-content click because the channel state's exhausted flag took precedence. Issue #29 Part 1 acceptance demanded the deep walk fire; Plan 01's implementation did not deliver it.
+
+**Why Pass 1 missed it:** Pass 1's test (c) (pre-fix) asserted `branch=deep` would fire on the next click, but it set up `backfillComplete=false` (partial walk) and `deepestWalked=30d-ago` shallower than target=epoch — the deep branch was reached via the partial-walk path, NOT via widening from exhausted. The test was logically consistent with the implementation but did not exercise the issue #29 acceptance scenario (complete=true + widening).
+
+**Fix (`810d5a9`):**
+- `updateSource` (`src/lib/server/services/data-sources.ts:269-303`, `676-687`): new private helper `maybeEnqueueForceDeepWalk` enqueues a `YOUTUBE_BACKFILL_CHANNEL` job with `forceDeep: true` when (a) new target is strictly deeper than previous, (b) channel state exists, (c) `backfillComplete === true`, (d) `backfillOldestAt !== null`, (e) new target is strictly deeper than `backfillOldestAt`. `singletonKey = "force-deep-{channelKey}-{userId}"` per-user. The trigger user pays quota; subscribers free-ride on fan-out.
+- `handleBackfillChannel` (`src/lib/sources/youtube/server/handlers/backfill-channel.ts:82-91`, `170-184`): new optional `forceDeep?: boolean` in job payload. When `forceDeep === true`, `branch = "deep"` is selected BEFORE the three-branch check, overriding `backfillComplete`. Cron paths (`auto-backfill-cron.ts:169`, `incremental-cron.ts:123`) do NOT set this flag, preserving multi-tenant fairness for cron walks.
+
+**Tests (`810d5a9`):**
+- Test (c) rewritten end-to-end (`refresh-content-quota.test.ts:358-512`): seeds complete=true + deepestWalked=30d-ago; PATCHes target to epoch via the live SvelteKit/Hono app; asserts `sentJobs` captures one `YOUTUBE_BACKFILL_CHANNEL` job with `forceDeep=true, flow="historical", depthBoundIso="1970-01-01T00:00:00.000Z"` and `singletonKey="force-deep-{channelKey}-{userId}"`; invokes `handleBackfillChannel` with the captured job; asserts `pollContent` received `since=epoch` (NOT `max(newestKnown, target)`) and the audit row carries `since_branch="deep"` + `flow="historical"`.
+- New test (c2) (`refresh-content-quota.test.ts:514-578`): no-op path — widening to a target that is STILL ≥ backfillOldestAt does NOT enqueue a force-deep job. Pins the predicate to prevent burning quota on redundant walks.
+
+**Privacy invariants preserved on the new code path:**
+- `updateSource` UPDATE at line 663-673 is userId+id scoped; `row` only returns if the caller owns the source. The boss send at line 676-687 reads `row.channelId` (the canonical channel key) and `userId` (the caller); no cross-tenant leak. (AGENTS.md Privacy §1)
+- `getChannelState` is cross-tenant by design per the channel-scoped state machine (Phase 03.0.1 D-13); the new caller does not bypass userId scoping because the channel-state row carries no userId. (AGENTS.md Privacy §1 channel-table exception)
+- No new `process.env` reads outside `src/lib/server/config/env.ts` (`grep` confirms 0 additions to `src/`).
+- No new secret-shaped field names in the job payload or row; Pino redact paths unchanged.
+- No `APP_MODE` branching (`grep` confirms APP_MODE only in `config/env.ts`).
+- No new ciphertext DTO leaks; the new field `forceDeep` is a boolean job-payload flag, never projected to a user-visible DTO.
+
+#### Gap D — P2 cleanup hygiene (`a8f463c`)
+
+- `channel-context-backfill.ts`: removed obsolete "Phase 03.0.1 Wave 4 — channel-scoped state writes" comment block. Historical reference to migration 0028, not load-bearing for current behavior.
+- `feed-enrichment.ts:29-37`: added a jsdoc on the `_userId` parameter explaining why it's intentionally unused (public-data tables; future adapters touching tenant-owned tables MUST scope by userId). Prevents a future maintainer from removing it as "unused" and breaking the contract.
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence (post-follow-up) |
+| --- | ----- | ------ | -------- |
+| 1 | An 8-channel `/sources` 'Pull new content' click on a steady-state account burns ≤8 YouTube quota units (not ~110). | VERIFIED (code path) / human_needed (real quota) | `backfill-channel.ts:170-184` implements the three-branch since-derivation; `forceDeep` override at line 171-177 routes widening users to deep walk WITHOUT changing the exhausted flag for other subscribers. Tests (a)/(b)/(c)/(c2) all pass. Real-quota observation needs production UAT. |
+| 2 | Backdated YouTube uploads (publishedAt < newestKnown but > prior session) are collected on the next refresh click. | VERIFIED (code path; honest framing) | Test (b) at `refresh-content-quota.test.ts:209` exercises branch selection + since derivation + fan-out. The walker-level walkedPastSince behavior (the actual mechanism that prevents drops) is filed as a separate unit-test TODO; production code at `backfill-channel.ts:168` reads `getNewestKnownPublishedAt` (MAX(youtube_videos.published_at) per channel) per D-#29-1. |
+| 3 | Widening `backfillTargetSince` (e.g. 30d → epoch) via `PATCH /api/sources/:id` triggers a deep walk on the next refresh-content click. | VERIFIED (post-fix) | `updateSource` at `data-sources.ts:676-687` calls `maybeEnqueueForceDeepWalk`; helper at `data-sources.ts:269-303` enqueues `YOUTUBE_BACKFILL_CHANNEL` with `forceDeep=true` when widening past `backfill_oldest_at` on a complete channel. Handler at `backfill-channel.ts:171-177` honors `forceDeep` BEFORE the three-branch check. Test (c) at `refresh-content-quota.test.ts:358-512` exercises end-to-end (PATCH → enqueue capture → handler invocation → since=epoch + audit `since_branch="deep"`). Test (c2) pins the no-op path. |
+| 4 | Onboarding context backfill (`channel-context-backfill`) writes terminal channel state per `stopReason` — no double-walk. | VERIFIED (extended post-fix) | `channel-context-backfill.ts:715-771` writes `backfill_complete`, `backfill_oldest_at`, `lastBackfillPageToken` keyed on `stopReason ∈ {no_more_pages, hard_cap, cutoff_crossed}` per D-#29-5. Follow-up `749b46e` removed the early-return at `channel-context-backfill.ts:497-509` that previously skipped the terminal writes on naturally-empty channels. New test `tests/integration/channel-context-backfill-empty.test.ts` (2 tests) pins both invariants. |
+| 5 | YouTube enrichment (stats + channelTitle) renders uniformly on `/feed` SSR first batch AND `GET /api/events` cursor pagination AND `/games/[gameId]`. | VERIFIED (code path) / human_needed (visual) | `adapter.enrichFeedDtos` contract method in `adapter.ts:558`; YouTube impl in `feed-enrichment.ts:28-105` (post-`a8f463c` jsdoc on `_userId`); loop wired at 3 callsites (`feed/+page.server.ts:163`, `events.ts:336`, `games/[gameId]/+page.server.ts:78`); test `feed-api-enrichment.test.ts` (1) passes for cursor batch parity, (2) passes for deleted-skip. |
+
+**Score:** 5/5 truths verified at the code-path level. Now 3/5 require human UAT (added: multi-tenant force-deep fairness observation).
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+| -------- | -------- | ------ | ------- |
+| `src/lib/sources/youtube/server/newest-known.ts` | `getNewestKnownPublishedAt` cursor helper | VERIFIED | Unchanged from Pass 1 — 37 lines. |
+| `src/lib/sources/youtube/server/handlers/backfill-channel.ts` | Three-branch + sinceBranch audit + `forceDeep` override | VERIFIED (extended) | Lines 82-91 declare `forceDeep?` in payload type. Lines 170-184 implement the four-branch logic (forceDeep first, then exhausted/incremental/deep). Lines 191-195 token-clear-on-incremental preserved. |
+| `src/lib/sources/youtube/server/handlers/channel-context-backfill.ts` | Terminal state writes per `stopReason` + empty-channel fall-through | VERIFIED (extended) | Lines 497-509: early-return on empty `collected` REMOVED (now just logs). Lines 599-604: new `sourceId && collected.length > 0` guard on the pre-insert SELECT. Lines 715-771: terminal state writes unchanged. |
+| `src/lib/server/services/channel-state.ts` | `resetChannelBackfillComplete` fully removed | VERIFIED | Unchanged from Pass 1 — `grep -r "resetChannelBackfillComplete" src/ tests/` returns 0 matches. |
+| `src/lib/server/services/data-sources.ts` | `updateSource` lazy widening comment + `maybeEnqueueForceDeepWalk` | VERIFIED (extended) | Line 649-660 carries the lazy-widening WHY comment. Lines 244-303: new `maybeEnqueueForceDeepWalk` private helper with full jsdoc explaining the predicate + quota attribution + multi-tenant fairness rationale. Lines 676-687: the call site after the userId-scoped UPDATE. |
+| `src/lib/server/http/routes/sources.ts` | `resetChannelBackfillComplete` call + import removed | VERIFIED | Unchanged from Pass 1. |
+| `tests/integration/refresh-content-quota.test.ts` | Behavioural tests | VERIFIED (extended) | 579 lines (was 525); 4 `it(...)` blocks at lines 117 (a), 209 (b — reframed), 358 (c — rewritten end-to-end), 514 (c2 — new); all 4 pass. |
+| `tests/integration/channel-context-backfill-empty.test.ts` | Empty-window terminal state writes | VERIFIED (new) | 172 lines (new file from `749b46e`); 2 `it(...)` blocks; both pass. |
+| `src/lib/sources/adapter.ts` | `enrichFeedDtos?` optional contract method | VERIFIED | Unchanged from Pass 1 — Line 558 declares the optional method; jsdoc references D-A1 + DeletedEventsPanel. |
+| `src/lib/sources/youtube/server/feed-enrichment.ts` | YouTube impl with internal kind filter + non-fatal error path + `_userId` jsdoc | VERIFIED (extended) | 105 lines (was 96); lines 29-37 carry the new `_userId` jsdoc per `a8f463c`. |
+| `src/lib/sources/youtube/server/adapter.ts` | `enrichFeedDtos` attachment | VERIFIED | Unchanged from Pass 1. |
+| `src/routes/feed/+page.server.ts` | Inline JOIN replaced with `for-of allAdapters` loop | VERIFIED | Unchanged from Pass 1. |
+| `src/lib/server/http/routes/events.ts` | Loop on GET /api/events + deliberate-skip WHY on /events/deleted | VERIFIED | Unchanged from Pass 1. |
+| `src/routes/games/[gameId]/+page.server.ts` | Loop after `mapEventsToDtos` | VERIFIED | Unchanged from Pass 1. |
+| `tests/integration/feed-api-enrichment.test.ts` | 2 live behavioural tests | VERIFIED | Unchanged from Pass 1 — both pass. |
+| `SOURCE-REFERENCE.md` | §10 + §11 | VERIFIED | Unchanged from Pass 1. |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+| ---- | -- | --- | ------ | ------- |
+| `backfill-channel.ts` | `newest-known.ts` | `getNewestKnownPublishedAt(channelKey)` | WIRED | Unchanged from Pass 1. |
+| `backfill-channel.ts` | `channel-state.ts` | `setChannelBackfillPageToken(kind, channelKey, null)` on incremental branch | WIRED | Lines 191-195 inside `if (incrementalBranchTaken)` guard (post-`810d5a9`). |
+| `channel-context-backfill.ts` | `channel-state.ts` | `markChannelBackfillComplete` / `setChannelBackfillPageToken` per stopReason | WIRED | Unchanged from Pass 1. |
+| `sources.ts` | (nothing — call removed) | `resetChannelBackfillComplete` is gone | WIRED | Unchanged from Pass 1. |
+| **NEW**: `data-sources.ts` (`updateSource`) | `pg-boss` queue | `getBoss().send(YOUTUBE_BACKFILL_CHANNEL, {..., forceDeep: true}, {singletonKey})` | WIRED | Lines 287-302 — full payload + per-user singleton key. Invoked at line 681-686 after userId+id-scoped UPDATE. |
+| **NEW**: `data-sources.ts` (`maybeEnqueueForceDeepWalk`) | `channel-state.ts` | `getChannelState(kind, channelKey)` | WIRED | Line 281 — reads channel state to gate the enqueue predicate. |
+| **NEW**: `backfill-channel.ts` (`forceDeep` branch) | (none — local decision) | `if (job.data.forceDeep === true) branch = "deep"` | WIRED | Lines 170-184 — override takes precedence over the three-branch check. |
+| `feed/+page.server.ts` | `registry.ts → allAdapters` | Loop | WIRED | Unchanged from Pass 1. |
+| `events.ts` (GET /api/events) | `registry.ts → allAdapters` | Same loop pattern | WIRED | Unchanged from Pass 1. |
+| `games/[gameId]/+page.server.ts` | `registry.ts → allAdapters` | Same loop pattern | WIRED | Unchanged from Pass 1. |
+| `events.ts` (GET /api/events/deleted) | (nothing — deliberate skip) | Inline WHY comment referencing DeletedEventsPanel.svelte | WIRED | Unchanged from Pass 1. |
+| `feed-enrichment.ts` | `youtube_video_snapshots` + `youtube_videos` | DISTINCT-via-Map + SELECT channelTitle | WIRED | Unchanged from Pass 1. |
+
+### Data-Flow Trace (Level 4)
+
+| Artifact | Data Variable | Source | Produces Real Data | Status |
+| -------- | ------------- | ------ | ------------------ | ------ |
+| `feed-enrichment.ts:youtubeEnrichFeedDtos` | `r.stats`, `r.channelTitle` | `youtube_video_snapshots` + `youtube_videos.channelTitle` DB queries | Yes | FLOWING |
+| `events.ts:GET /api/events` rows | `dtos[i].stats`, `dtos[i].channelTitle` | `mapEventsToDtos` + `adapter.enrichFeedDtos` mutation | Yes | FLOWING |
+| `feed/+page.server.ts` rowDtos | Same fields | Same loop | Yes | FLOWING |
+| `backfill-channel.ts:since` | `since` Date input to `adapter.pollContent` | `getNewestKnownPublishedAt` + state read + `forceDeep` override + target | Yes | FLOWING |
+| **NEW**: `updateSource → maybeEnqueueForceDeepWalk → boss.send` | `forceDeep: true` in job payload | `getChannelState` predicate + caller's PATCH input | Yes — test (c) captures the enqueue with `sentJobs` mock and asserts the full payload | FLOWING |
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+| -------- | ------- | ------ | ------ |
+| TypeScript compile | `pnpm tsc --noEmit` | exit 0 | PASS |
+| Pass 1 + Pass 2 quota tests | `pnpm exec vitest run tests/integration/refresh-content-quota.test.ts` | 4/4 passing (a, b reframed, c rewritten, c2 new) | PASS |
+| Plan 02 enrichment tests | `pnpm exec vitest run tests/integration/feed-api-enrichment.test.ts` | 2/2 passing | PASS |
+| Empty-window onboarding tests | `pnpm exec vitest run tests/integration/channel-context-backfill-empty.test.ts` | 2/2 passing | PASS |
+| Channel state helpers test | `pnpm exec vitest run tests/integration/channel-state-helpers.test.ts` | passing | PASS |
+| End-to-end catch-up test | `pnpm exec vitest run tests/integration/end-to-end-catch-up.test.ts` | passing | PASS |
+| API sources refresh-content baseline | `pnpm exec vitest run tests/integration/api-sources-refresh-content.test.ts` | 9/9 passing | PASS |
+| **Full focused phase suite** | 6 files, 26 tests | 26/26 passing | PASS |
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+| ----------- | ----------- | ----------- | ------ | -------- |
+| N/A (no new REQ-IDs) | Both plans declare `requirements: []` | Bug fix + perf, tracked by issue #29 | N/A | Unchanged from Pass 1. |
+
+No orphaned requirements.
+
+### Anti-Patterns Found
+
+| File | Pattern | Severity | Impact |
+| ---- | ------- | -------- | ------ |
+| `feed-enrichment.ts` (post-`a8f463c`) | None | — | Clean. New `_userId` jsdoc explicitly addresses the future-maintainer risk. |
+| `backfill-channel.ts` (post-`810d5a9`) | None | — | The new `forceDeep` branch is substantive (sets `branch = "deep"`), not a stub. Order-of-checks puts override BEFORE fairness — intentional and documented in the inline comment. |
+| `data-sources.ts` (post-`810d5a9`) | None | — | `maybeEnqueueForceDeepWalk` is a fully-implemented private helper with predicate guards and per-user singletonKey. Call site is after the userId-scoped UPDATE (no cross-tenant leak). |
+| `channel-context-backfill.ts` (post-`749b46e` + `a8f463c`) | None | — | Empty-window fall-through is intentional and documented. The new `collected.length > 0` guard on the events-INSERT block prevents the Postgres `IN ()` syntax error. |
+| `refresh-content-quota.test.ts` (post-`e28381d` + `810d5a9`) | None | — | Test (b) now carries honest framing + TODO. Test (c) rewritten to exercise the issue-#29 acceptance scenario end-to-end. Test (c2) new — no-op predicate. |
+| `.dev-oauth-mock.mjs` (untracked) | `process.env` reads outside `config/env.ts` | INFO (out of scope) | Pre-existing dev helper, untracked, NOT on master. Documented in `deferred-items.md` 3rd entry. |
+| Test infrastructure (~25 files) | Static-email collisions | INFO (pre-existing) | Documented in `deferred-items.md`; NOT a regression. |
+
+### Privacy & Multi-Tenancy Invariants (AGENTS.md compliance)
+
+| Invariant | Status (post-follow-up) | Evidence |
+| --------- | ----------------------- | -------- |
+| userId scoping on tenant-owned tables | PRESERVED | `updateSource` UPDATE at `data-sources.ts:663-673` is userId+id scoped; force-deep enqueue at lines 676-687 reads only `row.channelId` (canonical key, not user-data) + `userId` (caller). |
+| Cross-tenant access returns 404 (not 403) | PRESERVED | No changes to error mapping. |
+| No new `process.env` reads outside `src/lib/server/config/env.ts` | PRESERVED | grep confirms 0 new reads in `src/` from the 4 follow-up commits. |
+| DTO discipline | PRESERVED | New `forceDeep` field is a job-payload boolean, never projected to a DTO. |
+| Pino redact paths | PRESERVED | No new secret-shaped field names. |
+| No SaaS vs self-host code-path divergence | PRESERVED | No `APP_MODE` branching introduced. |
+| Audit log INSERT-only | PRESERVED | The force-deep path writes audit rows via existing `writeBackfillAudit` extension; no UPDATE/DELETE. |
+| **NEW**: Multi-tenant quota fairness on force-deep | PRESERVED | `singletonKey` is per-user (`force-deep-{channelKey}-{userId}`); cron paths (`auto-backfill-cron.ts`, `incremental-cron.ts`) do NOT set `forceDeep` — only `updateSource` does. Trigger user pays quota; subscribers free-ride on fan-out (same as a normal refresh-content click). |
+
+### Branch + Commit Hygiene
+
+| Item | Status | Evidence |
+| ---- | ------ | -------- |
+| Single feature branch | PRESERVED | `feat/phase-03.0.3-youtube-feed-fixes` carries all 21 commits; no intermediate merges. |
+| Total commits ahead of master | 21 | 16 (Pass 1) + 1 UAT artifact (`92102bf`) + 4 follow-ups (`749b46e`, `e28381d`, `810d5a9`, `a8f463c`). |
+| Conventional Commits | VERIFIED | All 4 follow-ups use `fix(03.0.3): ...`, `test(03.0.3): ...`, `chore(03.0.3): ...` scopes. |
+| Ready for ONE squash-merge PR | YES | All 26 phase-focused tests pass; TypeScript clean; AGENTS.md privacy invariants preserved. |
+
+### Human Verification Required
+
+See frontmatter `human_verification` array — now 5 items (up from 4):
+
+1. **Real YouTube quota observation on prod.** Operator clicks 'Pull new content' on 8 channels; verifies `/admin/quota` shows ≤8 units burned. (unchanged from Pass 1)
+2. **Visual /feed consistency past first SSR batch.** (unchanged from Pass 1)
+3. **Per-game curated view enrichment.** (unchanged from Pass 1)
+4. **DeletedEventsPanel compact rendering preserved.** (unchanged from Pass 1)
+5. **NEW**: **Multi-tenant force-deep fairness.** Operator widens `backfillTargetSince` on a fully-walked channel via PATCH; observes `/admin/quota` shows the deep walk consumed under THIS user only (not the cron pool, not other subscribers); another user's refresh-content click on the same channel without widening still burns ≤1 page. Validates that the new force-deep mechanism preserves D-#29-7 multi-tenant fairness in practice.
+
+### Known Infrastructure Debt (NOT a regression)
+
+- **Full integration suite shows 179/598 failures** — `user_email_unique` static-email collisions across ~25 test files. Pre-existing per `deferred-items.md`.
+- **`.dev-oauth-mock.mjs` lint failure** — pre-existing untracked dev helper.
+
+### Gaps Summary
+
+**Pass 2 verdict: no gaps remain at the code-path / artifact / wiring / data-flow level.**
+
+All 5 must-haves verified. The 4 follow-up commits closed:
+1. A latent empty-window double-walk that Pass 1 did not flag (gap A).
+2. A dishonest test (b) framing that violated AGENTS.md Validation §4 (gap B).
+3. A semantic gap between issue #29 acceptance and Plan 01's branch ordering — widening on a complete channel was a silent no-op; now properly wired via the per-user force-deep job (gap C).
+4. P2 cleanup hygiene (gap D).
+
+All 8 AGENTS.md privacy invariants preserved on the new code paths. The new `forceDeep` job-payload field is set ONLY by `updateSource` (after a userId-scoped UPDATE) and consumed BEFORE the three-branch check; cron paths do not set it, preserving multi-tenant fairness. The `singletonKey` is per-user so concurrent widenings from different users each get their own job.
+
+The verdict remains `human_needed` because:
+- 4 visual / real-quota invariants from Pass 1 are unchanged (operator must scroll /feed, observe /admin/quota counters, open /audit, open /games/[gameId]).
+- 1 NEW UAT item added: the multi-tenant force-deep fairness invariant. The mechanism is unit/integration-tested but the cross-user quota-attribution observation requires real production data + multiple user sessions.
+
+**Branch is ready for one squash-merge PR to master under the title:**
+`fix(03.0.3): YouTube refresh-content quota burn + feed enrichment in GET /api/events (#29)`
+
+---
+
+*Verified: 2026-05-11T20:35:00Z (Pass 2)*
+*Verifier: Claude (gsd-verifier)*
+*Pass 1 verified: 2026-05-11T19:35:00Z — see `re_verification` frontmatter for diff*

--- a/.planning/phases/03.0.3-youtube-feed-fixes/deferred-items.md
+++ b/.planning/phases/03.0.3-youtube-feed-fixes/deferred-items.md
@@ -1,0 +1,55 @@
+# Phase 03.0.3 deferred items
+
+Out-of-scope discoveries surfaced while executing plan 03.0.3-01. Logged per
+`AGENTS.md` Rule 1-3 scope-boundary rules — not auto-fixed; will be addressed
+in a follow-up issue or phase.
+
+## tests/integration/feed.test.ts — static-email collision on rerun
+
+**Found during:** End-of-plan verification (Plan 03.0.3-01 Task 6 follow-up).
+
+**Symptom:** `npx vitest run tests/integration/feed.test.ts` fails with
+`duplicate key value violates unique constraint "user_email_unique"` for
+static emails like `feed11a@test.local` / `p26-feed-a@test.local`.
+
+**Root cause:** The test seeds users with static deterministic emails;
+between runs, the prior rows linger in the test DB (`tests/setup.ts` runs
+migrations once but does NOT truncate the user table between runs).
+Pre-existing — confirmed by `git diff master..HEAD -- tests/integration/feed.test.ts`
+returning empty.
+
+**Scope decision:** NOT auto-fixed. The bug is unrelated to Plan 03.0.3-01's
+changes (refresh-content quota burn). Fixing it would require either:
+1. Rewriting the test's email-generation to use `uniq()` per call (similar to
+   the pattern in `tests/integration/refresh-content-quota.test.ts`).
+2. Adding a per-test cleanup hook that DELETEs users by email pattern.
+
+Either approach is a separate atomic PR — bundling it here would violate
+AGENTS.md "atomic PRs" practice.
+
+**Recommended follow-up:** File a standalone GitHub issue
+"feed.test.ts: static emails cause cross-run collisions" with the
+`tests/integration` label.
+
+## tests/integration/ingest-paste-then-poll.test.ts — handlePollActive throws
+
+**Found during:** End-of-plan verification (Plan 03.0.3-01 Task 6 follow-up).
+
+**Symptom:** Test "manual-paste event (source_id=NULL) flows through
+handlePollActive → snapshot row + youtube_videos.last_polled_at populated"
+fails with `TypeError: Cannot read properties of undefined (reading
+'status')` at `src/lib/sources/youtube/server/handlers/poll-active.ts:206`.
+
+**Root cause:** Pre-existing — confirmed by checking out `master` and
+running the same test (also fails). `git diff master..HEAD --
+src/lib/sources/youtube/server/handlers/poll-active.ts tests/integration/ingest-paste-then-poll.test.ts`
+returns empty.
+
+**Scope decision:** NOT auto-fixed. Unrelated to Plan 03.0.3-01's
+changes. Likely surfaced by a dependency bump in Phase 03.0.2 (Vitest 4
+upgrade or similar) or by `pollContent` returning a different shape in
+some test fixture. Out of scope per AGENTS.md atomic-PR rule.
+
+**Recommended follow-up:** File a standalone GitHub issue
+"ingest-paste-then-poll: handlePollActive TypeError on writeSnapshot"
+with the `tests/integration` label.

--- a/.planning/phases/03.0.3-youtube-feed-fixes/deferred-items.md
+++ b/.planning/phases/03.0.3-youtube-feed-fixes/deferred-items.md
@@ -53,3 +53,28 @@ some test fixture. Out of scope per AGENTS.md atomic-PR rule.
 **Recommended follow-up:** File a standalone GitHub issue
 "ingest-paste-then-poll: handlePollActive TypeError on writeSnapshot"
 with the `tests/integration` label.
+
+## .dev-oauth-mock.mjs — process.env reads outside config/env.ts (lint failure)
+
+**Found during:** Plan 03.0.3-02 end-of-plan `pnpm lint`.
+
+**Symptom:** `eslint .` fails on `.dev-oauth-mock.mjs` lines 9/10/11 with
+`'process.env' is restricted from being used. Read env via
+src/lib/server/config/env.ts (PITFALL P2 mitigation)`.
+
+**Root cause:** Pre-existing — `.dev-oauth-mock.mjs` is an untracked dev
+helper file (visible in `git status` at session start; not committed to
+master). The file uses `process.env` directly because it runs as a
+standalone Node script outside the SvelteKit/Hono runtime.
+
+**Scope decision:** NOT auto-fixed. The file is untracked and outside the
+plan's scope (Plan 03.0.3-02 touches feed-enrichment adapter wiring; the
+dev helper is unrelated). Options to resolve later:
+1. Add `.dev-*.mjs` / `.dev-*.ts` to `.eslintignore` (developer convention).
+2. Delete the file if it's an orphan from earlier dev work.
+3. Migrate the file to read env via `src/lib/server/config/env.ts` if it's
+   meant to ship.
+
+**Recommended follow-up:** Discuss with the operator (file is in their
+local working copy, not on master). Likely belongs in `.gitignore` /
+`.eslintignore` alongside the other `.dev-*.{ts,mjs}` developer scripts.

--- a/SOURCE-REFERENCE.md
+++ b/SOURCE-REFERENCE.md
@@ -551,9 +551,32 @@ User can change earliest-boundary через UI date picker:
 PATCH /api/sources/:id  body: { backfillTargetSince: "2023-06-01T00:00:00Z" }
 ```
 
-Server validates: future dates → `422 'date_must_be_past'`. Recomputes `backfill_complete`:
+Server validates: future dates → `422 'date_must_be_past'`. The PATCH does NOT eagerly mutate channel state — widening the target is handled lazily by the next refresh-content click's three-branch since-derivation (see §10 "Incremental-vs-deep-walk pattern"). Pre-Phase-03.0.3 this path called `resetChannelBackfillComplete` eagerly; that reset was a multi-tenant fairness violation because it re-opened the walk for ALL subscribers when a single user widened (D-#29-7).
 
-- Если new target older than current `backfill_oldest_at` → expanding window → reset complete=false (worker will re-pull historical).
-- Если new target newer than/equal frontier → covered → keep complete state.
+UI flow: user picks date → PATCH → optionally clicks Refresh → POST refresh-content (catch-up worker fires). Two clicks под одним user action. The refresh click's since-derivation decides whether to deep-walk or stay incremental based on the channel's current state — no PATCH-time state mutation required.
 
-UI flow: user picks date → PATCH → optionally clicks Refresh → POST refresh-content (catch-up worker fires). Two clicks под одним user action.
+## 10. Incremental-vs-deep-walk pattern
+
+*Established in Phase 03.0.3 P1 for YouTube; copy-the-pattern for Reddit / Twitter / Telegram / Discord adapters in Phase 03.1+.*
+
+The channel walker (`handlers/backfill-channel.ts` for YouTube; the analogous walker file for other adapters) computes the `since` argument it passes to `adapter.pollContent` using a three-branch derivation:
+
+| Channel state                                                                            | Branch        | `since`                              | `lastBackfillPageToken` |
+|------------------------------------------------------------------------------------------|---------------|--------------------------------------|--------------------------|
+| `backfill_complete = true`                                                               | `exhausted`   | `max(newestKnown, target)`           | cleared                  |
+| `!complete && deepestWalked !== null && target >= deepestWalked`                         | `incremental` | `max(newestKnown, target)`           | cleared                  |
+| else                                                                                     | `deep`        | `target`                             | preserved (resume cursor)|
+
+Definitions:
+  - **`target`** — the user's `backfill_target_since` for this source. Comes in as `job.data.depthBoundIso`.
+  - **`newestKnown`** — `MAX(<adapter's events table>.published_at) WHERE channel_id = $channelKey`. For YouTube: `getNewestKnownPublishedAt(channelKey)` in `src/lib/sources/youtube/server/newest-known.ts`. Returns `null` on a cold channel (caller falls back to `target`).
+  - **`deepestWalked`** — the channel's prior frontier (`backfill_oldest_at` column on `data_source_channel_state`).
+  - **`target >= deepestWalked`** — comparison by `.getTime()` ms-since-epoch. A "shallower" target (fewer days ago, more-recent instant) has a LARGER ms number than a deeper one. So `target=30d-ago, deepest=60d-ago` lands in incremental (30d-ago.ms > 60d-ago.ms); `target=epoch, deepest=30d-ago` lands in deep.
+
+Why `newestKnown` and not `last_polled_at`: backdated uploads (rare on YouTube, common on Telegram / Discord) have `publishedAt` earlier than the newest collected video. Using `MAX(published_at)` as the cursor means `walkedPastSince` fires only on items older than the newest collected — which is the correct semantic. `last_polled_at` would skip backdated uploads silently.
+
+Token-clear rule (incremental + exhausted branches): the persistent `lastBackfillPageToken` cursor from a prior deep-walk MUST be cleared before invoking `pollContent` in either incremental branch. Without this, a stale page-N cursor would cause `walkedPastSince` to fire immediately with zero events. Deep branch preserves the token so >MAX_PAGES walks resume from where the last walk stopped.
+
+Lazy widening: when the user widens `backfill_target_since` (e.g. 30d → epoch) via `PATCH /api/sources/:id`, the cross-source `updateSource` service does NOT eagerly reset channel state. The next refresh-content click sees `target < deepestWalked` and falls into the `deep` branch naturally. This avoids the multi-tenant fairness violation where one user's widening would re-open the walk for ALL subscribers on the channel (D-#29-7).
+
+Reference implementation: YouTube — `src/lib/sources/youtube/server/handlers/backfill-channel.ts` step 3 (the "Compute since" block). The `since_branch` discriminator is also written to the success/empty/error audit metadata for forensic queries — operator can run `SELECT metadata->>'since_branch', COUNT(*) FROM audit_log WHERE action='source.refresh_content_requested' GROUP BY 1` to see how often each branch fires on prod.

--- a/SOURCE-REFERENCE.md
+++ b/SOURCE-REFERENCE.md
@@ -580,3 +580,32 @@ Token-clear rule (incremental + exhausted branches): the persistent `lastBackfil
 Lazy widening: when the user widens `backfill_target_since` (e.g. 30d → epoch) via `PATCH /api/sources/:id`, the cross-source `updateSource` service does NOT eagerly reset channel state. The next refresh-content click sees `target < deepestWalked` and falls into the `deep` branch naturally. This avoids the multi-tenant fairness violation where one user's widening would re-open the walk for ALL subscribers on the channel (D-#29-7).
 
 Reference implementation: YouTube — `src/lib/sources/youtube/server/handlers/backfill-channel.ts` step 3 (the "Compute since" block). The `since_branch` discriminator is also written to the success/empty/error audit metadata for forensic queries — operator can run `SELECT metadata->>'since_branch', COUNT(*) FROM audit_log WHERE action='source.refresh_content_requested' GROUP BY 1` to see how often each branch fires on prod.
+
+## 11. Feed enrichment pattern
+
+*Established in Phase 03.0.3 P2 for YouTube; copy-the-pattern for Reddit / Twitter / Telegram / Discord adapters in Phase 03.1+.*
+
+Adapters that have per-event metadata worth showing on `FeedCard` (stats, channel/author chips, embedded media, etc.) implement the optional `enrichFeedDtos` method on `DataSourceAdapter`:
+
+```typescript
+interface DataSourceAdapter {
+  // ... other methods ...
+  enrichFeedDtos?(userId: string, dtos: EventDto[]): Promise<void>;
+}
+```
+
+Contract:
+  - The method MUST internally filter `dtos` to its own `kind` — callers do NOT pre-filter. Avoids the "did I forget to filter for adapter X?" footgun.
+  - The method MUTATES `dtos` in place; returns void.
+  - The method MUST swallow errors (log at WARN). A failed enrichment query MUST NOT break the feed render — the cards just render without the enrichment.
+  - The method MAY make multiple DB queries (YouTube makes 2: one for `youtube_video_snapshots` latest-per-videoId, one for `youtube_videos.channelTitle`). Batch by `IN (...)` over the externalIds extracted from filtered dtos.
+
+Three cross-source callsites iterate `allAdapters` and call this method:
+  - `src/routes/feed/+page.server.ts` — SSR for the primary `/feed` view
+  - `src/lib/server/http/routes/events.ts` — `GET /api/events` cursor pagination
+  - `src/routes/games/[gameId]/+page.server.ts` — per-game curated view
+
+Deliberate skip:
+  - `GET /api/events/deleted` (events.ts:374) does NOT call `enrichFeedDtos`. `DeletedEventsPanel.svelte` renders soft-deleted events with a compact KindIcon + strikethrough-title view — no stats line, no channel chip. The skip is documented inline with a load-bearing WHY comment at the call site.
+
+Reference implementation: YouTube — `src/lib/sources/youtube/server/feed-enrichment.ts`. The Phase 03.0.3 P2 commit replaced the inline JOIN in `/feed/+page.server.ts:162-237` with a single adapter loop that all three callsites share. Issue #29 Part 2 was the load-bearing motivation: pre-fix, the SSR first batch on `/feed` was enriched inline but `GET /api/events` cursor-paginated batches dropped both `stats` and `channelTitle` on every card past the first SSR batch.

--- a/drizzle/0029_outbox.sql
+++ b/drizzle/0029_outbox.sql
@@ -1,0 +1,72 @@
+-- Phase 03.0.3 follow-up (PR #31 Codex P2) — transactional outbox.
+--
+-- Closes the dual-write race between `data_sources` UPDATE and the
+-- force-deep `boss.send` enqueue. Any service that needs the queue
+-- write to commit atomically with a DB UPDATE writes a row here
+-- inside the same Drizzle transaction; a forwarder long-running in the
+-- worker process picks up pending rows (via Postgres LISTEN/NOTIFY)
+-- and forwards them to pg-boss.
+--
+-- Schema notes:
+--   - CROSS-TENANT BY DESIGN. The outbox is a queue-intent table; the
+--     payload carries tenant context (userId in the job data). The
+--     forwarder does NOT introspect payloads — it just calls
+--     boss.send(queue, payload, options). Tenant scope flows through
+--     the downstream queue handler, not this table.
+--   - `forwarded_at` is the durable "this row's intent reached pg-boss"
+--     marker. Cleanup (purge.daily extension) deletes rows older than
+--     7 days after forward.
+--   - Index on (created_at) WHERE forwarded_at IS NULL keeps the
+--     forwarder's pending-scan O(log N) regardless of total rows.
+--
+-- INSERT-only is NOT enforced at the trigger level (unlike audit_log)
+-- because the forwarder needs to UPDATE forwarded_at + retry counters.
+-- The audit-log structural lock is for tenant-relative pagination
+-- safety; outbox has neither tenant scope nor user-facing pagination.
+
+CREATE TABLE outbox (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  queue text NOT NULL,
+  payload jsonb NOT NULL,
+  options jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  -- Set by forwarder after a successful boss.send. NULL means pending.
+  forwarded_at timestamptz,
+  -- Retry telemetry — every failed forward attempt bumps this. Operator
+  -- visibility via SQL: SELECT * FROM outbox WHERE forwarder_attempt > 3
+  -- ORDER BY last_attempt_at DESC.
+  forwarder_attempt int NOT NULL DEFAULT 0,
+  last_error text,
+  last_attempt_at timestamptz
+);--> statement-breakpoint
+
+-- Partial index: scans only the pending tail. created_at ordering
+-- gives the forwarder a stable FIFO without needing a separate priority
+-- column.
+CREATE INDEX outbox_pending_idx
+  ON outbox (created_at)
+  WHERE forwarded_at IS NULL;--> statement-breakpoint
+
+-- AFTER INSERT trigger emits a NOTIFY so the forwarder picks up the new
+-- row within ms instead of waiting for the periodic sweep. The channel
+-- name 'outbox.new' is the contract — the forwarder LISTENs on it.
+-- The trigger fires per-row (FOR EACH ROW) so a transaction inserting
+-- multiple outbox rows generates one NOTIFY per row; pg deduplicates
+-- identical NOTIFY payloads within a transaction so the forwarder
+-- gets at most one wakeup per tx commit, not per row.
+--
+-- NOTIFY is "best-effort, fire-and-forget" at the protocol level — if
+-- the forwarder LISTEN connection dropped, we miss the wakeup. The
+-- forwarder's periodic sweep (default 30s) is the durability backstop.
+CREATE FUNCTION outbox_notify() RETURNS TRIGGER AS $$
+BEGIN
+  PERFORM pg_notify('outbox.new', '');
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;--> statement-breakpoint
+
+CREATE TRIGGER outbox_notify_trigger
+  AFTER INSERT ON outbox
+  FOR EACH ROW
+  EXECUTE FUNCTION outbox_notify();

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1778900000000,
       "tag": "0028_phase03_01_drop_data_sources_channel_state",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1779000000000,
+      "tag": "0029_outbox",
+      "breakpoints": true
     }
   ]
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -49,6 +49,16 @@ export default [
       // repo state from prior plan runs; ESLint should not police them.
       // The active source-of-truth is the top-level src/ + tests/ trees.
       ".claude/",
+      // Phase 03.0.3 follow-up — developer-personal dev helpers
+      // (.dev-worker.ts, .dev-oauth-mock.mjs, .dev-probe-youtube.ts,
+      // .dev-trigger-poll.ts, etc). These are intentionally outside
+      // source control (see .gitignore) and pin a single developer's
+      // machine setup. They read process.env directly because they run
+      // as standalone Node scripts outside the SvelteKit/Hono runtime
+      // (the no-restricted-properties rule is load-bearing for the
+      // runtime code, not for one-off dev scripts).
+      ".dev-*.ts",
+      ".dev-*.mjs",
     ],
   },
   js.configs.recommended,

--- a/src/lib/components/PollingBadge.svelte
+++ b/src/lib/components/PollingBadge.svelte
@@ -69,7 +69,15 @@
   // Per-video refactor (2026-05-06): tier keyed on publishedAt (the video's
   // age), not occurredAt (the event's age). NULL publishedAt → 'pending'
   // (channel-context-backfill in flight; show "Pending..." badge).
-  function resolveTier(publishedAt: Date | null, lastPollStatus: string | null, now: Date): Tier {
+  // Phase 03.0.3 follow-up — bootstrap rule: frozen by age + lastPolledAt=null
+  // → upgrade to 'cold' so the scheduler picks the video up once. See the
+  // canonical resolver header for the issue #29 extension rationale.
+  function resolveTier(
+    publishedAt: Date | null,
+    lastPollStatus: string | null,
+    lastPolledAt: Date | null,
+    now: Date,
+  ): Tier {
     if (publishedAt === null) return "pending";
     if (lastPollStatus !== null && UNAVAILABLE_POLL_STATUSES.includes(lastPollStatus)) {
       return "unavailable";
@@ -77,6 +85,7 @@
     const ageMs = now.getTime() - publishedAt.getTime();
     if (ageMs < TIER_BOUNDARY_ACTIVE_MS) return "active";
     if (ageMs < TIER_BOUNDARY_COLD_MS) return "cold";
+    if (lastPolledAt === null) return "cold";
     return "frozen";
   }
 
@@ -121,7 +130,7 @@
   // enough for the user-facing copy.
   const now = $derived(new Date());
 
-  const tier: Tier = $derived(resolveTier(publishedAt, event.lastPollStatus, now));
+  const tier: Tier = $derived(resolveTier(publishedAt, event.lastPollStatus, lastPolledAt, now));
 
   // Variant resolution per UI-SPEC §"Interaction Contracts → Variant resolution".
   type Variant =

--- a/src/lib/server/db/schema/index.ts
+++ b/src/lib/server/db/schema/index.ts
@@ -15,6 +15,8 @@ export * from "./event-games.js";
 export * from "./events.js";
 export * from "./game-steam-listings.js";
 export * from "./games.js";
+// Phase 03.0.3 follow-up (PR #31 Codex P2) — transactional outbox.
+export * from "./outbox.js";
 // Phase 03.0.1 Plan 02 — YouTube schemas relocated to per-source folder
 // per D-14. Re-exported here so existing call sites
 // (`import { youtubeVideos } from "$lib/server/db/schema/index.js"`)

--- a/src/lib/server/db/schema/outbox.ts
+++ b/src/lib/server/db/schema/outbox.ts
@@ -64,6 +64,8 @@ export const outbox = pgTable(
     // without the partial clause — defeating the forwarder's
     // pending-scan optimisation (full index over every forwarded
     // row instead of the tight pending tail).
-    index("outbox_pending_idx").on(t.createdAt).where(sql`forwarded_at IS NULL`),
+    index("outbox_pending_idx")
+      .on(t.createdAt)
+      .where(sql`forwarded_at IS NULL`),
   ],
 );

--- a/src/lib/server/db/schema/outbox.ts
+++ b/src/lib/server/db/schema/outbox.ts
@@ -1,0 +1,55 @@
+// Phase 03.0.3 follow-up (PR #31 Codex P2) — transactional outbox table.
+//
+// CROSS-TENANT BY DESIGN. This is a queue-intent table: rows describe
+// pg-boss jobs to be sent. Tenant context is inside `payload`; the
+// forwarder does NOT introspect — it just calls boss.send(queue, payload,
+// options). Tenant scope flows through the downstream queue handler.
+// ESLint tenant-scope rule allowlists this table via the same header
+// comment convention used by youtube_video_snapshots / youtube_videos.
+//
+// Writer pattern (idiomatic):
+//   await db.transaction(async (tx) => {
+//     await tx.update(dataSources).set(...).where(...);
+//     await enqueueViaOutbox(tx, QUEUES.YOUTUBE_BACKFILL_CHANNEL, payload, opts);
+//   });
+//   // Single COMMIT — UPDATE and outbox row commit atomically. The
+//   // forwarder picks up the row via LISTEN/NOTIFY (or 30s fallback
+//   // sweep) and calls boss.send.
+//
+// Failure modes:
+//   - boss.send fails: forwarder leaves the row pending, bumps
+//     forwarder_attempt, logs last_error. Next tick (or NOTIFY)
+//     retries. At-least-once delivery.
+//   - Forwarder crashes between boss.send success and forwarded_at
+//     update: next tick re-forwards. pg-boss singletonKey in options
+//     dedups duplicate sends; downstream handlers must be idempotent
+//     (events have UNIQUE (user_id, source_id, external_id); audit
+//     writes are accepted as occasional dup).
+//
+// Cleanup: extended purge.daily cron deletes rows older than 7 days
+// after successful forward.
+
+import { pgTable, text, timestamp, jsonb, integer, uuid, index } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+
+export const outbox = pgTable(
+  "outbox",
+  {
+    id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+    queue: text("queue").notNull(),
+    payload: jsonb("payload").$type<Record<string, unknown>>().notNull(),
+    options: jsonb("options").$type<Record<string, unknown>>().notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    forwardedAt: timestamp("forwarded_at", { withTimezone: true }),
+    forwarderAttempt: integer("forwarder_attempt").notNull().default(0),
+    lastError: text("last_error"),
+    lastAttemptAt: timestamp("last_attempt_at", { withTimezone: true }),
+  },
+  (t) => [
+    // Mirrors the partial index in migration 0029 — Drizzle's pg dialect
+    // doesn't have a first-class partial-index helper but does pass
+    // arbitrary `where` clauses through; declared here so drizzle-kit's
+    // diff stays clean against future schema changes.
+    index("outbox_pending_idx").on(t.createdAt),
+  ],
+);

--- a/src/lib/server/db/schema/outbox.ts
+++ b/src/lib/server/db/schema/outbox.ts
@@ -18,13 +18,21 @@
 //
 // Failure modes:
 //   - boss.send fails: forwarder leaves the row pending, bumps
-//     forwarder_attempt, logs last_error. Next tick (or NOTIFY)
-//     retries. At-least-once delivery.
-//   - Forwarder crashes between boss.send success and forwarded_at
-//     update: next tick re-forwards. pg-boss singletonKey in options
-//     dedups duplicate sends; downstream handlers must be idempotent
-//     (events have UNIQUE (user_id, source_id, external_id); audit
-//     writes are accepted as occasional dup).
+//     forwarder_attempt, logs last_error. Retry happens after the
+//     CLAIM_WINDOW_SECONDS interval (60s in outbox-forwarder.ts) has
+//     elapsed since last_attempt_at — concurrent claimers see the
+//     bumped timestamp and skip the row until the window expires.
+//     So a failed row retries roughly every 60s on the next sweep
+//     or NOTIFY wakeup, NOT every tick. After MAX_ATTEMPTS (20) the
+//     row stays pending until an operator manually intervenes.
+//   - Forwarder crashes mid-send (last_attempt_at bumped but no
+//     forwarded_at update and no logged failure): the row stays
+//     claimed for CLAIM_WINDOW_SECONDS, then releases naturally.
+//     Another forwarder (or the next sweep) picks it up. pg-boss
+//     singletonKey in options dedups duplicate sends in the worst-
+//     case race; downstream handlers must be idempotent (events
+//     have UNIQUE (user_id, source_id, external_id); audit writes
+//     are accepted as occasional dup).
 //
 // Cleanup: extended purge.daily cron deletes rows older than 7 days
 // after successful forward.

--- a/src/lib/server/db/schema/outbox.ts
+++ b/src/lib/server/db/schema/outbox.ts
@@ -35,7 +35,9 @@ import { sql } from "drizzle-orm";
 export const outbox = pgTable(
   "outbox",
   {
-    id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
     queue: text("queue").notNull(),
     payload: jsonb("payload").$type<Record<string, unknown>>().notNull(),
     options: jsonb("options").$type<Record<string, unknown>>().notNull().default({}),

--- a/src/lib/server/db/schema/outbox.ts
+++ b/src/lib/server/db/schema/outbox.ts
@@ -56,10 +56,14 @@ export const outbox = pgTable(
     lastAttemptAt: timestamp("last_attempt_at", { withTimezone: true }),
   },
   (t) => [
-    // Mirrors the partial index in migration 0029 — Drizzle's pg dialect
-    // doesn't have a first-class partial-index helper but does pass
-    // arbitrary `where` clauses through; declared here so drizzle-kit's
-    // diff stays clean against future schema changes.
-    index("outbox_pending_idx").on(t.createdAt),
+    // Phase 03.0.3 round-5 (Codex P2) — partial index matching
+    // migration 0029's `CREATE INDEX outbox_pending_idx ON outbox
+    // (created_at) WHERE forwarded_at IS NULL`. Without the `.where`
+    // chain the schema would diverge from the applied migration and
+    // a future `drizzle-kit generate` could regenerate the index
+    // without the partial clause — defeating the forwarder's
+    // pending-scan optimisation (full index over every forwarded
+    // row instead of the tight pending tail).
+    index("outbox_pending_idx").on(t.createdAt).where(sql`forwarded_at IS NULL`),
   ],
 );

--- a/src/lib/server/http/routes/events.ts
+++ b/src/lib/server/http/routes/events.ts
@@ -79,6 +79,7 @@ import { requestRefreshPoll } from "../../services/refresh-poll.js";
 import { AppError } from "../../services/errors.js";
 import { parseIngestUrl } from "../../services/url-parser.js";
 import type { EventKind } from "$lib/sources/adapter.js";
+import { allAdapters } from "$lib/sources/registry.js";
 import { toEventDto, loadGameIdsForEvent, mapEventsToDtos } from "../../dto.js";
 import { getAuditContext } from "../middleware/audit-ip.js";
 import { mapErr, type RouteVars } from "./_shared.js";
@@ -328,6 +329,15 @@ eventsRoutes.get(
       // lookup. Two queries total: one for events (page.rows above),
       // one for the junction (mapEventsToDtos).
       const dtos = await mapEventsToDtos(c.var.userId, page.rows);
+      // Phase 03.0.3 P2 — adapter-driven feed enrichment. Same loop as the
+      // /feed SSR loader; closes issue #29 Part 2 (cursor-paginated batches
+      // pre-fix dropped stats + channelTitle on every card past the first
+      // SSR batch).
+      for (const adapter of allAdapters) {
+        if (adapter.enrichFeedDtos) {
+          await adapter.enrichFeedDtos(c.var.userId, dtos);
+        }
+      }
       return c.json({
         rows: dtos,
         nextCursor: page.nextCursor,
@@ -380,6 +390,13 @@ eventsRoutes.get("/events/deleted", async (c) => {
     // column by Plan 02.1-27 design), so the DTO will surface the gameIds
     // they were attached to at delete time.
     const dtos = await mapEventsToDtos(c.var.userId, rows);
+    // Phase 03.0.3 P2 — deliberately NOT calling adapter.enrichFeedDtos
+    // here. DeletedEventsPanel.svelte (`src/lib/components/DeletedEventsPanel.svelte`)
+    // renders soft-deleted events with a compact KindIcon + strikethrough-
+    // title view — no stats line, no channel chip. Running the enrichment
+    // query would be wasted I/O. If a future redesign of DeletedEventsPanel
+    // adds the stats/channel chips back, add the same `for-of allAdapters`
+    // loop the GET /api/events handler uses (see ~25 lines up).
     return c.json({ rows: dtos });
   } catch (err) {
     return mapErr(c, err, "GET /api/events/deleted");

--- a/src/lib/server/http/routes/sources.ts
+++ b/src/lib/server/http/routes/sources.ts
@@ -31,7 +31,6 @@ import {
   softDeleteSource,
   restoreSource,
 } from "../../services/data-sources.js";
-import { resetChannelBackfillComplete } from "../../services/channel-state.js";
 import { getUserQuotaUsedToday, nextPacificMidnight } from "../../services/quota.js";
 import { toDataSourceDto } from "../../dto.js";
 import { db } from "../../db/client.js";
@@ -383,14 +382,12 @@ sourcesRoutes.post("/sources/:id/refresh-content", async (c) => {
       }
     }
 
-    // Phase 03.0.1 Wave 2 — channel-scoped trust-but-verify. Reset
-    // channel-level backfill_complete BEFORE worker enqueue so the
-    // catch-up walk re-checks completeness. Channel state covers ALL
-    // subscribers; one user's refresh can re-open the walk for everyone.
-    if (source.channelId) {
-      await resetChannelBackfillComplete(source.kind, source.channelId);
-    }
-
+    // Phase 03.0.3 P1 — no eager state reset. The three-branch
+    // since-derivation in backfill-channel.ts decides at walk-time whether
+    // the click is steady-state (exhausted), incremental, or deep — the
+    // pre-Phase-03.0.3 trust-but-verify reset was redundant AND a
+    // multi-tenant fairness violation (it re-opened the walk for ALL
+    // subscribers when one user clicked refresh — D-#29-7).
     const result = await adapter.backfillSource(
       {
         id: source.id,

--- a/src/lib/server/services/channel-state.ts
+++ b/src/lib/server/services/channel-state.ts
@@ -129,26 +129,6 @@ export async function markChannelBackfillComplete(
 }
 
 /**
- * Reset `backfill_complete=false` — called from the user-facing
- * refresh-content endpoint as trust-but-verify (let the worker re-check
- * if the channel has new content past endOfPlaylist; if still empty,
- * worker re-sets to true).
- */
-export async function resetChannelBackfillComplete(
-  kind: SourceKind,
-  channelKey: string,
-  dbCtx: DbOrTx = db,
-): Promise<void> {
-  await dbCtx
-    .insert(dataSourceChannelState)
-    .values({ kind, channelKey, backfillComplete: false })
-    .onConflictDoUpdate({
-      target: [dataSourceChannelState.kind, dataSourceChannelState.channelKey],
-      set: { backfillComplete: false, updatedAt: new Date() },
-    });
-}
-
-/**
  * Persistent backfill pagination cursor. Adapter returns `nextPageToken`
  * from each walk; worker stores it here so the next walk resumes from the
  * saved position instead of re-fetching the same first MAX_PAGES of pages.

--- a/src/lib/server/services/data-sources.ts
+++ b/src/lib/server/services/data-sources.ts
@@ -308,7 +308,20 @@ async function maybeEnqueueForceDeepWalk(
       forceDeep: true,
     },
     {
-      singletonKey: `force-deep-${opts.channelKey}-${opts.triggerUserId}`,
+      // Phase 03.0.3 round-4 (Codex P2) — include target in the
+      // singleton key. The key dedupes IN-FLIGHT pg-boss jobs (queued
+      // or active). Without `newTarget` in the key, two rapid widens
+      // (e.g. 30d→90d, then 90d→epoch before the first walk finishes)
+      // share the same key; pg-boss rejects the second send with a
+      // null return value, the forwarder marks the row forwarded
+      // anyway, and the deeper user intent is silently lost — later
+      // refresh-content clicks land in branch=exhausted because the
+      // first walk already set complete=true at the shallower depth.
+      // Including the target gives each unique widen its own key:
+      // back-to-back widens with different targets both run; an
+      // idempotent re-PATCH with the same target stays correctly
+      // deduped.
+      singletonKey: `force-deep-${opts.channelKey}-${opts.triggerUserId}-${opts.newTarget.getTime()}`,
       priority: 1,
     },
   );

--- a/src/lib/server/services/data-sources.ts
+++ b/src/lib/server/services/data-sources.ts
@@ -660,6 +660,46 @@ export async function updateSource(
     // fairness violation per D-#29-7).
   }
 
+  // Phase 03.0.3 follow-up (PR #31 review P2) — atomicity-of-intent.
+  // The force-deep enqueue runs BEFORE the UPDATE so a transient
+  // boss.send failure aborts the PATCH cleanly (HTTP 500 → user
+  // retries → eventual success). Pre-fix order was UPDATE-then-enqueue;
+  // on enqueue failure that committed the widen but silently lost the
+  // force-deep job → user's intent to walk older history permanently
+  // broken with no recovery path (a re-PATCH with the same target is a
+  // no-op because previousTarget already equals the widened value).
+  //
+  // Source identity fields used here (existing.kind, existing.channelId)
+  // cannot change via PATCH — updateSource only mutates displayName /
+  // autoImport / isOwnedByMe / metadata / backfillTargetSince. Reading
+  // them off `existing` instead of the post-UPDATE `row` is safe.
+  //
+  // Failure modes after reversal:
+  //   - boss.send throws → maybeEnqueueForceDeepWalk re-throws → UPDATE
+  //     never runs → user sees 500 → retries → consistent recovery.
+  //   - UPDATE throws AFTER successful enqueue (extremely rare —
+  //     connection drop in the ms window) → job is in queue with the
+  //     new target, but data_sources still has the old target. The
+  //     subsequent walker run's fan-out (backfill-channel.ts:445)
+  //     filters per-subscriber by their STORED target_since → events
+  //     past the user's old target are skipped at INSERT. User's
+  //     PATCH retry succeeds, and a second deep walk (triggered by the
+  //     same maybeEnqueueForceDeepWalk check) fan-outs the older events
+  //     correctly. Cost: one wasted deep walk (~50 quota units), no
+  //     correctness regression, no silent loss.
+  if (
+    patch.backfillTargetSince !== undefined &&
+    existing.kind === "youtube_channel" &&
+    existing.channelId !== null
+  ) {
+    await maybeEnqueueForceDeepWalk({
+      channelKey: existing.channelId,
+      triggerUserId: userId,
+      previousTarget: existing.backfillTargetSince,
+      newTarget: patch.backfillTargetSince,
+    });
+  }
+
   const [row] = await db
     .update(dataSources)
     .set(update)
@@ -672,19 +712,6 @@ export async function updateSource(
     )
     .returning();
   if (!row) throw new NotFoundError();
-
-  if (
-    patch.backfillTargetSince !== undefined &&
-    row.kind === "youtube_channel" &&
-    row.channelId !== null
-  ) {
-    await maybeEnqueueForceDeepWalk({
-      channelKey: row.channelId,
-      triggerUserId: userId,
-      previousTarget: existing.backfillTargetSince,
-      newTarget: patch.backfillTargetSince,
-    });
-  }
 
   if (patch.autoImport !== undefined && patch.autoImport !== existing.autoImport) {
     await writeAudit({

--- a/src/lib/server/services/data-sources.ts
+++ b/src/lib/server/services/data-sources.ts
@@ -42,7 +42,9 @@ import { withQuotaGuard } from "./quota.js";
 import { isPgUniqueViolation } from "../db/postgres-errors.js";
 import { getAdapter } from "$lib/sources/registry.js";
 import { youtubeChannels } from "../db/schema/index.js";
-import { ensureChannelState } from "./channel-state.js";
+import { ensureChannelState, getChannelState } from "./channel-state.js";
+import { getBoss } from "../queue-client.js";
+import { QUEUES } from "../queues.js";
 
 // Phase 03.0-12 (D-09 / UI-SPEC BackfillPicker) — initial-backfill window
 // presets accepted by createSource for kind=youtube_channel + autoImport.
@@ -239,6 +241,67 @@ export async function assertNoChannelConflict(
  * 2005 to prevent the sentinel being indistinguishable from legitimate
  * input.
  */
+/**
+ * Phase 03.0.3 follow-up — when a user widens `backfillTargetSince` past the
+ * channel's recorded `backfill_oldest_at` on a fully-walked channel, enqueue
+ * a one-shot force-deep walk for this user. Without this override, the
+ * three-branch since-derivation in `handleBackfillChannel` always routes to
+ * `branch=exhausted` (D-#29-7 multi-tenant fairness prioritises the channel
+ * state's exhausted flag over the per-user target), so historical events
+ * below the prior depth would never surface on the next refresh-content
+ * click. This function is the single per-user opt-in to override that.
+ *
+ * Skipped when:
+ *   - new target is NOT deeper than the previous target (no widening);
+ *   - channel state row missing (no prior walk — three-branch logic
+ *     naturally routes to `branch=deep` on its own);
+ *   - channel state's `backfillComplete` is false (three-branch logic
+ *     already routes to `incremental` or `deep` based on `backfillOldestAt`);
+ *   - new target is NOT deeper than `backfill_oldest_at` (we already walked
+ *     past the requested depth — nothing new to find).
+ *
+ * Quota attribution: the trigger user (this PATCH author) pays. Subscribers
+ * on the same channel free-ride on fan-out — same as a normal refresh-content
+ * click. `singletonKey` is `force-deep-{channelKey}-{userId}` so each user
+ * gets one job per channel, but two users widening on the same channel
+ * concurrently both get their own walk.
+ */
+async function maybeEnqueueForceDeepWalk(opts: {
+  channelKey: string;
+  triggerUserId: string;
+  previousTarget: Date | null;
+  newTarget: Date;
+}): Promise<void> {
+  if (
+    opts.previousTarget !== null &&
+    opts.newTarget.getTime() >= opts.previousTarget.getTime()
+  ) {
+    return;
+  }
+  const state = await getChannelState("youtube_channel", opts.channelKey);
+  if (!state) return;
+  if (state.backfillComplete !== true) return;
+  if (state.backfillOldestAt === null) return;
+  if (opts.newTarget.getTime() >= state.backfillOldestAt.getTime()) return;
+
+  const boss = await getBoss();
+  await boss.send(
+    QUEUES.YOUTUBE_BACKFILL_CHANNEL,
+    {
+      kind: "youtube_channel" as const,
+      channelKey: opts.channelKey,
+      triggerUserId: opts.triggerUserId,
+      depthBoundIso: opts.newTarget.toISOString(),
+      flow: "historical" as const,
+      forceDeep: true,
+    },
+    {
+      singletonKey: `force-deep-${opts.channelKey}-${opts.triggerUserId}`,
+      priority: 1,
+    },
+  );
+}
+
 function backfillWindowToDate(window: BackfillWindow): Date {
   const now = Date.now();
   switch (window) {
@@ -609,6 +672,19 @@ export async function updateSource(
     )
     .returning();
   if (!row) throw new NotFoundError();
+
+  if (
+    patch.backfillTargetSince !== undefined &&
+    row.kind === "youtube_channel" &&
+    row.channelId !== null
+  ) {
+    await maybeEnqueueForceDeepWalk({
+      channelKey: row.channelId,
+      triggerUserId: userId,
+      previousTarget: existing.backfillTargetSince,
+      newTarget: patch.backfillTargetSince,
+    });
+  }
 
   if (patch.autoImport !== undefined && patch.autoImport !== existing.autoImport) {
     await writeAudit({

--- a/src/lib/server/services/data-sources.ts
+++ b/src/lib/server/services/data-sources.ts
@@ -38,7 +38,7 @@ import type { SourceKind } from "$lib/sources/adapter.js";
 import { writeAudit } from "../audit.js";
 import { env } from "../config/env.js";
 import { AppError, NotFoundError } from "./errors.js";
-import { withQuotaGuard } from "./quota.js";
+import { withQuotaGuard, getUserQuotaUsedToday, nextPacificMidnight } from "./quota.js";
 import { isPgUniqueViolation } from "../db/postgres-errors.js";
 import { getAdapter } from "$lib/sources/registry.js";
 import { youtubeChannels } from "../db/schema/index.js";
@@ -283,6 +283,48 @@ async function maybeEnqueueForceDeepWalk(
   if (state.backfillComplete !== true) return;
   if (state.backfillOldestAt === null) return;
   if (opts.newTarget.getTime() >= state.backfillOldestAt.getTime()) return;
+
+  // Phase 03.0.3 round-6 (Codex P2) — per-user fair-share cap check.
+  // Force-deep walks consume the same user quota as a refresh-content
+  // click (the worker audits them as a capped 'historical' flow). The
+  // POST /api/sources/:id/refresh-content path runs this check before
+  // enqueueing; without the equivalent guard here, a user who already
+  // hit their daily cap could trigger a deep historical walk through
+  // PATCH /api/sources/:id widening — the cap counter would only
+  // observe the overage post-walk, by which time operator quota is
+  // already spent. Mirror the refresh-content check verbatim so both
+  // paths fail-loud with the same 429 envelope.
+  const adapter = getAdapter("youtube_channel");
+  const cap = adapter?.observability.userQuotaCap;
+  if (cap?.requestsPerDay !== undefined || cap?.eventsPerDay !== undefined) {
+    const used = await getUserQuotaUsedToday(opts.triggerUserId, "youtube_channel");
+    const resetAt = nextPacificMidnight();
+    const resetInSeconds = Math.max(0, Math.floor((resetAt.getTime() - Date.now()) / 1000));
+    if (cap.requestsPerDay !== undefined && used.requests >= cap.requestsPerDay) {
+      throw new AppError(
+        `daily request quota exhausted: ${used.requests}/${cap.requestsPerDay}`,
+        "requests_quota_exhausted",
+        429,
+        {
+          cap: cap.requestsPerDay,
+          used: used.requests,
+          reset_in_seconds: resetInSeconds,
+        },
+      );
+    }
+    if (cap.eventsPerDay !== undefined && used.events >= cap.eventsPerDay) {
+      throw new AppError(
+        `daily events quota exhausted: ${used.events}/${cap.eventsPerDay}`,
+        "events_quota_exhausted",
+        429,
+        {
+          cap: cap.eventsPerDay,
+          used: used.events,
+          reset_in_seconds: resetInSeconds,
+        },
+      );
+    }
+  }
 
   // Phase 03.0.3 follow-up (PR #31 Codex P2) — write the force-deep
   // intent through the transactional outbox so it commits atomically

--- a/src/lib/server/services/data-sources.ts
+++ b/src/lib/server/services/data-sources.ts
@@ -43,8 +43,8 @@ import { isPgUniqueViolation } from "../db/postgres-errors.js";
 import { getAdapter } from "$lib/sources/registry.js";
 import { youtubeChannels } from "../db/schema/index.js";
 import { ensureChannelState, getChannelState } from "./channel-state.js";
-import { getBoss } from "../queue-client.js";
 import { QUEUES } from "../queues.js";
+import { enqueueViaOutbox } from "./outbox.js";
 
 // Phase 03.0-12 (D-09 / UI-SPEC BackfillPicker) — initial-backfill window
 // presets accepted by createSource for kind=youtube_channel + autoImport.
@@ -266,12 +266,15 @@ export async function assertNoChannelConflict(
  * gets one job per channel, but two users widening on the same channel
  * concurrently both get their own walk.
  */
-async function maybeEnqueueForceDeepWalk(opts: {
-  channelKey: string;
-  triggerUserId: string;
-  previousTarget: Date | null;
-  newTarget: Date;
-}): Promise<void> {
+async function maybeEnqueueForceDeepWalk(
+  tx: Tx,
+  opts: {
+    channelKey: string;
+    triggerUserId: string;
+    previousTarget: Date | null;
+    newTarget: Date;
+  },
+): Promise<void> {
   if (opts.previousTarget !== null && opts.newTarget.getTime() >= opts.previousTarget.getTime()) {
     return;
   }
@@ -281,8 +284,20 @@ async function maybeEnqueueForceDeepWalk(opts: {
   if (state.backfillOldestAt === null) return;
   if (opts.newTarget.getTime() >= state.backfillOldestAt.getTime()) return;
 
-  const boss = await getBoss();
-  await boss.send(
+  // Phase 03.0.3 follow-up (PR #31 Codex P2) — write the force-deep
+  // intent through the transactional outbox so it commits atomically
+  // with the data_sources UPDATE in the enclosing transaction. The
+  // forwarder picks the row up via LISTEN/NOTIFY (typically <10ms) and
+  // calls boss.send asynchronously. If boss.send fails the row stays
+  // pending and the forwarder retries on every NOTIFY + 30s sweep.
+  // Pre-outbox the same code path did a direct boss.send which:
+  //   - could win the race against the UPDATE (worker reads pre-UPDATE
+  //     state of data_sources, fan-out filters old events out, silent
+  //     loss of widen intent), and
+  //   - committed UPDATE before send so a transient queue failure was
+  //     a permanent silent loss with no user-side recovery.
+  await enqueueViaOutbox(
+    tx,
     QUEUES.YOUTUBE_BACKFILL_CHANNEL,
     {
       kind: "youtube_channel" as const,
@@ -674,58 +689,52 @@ export async function updateSource(
     // above are per-user.
   }
 
-  // Phase 03.0.3 follow-up (PR #31 review P2) — atomicity-of-intent.
-  // The force-deep enqueue runs BEFORE the UPDATE so a transient
-  // boss.send failure aborts the PATCH cleanly (HTTP 500 → user
-  // retries → eventual success). Pre-fix order was UPDATE-then-enqueue;
-  // on enqueue failure that committed the widen but silently lost the
-  // force-deep job → user's intent to walk older history permanently
-  // broken with no recovery path (a re-PATCH with the same target is a
-  // no-op because previousTarget already equals the widened value).
+  // Phase 03.0.3 follow-up (PR #31 Codex P2) — atomicity-of-intent via
+  // transactional outbox. The UPDATE and the force-deep queue intent
+  // commit in a single Drizzle transaction so the worker cannot pick
+  // up the force-deep job before data_sources reflects the widened
+  // target (the pre-outbox direct boss.send path raced against the
+  // UPDATE: pg-boss NOTIFY arrives in ~5ms; our UPDATE commits in
+  // ~15-25ms; worker reads pre-UPDATE subscriber state ~30% of the
+  // time on healthy load; fan-out filters by stored backfillTargetSince
+  // and silently skips old events — permanent silent loss with no
+  // user-side recovery). Outbox writes the intent into the outbox
+  // table inside the tx; the forwarder (worker handler) translates
+  // committed rows into boss.send asynchronously via LISTEN/NOTIFY.
   //
-  // Source identity fields used here (existing.kind, existing.channelId)
-  // cannot change via PATCH — updateSource only mutates displayName /
-  // autoImport / isOwnedByMe / metadata / backfillTargetSince. Reading
-  // them off `existing` instead of the post-UPDATE `row` is safe.
-  //
-  // Failure modes after reversal:
-  //   - boss.send throws → maybeEnqueueForceDeepWalk re-throws → UPDATE
-  //     never runs → user sees 500 → retries → consistent recovery.
-  //   - UPDATE throws AFTER successful enqueue (extremely rare —
-  //     connection drop in the ms window) → job is in queue with the
-  //     new target, but data_sources still has the old target. The
-  //     subsequent walker run's fan-out (backfill-channel.ts:445)
-  //     filters per-subscriber by their STORED target_since → events
-  //     past the user's old target are skipped at INSERT. User's
-  //     PATCH retry succeeds, and a second deep walk (triggered by the
-  //     same maybeEnqueueForceDeepWalk check) fan-outs the older events
-  //     correctly. Cost: one wasted deep walk (~50 quota units), no
-  //     correctness regression, no silent loss.
-  if (
-    patch.backfillTargetSince !== undefined &&
-    existing.kind === "youtube_channel" &&
-    existing.channelId !== null
-  ) {
-    await maybeEnqueueForceDeepWalk({
-      channelKey: existing.channelId,
-      triggerUserId: userId,
-      previousTarget: existing.backfillTargetSince,
-      newTarget: patch.backfillTargetSince,
-    });
-  }
+  // Source identity fields used to gate the enqueue (existing.kind,
+  // existing.channelId) cannot change via PATCH — updateSource only
+  // mutates displayName / autoImport / isOwnedByMe / metadata /
+  // backfillTargetSince. Reading them off `existing` instead of the
+  // post-UPDATE `row` is safe.
+  const row = await db.transaction(async (tx) => {
+    if (
+      patch.backfillTargetSince !== undefined &&
+      existing.kind === "youtube_channel" &&
+      existing.channelId !== null
+    ) {
+      await maybeEnqueueForceDeepWalk(tx, {
+        channelKey: existing.channelId,
+        triggerUserId: userId,
+        previousTarget: existing.backfillTargetSince,
+        newTarget: patch.backfillTargetSince,
+      });
+    }
 
-  const [row] = await db
-    .update(dataSources)
-    .set(update)
-    .where(
-      and(
-        eq(dataSources.userId, userId),
-        eq(dataSources.id, sourceId),
-        isNull(dataSources.deletedAt),
-      ),
-    )
-    .returning();
-  if (!row) throw new NotFoundError();
+    const [updated] = await tx
+      .update(dataSources)
+      .set(update)
+      .where(
+        and(
+          eq(dataSources.userId, userId),
+          eq(dataSources.id, sourceId),
+          isNull(dataSources.deletedAt),
+        ),
+      )
+      .returning();
+    if (!updated) throw new NotFoundError();
+    return updated;
+  });
 
   if (patch.autoImport !== undefined && patch.autoImport !== existing.autoImport) {
     await writeAudit({

--- a/src/lib/server/services/data-sources.ts
+++ b/src/lib/server/services/data-sources.ts
@@ -646,18 +646,35 @@ export async function updateSource(
       );
     }
     update.backfillTargetSince = patch.backfillTargetSince;
-    // Phase 03.0.3 — widening backfillTargetSince is handled LAZILY by
-    // the next refresh-content click's three-branch since-derivation
-    // (backfill-channel.ts), NOT by an eager channel-state reset here.
-    // After this UPDATE `target` becomes deeper than the channel's
-    // recorded `backfillOldestAt`, so the next walk lands in the `deep`
-    // branch: since=target, token preserved, walk resumes from the saved
-    // cursor or restarts. Pre-Phase-03.0.3 this path eagerly flipped
-    // backfill_complete=false at the channel level; that reset was
-    // redundant (the three-branch since-derivation covers the same
-    // ground) AND wrong (it re-opened the walk for ALL subscribers on
-    // the channel, not just the user who widened — multi-tenant
-    // fairness violation per D-#29-7).
+    // Phase 03.0.3 — widening backfillTargetSince is handled in TWO
+    // places, depending on whether the channel was previously walked
+    // to exhaustion:
+    //
+    //   1. If channel_state.backfill_complete === true AND newTarget
+    //      crosses past backfill_oldest_at: immediate force-deep job
+    //      enqueued for THIS user via maybeEnqueueForceDeepWalk below
+    //      (Phase 03.0.3-02 D-#29-acceptance). The user pays quota for
+    //      the deep walk; other subscribers free-ride on fan-out. The
+    //      enqueue runs BEFORE the UPDATE for atomicity-of-intent —
+    //      see the inline rationale block on the enqueue call itself.
+    //
+    //   2. Otherwise (channel still has unwalked history below the
+    //      previous target — backfill_complete=false): no enqueue
+    //      here. The next refresh-content click (or scheduler tick)
+    //      lands in the three-branch since-derivation in
+    //      backfill-channel.ts and picks the deep branch
+    //      automatically because target < deepest_walked. This is the
+    //      "lazy" path; the early refactor pass had it as the ONLY
+    //      path until D-#29-7 fairness review surfaced that the
+    //      exhausted-channel widen needed an explicit override.
+    //
+    // Pre-Phase-03.0.3 this path also eagerly flipped
+    // backfill_complete=false at the CHANNEL level; that reset was
+    // redundant (the three-branch since-derivation covers the
+    // never-walked case) AND wrong (it re-opened the walk for ALL
+    // subscribers on the channel, not just the user who widened —
+    // multi-tenant fairness violation per D-#29-7). Both behaviours
+    // above are per-user.
   }
 
   // Phase 03.0.3 follow-up (PR #31 review P2) — atomicity-of-intent.

--- a/src/lib/server/services/data-sources.ts
+++ b/src/lib/server/services/data-sources.ts
@@ -272,10 +272,7 @@ async function maybeEnqueueForceDeepWalk(opts: {
   previousTarget: Date | null;
   newTarget: Date;
 }): Promise<void> {
-  if (
-    opts.previousTarget !== null &&
-    opts.newTarget.getTime() >= opts.previousTarget.getTime()
-  ) {
+  if (opts.previousTarget !== null && opts.newTarget.getTime() >= opts.previousTarget.getTime()) {
     return;
   }
   const state = await getChannelState("youtube_channel", opts.channelKey);

--- a/src/lib/server/services/data-sources.ts
+++ b/src/lib/server/services/data-sources.ts
@@ -583,13 +583,18 @@ export async function updateSource(
       );
     }
     update.backfillTargetSince = patch.backfillTargetSince;
-    // Phase 03.0.1 Wave 4 — channel-scoped state machine. Per-source
-    // backfill_complete column dropped; channel-level state is now
-    // shared across subscribers. Widening one user's target_since does
-    // NOT reset the channel's complete flag — other subscribers may have
-    // narrower targets that are already satisfied. The next refresh-
-    // content click by THIS user explicitly resets channel complete via
-    // resetChannelBackfillComplete (trust-but-verify).
+    // Phase 03.0.3 — widening backfillTargetSince is handled LAZILY by
+    // the next refresh-content click's three-branch since-derivation
+    // (backfill-channel.ts), NOT by an eager channel-state reset here.
+    // After this UPDATE `target` becomes deeper than the channel's
+    // recorded `backfillOldestAt`, so the next walk lands in the `deep`
+    // branch: since=target, token preserved, walk resumes from the saved
+    // cursor or restarts. Pre-Phase-03.0.3 this path eagerly flipped
+    // backfill_complete=false at the channel level; that reset was
+    // redundant (the three-branch since-derivation covers the same
+    // ground) AND wrong (it re-opened the walk for ALL subscribers on
+    // the channel, not just the user who widened — multi-tenant
+    // fairness violation per D-#29-7).
   }
 
   const [row] = await db
@@ -778,7 +783,10 @@ export async function markSourceNeedsReconnect(
 //   markSourceBackfillFrontier    → markChannelBackfillFrontier
 //   markSourceBackfillComplete    → markChannelBackfillComplete
 //   setSourceBackfillPageToken    → setChannelBackfillPageToken
-//   resetSourceBackfillComplete   → resetChannelBackfillComplete
+// Phase 03.0.3 P1 — `resetSourceBackfillComplete` and the wave-4
+// channel-level reset helper were both dropped: the new three-branch
+// since-derivation in backfill-channel.ts subsumes the
+// "trust-but-verify" reset (D-D1 / D-#29-6 / D-#29-7).
 // computeSinceForRefresh removed — channel-scoped worker passes
 // depthBoundIso explicitly per trigger context (user click → user's
 // target_since; cron auto-backfill → 1970 sentinel; cron incremental

--- a/src/lib/server/services/outbox.ts
+++ b/src/lib/server/services/outbox.ts
@@ -54,6 +54,29 @@ export interface OutboxEnqueueOptions {
  *
  * Returns nothing — the row id is auto-generated and not needed by
  * callers (the forwarder owns the lifecycle).
+ *
+ * ⚠ SECRETS RULE (AGENTS.md Constraints — "Secrets at rest envelope-
+ * encrypted"):
+ *
+ *   `payload` is persisted as plaintext jsonb. It MUST NOT contain:
+ *     - API keys (Google YouTube, Reddit, Twitter, etc.)
+ *     - OAuth access / refresh / id tokens
+ *     - Encrypted ciphertext columns (`secret_ct`, `wrapped_dek`, …)
+ *     - User passwords, session cookies, raw Authorization headers
+ *     - Any other field name covered by REDACT_PATHS in logger.ts
+ *
+ *   When a worker needs a secret to run a job, the caller must:
+ *     1. Store the secret in the envelope-encrypted table that owns it
+ *        (`api_keys_steam`, the future `api_keys_reddit`, etc.).
+ *     2. Pass an opaque id reference in the outbox payload.
+ *     3. The worker looks the secret up by id, decrypts via the KEK,
+ *        and uses it in-memory only.
+ *
+ *   The forwarder does NOT introspect payloads, but Pino's redact
+ *   patterns (logger.ts REDACT_PATHS) cover all the field-name shapes
+ *   above — so an accidental `logger.info({ row })` on a stuck outbox
+ *   debug path won't leak even if the payload contains a token.
+ *   Defense in depth, not a license to violate the rule.
  */
 export async function enqueueViaOutbox(
   tx: Tx,

--- a/src/lib/server/services/outbox.ts
+++ b/src/lib/server/services/outbox.ts
@@ -52,6 +52,15 @@ export interface OutboxEnqueueOptions {
  * `boss.send`, the forwarder sets `forwarded_at` and the cleanup
  * cron deletes rows older than 7 days from that mark.
  *
+ * Retry timing (Phase 03.0.3 round-3 Codex P3): on a failed
+ * `boss.send`, the row stays pending but its last_attempt_at is
+ * already stamped from the atomic claim — concurrent claimers (and
+ * follow-up sweeps within this process) skip the row until the
+ * CLAIM_WINDOW_SECONDS interval (60s, see outbox-forwarder.ts)
+ * elapses. Effective retry cadence is therefore ~60s, NOT
+ * "next tick / next NOTIFY". After MAX_ATTEMPTS (20) the row stays
+ * pending forever and operator intervention is required.
+ *
  * Returns nothing — the row id is auto-generated and not needed by
  * callers (the forwarder owns the lifecycle).
  *

--- a/src/lib/server/services/outbox.ts
+++ b/src/lib/server/services/outbox.ts
@@ -1,0 +1,95 @@
+// Phase 03.0.3 follow-up (PR #31 Codex P2) — transactional outbox helper.
+//
+// Public surface — one function that callers use INSIDE a Drizzle
+// transaction to atomically commit a queue-intent alongside their DB
+// changes. The forwarder (src/worker/handlers/outbox-forwarder.ts)
+// translates outbox rows into pg-boss `boss.send` calls asynchronously.
+//
+// Use when:
+//   - You have a DB UPDATE/INSERT that MUST be visible to the worker
+//     BEFORE the worker starts (e.g. backfillTargetSince widening +
+//     force-deep job — the worker's fan-out reads the new
+//     backfillTargetSince).
+//   - You want at-least-once delivery semantics with crash safety
+//     (boss.send failure + retry without losing user intent).
+//
+// Don't use when:
+//   - The job is purely scheduler-driven (cron tick) with no prior
+//     request UPDATE — `boss.send` directly is fine and avoids the
+//     0-200ms forwarder pickup latency.
+//   - The job payload is fully self-contained (worker reads only
+//     job.data, no DB lookup against just-updated rows) — direct
+//     `boss.send` after the awaited UPDATE is fine because the UPDATE
+//     commits before the await resolves.
+//
+// SOURCE-REFERENCE.md §12 has the full decision guide.
+
+import { sql } from "drizzle-orm";
+import { outbox } from "../db/schema/outbox.js";
+import type { Tx } from "../db/client.js";
+
+export interface OutboxEnqueueOptions {
+  /** pg-boss singletonKey — set this to dedupe duplicate forwards on
+   *  retry. The forwarder is at-least-once: if it crashes between
+   *  boss.send success and updating forwarded_at, the next sweep will
+   *  resend. A singletonKey makes the second send a no-op at the
+   *  pg-boss layer. */
+  singletonKey?: string;
+  /** pg-boss singletonSeconds — coalescing window. */
+  singletonSeconds?: number;
+  /** pg-boss priority — higher runs first when the worker has multiple
+   *  jobs in the queue. */
+  priority?: number;
+}
+
+/**
+ * Insert a queue-intent row into the outbox table. Must be called with
+ * a transaction handle (`tx`) so the insert commits atomically with
+ * other DB changes in the same transaction.
+ *
+ * The forwarder picks up the row via Postgres LISTEN/NOTIFY (instant in
+ * normal conditions) or its 30s fallback sweep. After successful
+ * `boss.send`, the forwarder sets `forwarded_at` and the cleanup
+ * cron deletes rows older than 7 days from that mark.
+ *
+ * Returns nothing — the row id is auto-generated and not needed by
+ * callers (the forwarder owns the lifecycle).
+ */
+export async function enqueueViaOutbox(
+  tx: Tx,
+  queue: string,
+  payload: Record<string, unknown>,
+  options: OutboxEnqueueOptions = {},
+): Promise<void> {
+  await tx
+    .insert(outbox)
+    .values({
+      queue,
+      payload,
+      options: options as Record<string, unknown>,
+    })
+    .execute();
+}
+
+/**
+ * Operator visibility helper — list outbox rows that have failed at
+ * least one forward attempt. Useful for /admin/quota-style debugging
+ * (Phase 6+) or ad-hoc SQL (`SELECT * FROM outbox WHERE
+ * forwarder_attempt > 0 ORDER BY last_attempt_at DESC`).
+ *
+ * Returns the raw rows; callers project as needed. Limited to 100 by
+ * default to keep the response bounded.
+ */
+export async function listStuckOutboxRows(
+  db: { execute: (q: ReturnType<typeof sql>) => Promise<{ rows: unknown[] }> },
+  limit = 100,
+): Promise<unknown[]> {
+  const result = await db.execute(sql`
+    SELECT id, queue, forwarder_attempt, last_error, last_attempt_at, created_at
+    FROM outbox
+    WHERE forwarded_at IS NULL AND forwarder_attempt > 0
+    ORDER BY last_attempt_at DESC NULLS LAST
+    LIMIT ${limit}
+  `);
+  return result.rows;
+}

--- a/src/lib/server/services/poll-eligibility.ts
+++ b/src/lib/server/services/poll-eligibility.ts
@@ -50,6 +50,9 @@ import { resolveTier } from "./tier-resolver.js";
  *
  * Returns the de-duplicated list of external_ids whose:
  *   - youtube_videos.published_at falls in the (cutoffOldest, cutoffNewest] window
+ *     OR (Phase 03.0.3 bootstrap rule) the video is older than the window
+ *     AND last_polled_at IS NULL — the never-polled bootstrap path that gives
+ *     each frozen-by-age video exactly one cron-driven shot at writeSnapshot.
  *   - youtube_videos.last_poll_status is NOT in the unavailable override list
  *     (the JS-side resolveTier check applies it)
  *   - at least one alive (deleted_at IS NULL) event references the video
@@ -68,12 +71,22 @@ export async function selectEligibleVideoIds(
   expectedTier: "active" | "cold",
   now: Date,
 ): Promise<string[]> {
+  // Phase 03.0.3 follow-up — the SQL window widens for tier=cold to include
+  // never-polled frozen videos (last_polled_at IS NULL AND published_at <=
+  // cutoffOldest). The JS-side resolveTier() collapses them to 'cold' via
+  // the bootstrap rule, so they get picked up by the cold-tier worker
+  // exactly once. tier=active stays untouched — active is age-only and
+  // never crosses the frozen boundary by definition.
+  const bootstrapClause =
+    expectedTier === "cold" ? sql`OR (${youtubeVideos.lastPolledAt} IS NULL)` : sql``;
+
   // eslint-disable-next-line tenant-scope/no-unfiltered-tenant-query -- scheduler fan-out is service-wide by design (Plan 03.0-09 §"scheduler tick" — one cron tick batches eligible videos across ALL tenants into POLL_ACTIVE/COLD jobs). Per-video writeSnapshot downstream is public-data; tenant scope does not apply.
   const rows = await db
     .selectDistinct({
       videoId: youtubeVideos.videoId,
       publishedAt: youtubeVideos.publishedAt,
       lastPollStatus: youtubeVideos.lastPollStatus,
+      lastPolledAt: youtubeVideos.lastPolledAt,
     })
     .from(events)
     .innerJoin(youtubeVideos, eq(events.externalId, youtubeVideos.videoId))
@@ -84,13 +97,15 @@ export async function selectEligibleVideoIds(
         isNull(events.deletedAt),
         isNotNull(youtubeVideos.publishedAt),
         cutoffNewest ? lte(youtubeVideos.publishedAt, cutoffNewest) : sql`true`,
-        gt(youtubeVideos.publishedAt, cutoffOldest),
+        sql`(${gt(youtubeVideos.publishedAt, cutoffOldest)} ${bootstrapClause})`,
       ),
     );
 
   // Authoritative tier classification on the JS side. SQL window is a
   // superset (it does not know about UNAVAILABLE_POLL_STATUSES override).
   return rows
-    .filter((r) => resolveTier(r.publishedAt, r.lastPollStatus, now) === expectedTier)
+    .filter(
+      (r) => resolveTier(r.publishedAt, r.lastPollStatus, r.lastPolledAt, now) === expectedTier,
+    )
     .map((r) => r.videoId);
 }

--- a/src/lib/server/services/purge-account.ts
+++ b/src/lib/server/services/purge-account.ts
@@ -33,7 +33,7 @@
 // the `user` DELETE in step 8 takes them down via Postgres FK cascade
 // (no explicit tx step needed).
 
-import { and, eq, isNotNull, lt } from "drizzle-orm";
+import { and, eq, isNotNull, lt, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { user, session } from "../db/schema/auth.js";
 import { games } from "../db/schema/games.js";
@@ -42,6 +42,7 @@ import { dataSources } from "../db/schema/data-sources.js";
 import { events } from "../db/schema/events.js";
 import { eventGames } from "../db/schema/event-games.js";
 import { apiKeysSteam } from "../db/schema/api-keys-steam.js";
+import { outbox } from "../db/schema/outbox.js";
 import { writeAudit } from "../audit.js";
 import { env } from "../config/env.js";
 import { logger } from "../logger.js";
@@ -72,6 +73,16 @@ export interface PurgeRowCounts {
   games: number;
   sessions: number;
   user: number;
+  /** Phase 03.0.3 round-8 (Codex P1) — outbox rows that referenced the
+   *  purged user via payload.triggerUserId, deleted inside the same
+   *  cascade transaction. Pending rows (forwarded_at IS NULL) would
+   *  otherwise be forwarded to pg-boss AFTER the user row is gone,
+   *  enqueueing work for a deleted tenant and breaking the hard-delete
+   *  contract. Forwarded rows (forwarded_at IS NOT NULL) are deleted
+   *  too — they retained the purged user_id for up to 7 days under the
+   *  purge.daily retention window, violating GDPR Art. 17 for that
+   *  period. */
+  outbox: number;
 }
 
 export interface PurgeResult {
@@ -151,6 +162,20 @@ export async function purgeAccount(userId: string, opts: PurgeOptions = {}): Pro
       .where(eq(dataSources.userId, userId))
       .returning({ id: dataSources.id });
 
+    // 5b. outbox — queue intents that reference this user via
+    //     payload.triggerUserId (Phase 03.0.3 force-deep enqueues are
+    //     the only such payload today). Codex round-8 P1: deleting the
+    //     user without scrubbing the outbox lets the forwarder later
+    //     enqueue a YOUTUBE_BACKFILL_CHANNEL job with the purged
+    //     userId, which the worker then audits against a non-existent
+    //     tenant. Filter via the JSON ->>'triggerUserId' accessor —
+    //     rows whose payload omits the field (system-level enqueues if
+    //     any future ones land) don't match and survive.
+    const ob = await tx
+      .delete(outbox)
+      .where(sql`${outbox.payload}->>'triggerUserId' = ${userId}`)
+      .returning({ id: outbox.id });
+
     // 6. games — children of user.
     const g = await tx.delete(games).where(eq(games.userId, userId)).returning({ id: games.id });
 
@@ -175,6 +200,7 @@ export async function purgeAccount(userId: string, opts: PurgeOptions = {}): Pro
       games: g.length,
       sessions: sess.length,
       user: u.length,
+      outbox: ob.length,
     } satisfies PurgeRowCounts;
   });
 

--- a/src/lib/server/services/tier-resolver.ts
+++ b/src/lib/server/services/tier-resolver.ts
@@ -42,6 +42,18 @@
 // age rule still applies. This keeps the override list narrow and predictable;
 // any new override must land here in lock-step with the worker code that
 // writes the new lastPollStatus value.
+//
+// Phase 03.0.3 follow-up — bootstrap rule (issue #29 extension). A video
+// that is frozen by age (publishedAt > 28d ago) but has NEVER been polled
+// (lastPolledAt IS NULL) is upgraded to 'cold' so the next scheduler tick
+// picks it up exactly once. After the first poll fires writeSnapshot
+// (success OR failure — auth_error/not_found/timeout all stamp lastPolledAt
+// + lastPollStatus), the tier collapses back to 'frozen' (or 'unavailable')
+// on the next resolve call. This guarantees every event with a resolved
+// video gets at least one snapshot row, regardless of how it landed in the
+// DB (initial backfill, manual paste, channel-context-backfill that
+// pre-dated this rule, etc.). No quota runaway: each frozen video burns
+// exactly ONE additional videos.list batch entry.
 
 export type Tier = "pending" | "active" | "cold" | "frozen" | "unavailable";
 
@@ -55,7 +67,8 @@ export const TIER_BOUNDARY_COLD_MS = 28 * 86_400_000;
 export const UNAVAILABLE_POLL_STATUSES: readonly string[] = ["not_found", "private", "auth_error"];
 
 /**
- * Pure tier resolution. Deterministic given (publishedAt, lastPollStatus, now).
+ * Pure tier resolution. Deterministic given
+ * (publishedAt, lastPollStatus, lastPolledAt, now).
  *
  * Pure-function discipline: no DB / IO / module-level mutable state read.
  * Same inputs → same output, every time. Any caller that needs different
@@ -66,10 +79,15 @@ export const UNAVAILABLE_POLL_STATUSES: readonly string[] = ["not_found", "priva
  * publishedAt is the YouTube-native timestamp from `youtube_videos.published_at`,
  * loaded by the caller from the JOIN. It is NULL while channel-context-backfill
  * has not yet run (the 'pending' tier window).
+ *
+ * lastPolledAt is the YouTube-side metadata timestamp from
+ * `youtube_videos.last_polled_at`, stamped by every writeSnapshot regardless
+ * of success/failure. NULL means: never polled (the bootstrap path applies).
  */
 export function resolveTier(
   publishedAt: Date | null,
   lastPollStatus: string | null,
+  lastPolledAt: Date | null,
   now: Date = new Date(),
 ): Tier {
   if (publishedAt === null) {
@@ -81,5 +99,10 @@ export function resolveTier(
   const ageMs = now.getTime() - publishedAt.getTime();
   if (ageMs < TIER_BOUNDARY_ACTIVE_MS) return "active";
   if (ageMs < TIER_BOUNDARY_COLD_MS) return "cold";
+  // Phase 03.0.3 follow-up — bootstrap: frozen by age but never polled
+  // gets ONE shot at 'cold' classification. After the next writeSnapshot
+  // (any status) stamps lastPolledAt, this branch is dormant for the
+  // video forever. See file header for the issue #29 extension rationale.
+  if (lastPolledAt === null) return "cold";
   return "frozen";
 }

--- a/src/lib/sources/adapter.ts
+++ b/src/lib/sources/adapter.ts
@@ -33,6 +33,7 @@
 
 import type { dataSources, events } from "$lib/server/db/schema/index.js";
 import type { DbOrTx } from "$lib/server/db/client.js";
+import type { EventDto } from "$lib/server/dto.js";
 import type { Hono } from "hono";
 
 export type DataSourceRow = typeof dataSources.$inferSelect;
@@ -529,4 +530,30 @@ export interface DataSourceAdapter {
    *  instance. YouTube: mounts /api/youtube/fetch-metadata (preview button on
    *  /events/new). Synchronous mount per Hono's contract. */
   registerRoutes?(app: Hono<AdapterAppContext>): void;
+
+  /**
+   * Phase 03.0.3 P2 (D-A1) — enrich the supplied feed DTOs in-place with
+   * adapter-specific data (stats, channel/author metadata, anything that
+   * lives in per-kind metadata tables and renders on FeedCard).
+   *
+   * Cross-source callsites (/feed loader, GET /api/events, /games/[id])
+   * iterate allAdapters and call this method per adapter. The adapter
+   * MUST filter internally to its own kind(s) — callers do NOT pre-filter
+   * (avoids the "did I forget to filter for adapter X?" footgun).
+   *
+   * Mutates `dtos` in place; returns void. Errors are swallowed by the
+   * adapter (logged at WARN); a failed enrichment query MUST NOT break
+   * the feed render — the cards just render without the enrichment.
+   *
+   * Future adapters (Reddit / Twitter / Telegram / Discord) implement this
+   * against their own metadata tables. Adapters that have no enrichment
+   * can omit the method entirely (optional via `?:`); the caller's
+   * `if (adapter.enrichFeedDtos)` gate skips undefined methods.
+   *
+   * Deliberately NOT called from GET /api/events/deleted — DeletedEventsPanel
+   * renders a compact KindIcon + strikethrough-title view that needs none
+   * of the enrichment data. See events.ts:374 for the load-bearing skip
+   * comment.
+   */
+  enrichFeedDtos?(userId: string, dtos: EventDto[]): Promise<void>;
 }

--- a/src/lib/sources/adapter.ts
+++ b/src/lib/sources/adapter.ts
@@ -97,6 +97,19 @@ export interface PollableSource {
 export interface AdapterContext {
   userId: string | null;
   origin: "cron" | "user";
+  /** Phase 03.0.3 follow-up — how the playlist walker decides when to stop.
+   *  - "depth" (default): items with publishedAt <= since are dropped AND
+   *    end the walk. Use for deep walks where `since` is the historical floor
+   *    (e.g. user widened backfill_target_since to epoch — walker stops at
+   *    epoch via endOfPlaylist, or at 30d-ago when since=30d-ago).
+   *  - "overlap": items are NOT dropped by publishedAt alone. Walker stops
+   *    after K consecutive items that are BOTH already in the youtube_videos
+   *    cache AND have publishedAt <= since. Use for incremental walks
+   *    (channel previously walked; we just want what's new). Backdated
+   *    uploads with publishedAt below newestKnown but NOT yet in cache
+   *    survive — they get collected because cache-miss means "we have not
+   *    seen this video before", which is the D-#29-1 invariant. */
+  walkStop?: "depth" | "overlap";
 }
 
 /**
@@ -393,7 +406,7 @@ export interface DataSourceAdapter {
   pollContent(
     source: PollableSource,
     since: Date,
-    ctx?: { origin?: "cron" | "user" },
+    ctx?: { origin?: "cron" | "user"; walkStop?: "depth" | "overlap" },
   ): Promise<{
     events: RawEvent[];
     unitsUsed: number;

--- a/src/lib/sources/youtube/server/adapter.ts
+++ b/src/lib/sources/youtube/server/adapter.ts
@@ -41,6 +41,7 @@
 
 import { pickKeyForJob, youtubeQuotaUser } from "./quota.js";
 import { chargedFetch, fetchWithTimeout } from "./http.js";
+import { youtubeEnrichFeedDtos } from "./feed-enrichment.js";
 import { youtubeChannels } from "./schema/index.js";
 import { db as serverDb } from "$lib/server/db/client.js";
 import { eq as serverEq } from "drizzle-orm";
@@ -104,6 +105,7 @@ type YoutubeChannelAdapterCore = Pick<
   | "parseUrl"
   | "observability"
   | "canRefreshPoll"
+  | "enrichFeedDtos"
 >;
 
 // Plan 03.0-03's canonical pickKeyForJob + hashApiKeyId are imported above
@@ -542,4 +544,9 @@ export const youtubeChannelAdapterCore: YoutubeChannelAdapterCore = {
    *  (Plan 06). YouTube returns true for kind === "youtube_video"; Reddit
    *  (Phase 03.1) returns true for kind === "reddit_post". */
   canRefreshPoll: (eventKind: EventKind): boolean => eventKind === "youtube_video",
+  /** enrichFeedDtos — Phase 03.0.3 P2 (D-A1). Internal filter to
+   *  kind=youtube_video; mutates stats + channelTitle in place. The
+   *  barrel spreads this into the exported youtubeAdapter alongside the
+   *  rest of the Core surface. */
+  enrichFeedDtos: youtubeEnrichFeedDtos,
 };

--- a/src/lib/sources/youtube/server/adapter.ts
+++ b/src/lib/sources/youtube/server/adapter.ts
@@ -42,9 +42,9 @@
 import { pickKeyForJob, youtubeQuotaUser } from "./quota.js";
 import { chargedFetch, fetchWithTimeout } from "./http.js";
 import { youtubeEnrichFeedDtos } from "./feed-enrichment.js";
-import { youtubeChannels } from "./schema/index.js";
+import { youtubeChannels, youtubeVideos as youtubeVideosTable } from "./schema/index.js";
 import { db as serverDb } from "$lib/server/db/client.js";
-import { eq as serverEq } from "drizzle-orm";
+import { eq as serverEq, inArray as serverInArray } from "drizzle-orm";
 import { youtubeObservability } from "./observability.js";
 import { youtubeParseUrl } from "./url.js";
 import { z } from "zod";
@@ -307,7 +307,7 @@ export const youtubeChannelAdapterCore: YoutubeChannelAdapterCore = {
   async pollContent(
     source: PollableSource,
     since: Date,
-    ctx?: { origin?: "cron" | "user" },
+    ctx?: { origin?: "cron" | "user"; walkStop?: "depth" | "overlap" },
   ): Promise<{
     events: RawEvent[];
     unitsUsed: number;
@@ -398,6 +398,32 @@ export const youtubeChannelAdapterCore: YoutubeChannelAdapterCore = {
     let endOfPlaylist = false;
     let nextPageToken: string | undefined;
 
+    // Phase 03.0.3 follow-up — D-#29-1 backdated-upload safety. The legacy
+    // "depth" walk drops every item with publishedAt <= since unconditionally;
+    // that silently loses videos whose publishedAt is older than newestKnown
+    // (e.g. uploaded today but with a custom publishedAt months back —
+    // unlisted-then-public, podcast schedule, channel takeover migration).
+    //
+    // The "overlap" mode does a per-page cache lookup against
+    // youtube_videos. An item is treated as a stop signal only when it is
+    // BOTH already in the cache (we've seen it before) AND publishedAt is
+    // past since (we'd previously have dropped it). After OVERLAP_THRESHOLD
+    // consecutive such items the walker stops. Backdated cache-miss items
+    // continue to be collected. Single-item gaps (one re-uploaded video
+    // in the middle of unknown territory) do NOT terminate the walk
+    // because the counter resets on every unknown item.
+    //
+    // Mode is chosen by the orchestrator (backfill-channel.ts) per branch:
+    //   - branch="deep"        → walkStop="depth"   (since = historical floor)
+    //   - branch="exhausted"   → walkStop="overlap" (since = newestKnown)
+    //   - branch="incremental" → walkStop="overlap" (since = max(newestKnown, target))
+    // Cron paths default to "depth" — they pass since=epoch and rely on
+    // endOfPlaylist / MAX_PAGES as their natural floors; overlap would
+    // be no-op for cron's epoch-since anyway.
+    const walkStop = ctx?.walkStop ?? "depth";
+    const OVERLAP_THRESHOLD = 3;
+    let consecutiveKnownPastSince = 0;
+
     for (let page = 0; page < MAX_PAGES; page++) {
       const url = new URL(`${env.YOUTUBE_API_BASE_URL}/playlistItems`);
       url.searchParams.set("playlistId", uploadsPlaylistId);
@@ -417,17 +443,58 @@ export const youtubeChannelAdapterCore: YoutubeChannelAdapterCore = {
       if (!resp.ok) break;
       const json = PLAYLIST_ITEMS_LIST_RESPONSE.parse(await resp.json());
 
+      // Overlap-mode: one indexed SELECT per page against the public-data
+      // youtube_videos cache (no userId scope — every tenant shares the
+      // row). Empty page short-circuits the query to avoid Postgres `IN ()`.
+      let knownByPage: Set<string> = new Set<string>();
+      if (walkStop === "overlap" && json.items.length > 0) {
+        const pageExternalIds = json.items.map((it) => it.snippet.resourceId.videoId);
+        const rows = await serverDb
+          .select({ videoId: youtubeVideosTable.videoId })
+          .from(youtubeVideosTable)
+          .where(serverInArray(youtubeVideosTable.videoId, pageExternalIds));
+        knownByPage = new Set(rows.map((r) => r.videoId));
+      }
+
       for (const item of json.items) {
+        const externalId = item.snippet.resourceId.videoId;
         const occurredAt = new Date(item.snippet.publishedAt);
-        if (occurredAt.getTime() <= sinceMs) {
-          walkedPastSince = true;
-          continue;
+        const pastSince = occurredAt.getTime() <= sinceMs;
+
+        if (walkStop === "depth") {
+          if (pastSince) {
+            walkedPastSince = true;
+            continue;
+          }
+        } else {
+          // walkStop === "overlap"
+          const isKnown = knownByPage.has(externalId);
+          if (isKnown && pastSince) {
+            consecutiveKnownPastSince += 1;
+            if (consecutiveKnownPastSince >= OVERLAP_THRESHOLD) {
+              walkedPastSince = true;
+              break;
+            }
+            continue;
+          }
+          // Unknown-OR-fresh item resets the counter. Known-and-fresh
+          // (a video the cache already saw but published AFTER since)
+          // is rare — we still skip it (dedup) without breaking. Backdated
+          // cache-miss (the D-#29-1 case) lands here and IS collected.
+          consecutiveKnownPastSince = 0;
+          if (isKnown) {
+            // Defensive skip to avoid double-fan-out on re-upload edge case;
+            // the events INSERT-ON-CONFLICT downstream is the load-bearing
+            // dedup, but skipping here saves an idempotency-loss INSERT.
+            continue;
+          }
         }
+
         collected.push({
-          externalId: item.snippet.resourceId.videoId,
+          externalId,
           title: item.snippet.title,
           occurredAt,
-          url: `https://www.youtube.com/watch?v=${item.snippet.resourceId.videoId}`,
+          url: `https://www.youtube.com/watch?v=${externalId}`,
           kind: "youtube_video",
           metadata: { channelId: item.snippet.channelId },
         });

--- a/src/lib/sources/youtube/server/feed-enrichment.ts
+++ b/src/lib/sources/youtube/server/feed-enrichment.ts
@@ -56,10 +56,7 @@ export async function youtubeEnrichFeedDtos(
       })
       .from(youtubeVideoSnapshots)
       .where(inArray(youtubeVideoSnapshots.videoId, youtubeExternalIds))
-      .orderBy(
-        youtubeVideoSnapshots.videoId,
-        sql`${youtubeVideoSnapshots.polledAt} DESC`,
-      );
+      .orderBy(youtubeVideoSnapshots.videoId, sql`${youtubeVideoSnapshots.polledAt} DESC`);
     const latest = new Map<
       string,
       { viewCount: number; likeCount: number; commentCount: number; polledAt: Date }

--- a/src/lib/sources/youtube/server/feed-enrichment.ts
+++ b/src/lib/sources/youtube/server/feed-enrichment.ts
@@ -26,6 +26,15 @@ import { logger } from "$lib/server/logger.js";
 import type { EventDto } from "$lib/server/dto.js";
 
 export async function youtubeEnrichFeedDtos(
+  /**
+   * userId is required by the DataSourceAdapter.enrichFeedDtos contract but
+   * is intentionally unused here: youtube_video_snapshots and youtube_videos
+   * are PUBLIC-DATA tables (no userId column — already in the ESLint
+   * tenant-scope allowlist). The tenant guarantee comes from the upstream
+   * events SELECT in mapEventsToDtos. Other adapters whose enrichment
+   * touches tenant-owned tables (e.g. a future Reddit adapter reading
+   * per-user OAuth-scoped metadata) MUST scope by userId in their queries.
+   */
   _userId: string,
   dtos: EventDto[],
 ): Promise<void> {

--- a/src/lib/sources/youtube/server/feed-enrichment.ts
+++ b/src/lib/sources/youtube/server/feed-enrichment.ts
@@ -75,10 +75,13 @@ export async function youtubeEnrichFeedDtos(
       { viewCount: number; likeCount: number; commentCount: number; polledAt: Date }
     >();
     for (const s of latestRows.rows) {
+      // db.execute returns raw pg driver shapes — int columns come
+      // back as strings on some pg versions; explicit Number() coercion
+      // matches the snapshot column types declared in the schema.
       latest.set(s.video_id, {
-        viewCount: s.view_count ?? 0,
-        likeCount: s.like_count ?? 0,
-        commentCount: s.comment_count ?? 0,
+        viewCount: s.view_count === null ? 0 : Number(s.view_count),
+        likeCount: s.like_count === null ? 0 : Number(s.like_count),
+        commentCount: s.comment_count === null ? 0 : Number(s.comment_count),
         polledAt:
           s.polled_at instanceof Date ? s.polled_at : new Date(s.polled_at as unknown as string),
       });

--- a/src/lib/sources/youtube/server/feed-enrichment.ts
+++ b/src/lib/sources/youtube/server/feed-enrichment.ts
@@ -21,7 +21,7 @@
 
 import { inArray, sql } from "drizzle-orm";
 import { db } from "$lib/server/db/client.js";
-import { youtubeVideoSnapshots, youtubeVideos } from "$lib/server/db/schema/index.js";
+import { youtubeVideos } from "$lib/server/db/schema/index.js";
 import { logger } from "$lib/server/logger.js";
 import type { EventDto } from "$lib/server/dto.js";
 
@@ -44,32 +44,44 @@ export async function youtubeEnrichFeedDtos(
   if (youtubeExternalIds.length === 0) return;
 
   try {
-    // 1. Latest-snapshot lookup. ORDER BY videoId, polledAt DESC; pick
-    //    first row per videoId.
-    const snapshots = await db
-      .select({
-        videoId: youtubeVideoSnapshots.videoId,
-        polledAt: youtubeVideoSnapshots.polledAt,
-        viewCount: youtubeVideoSnapshots.viewCount,
-        likeCount: youtubeVideoSnapshots.likeCount,
-        commentCount: youtubeVideoSnapshots.commentCount,
-      })
-      .from(youtubeVideoSnapshots)
-      .where(inArray(youtubeVideoSnapshots.videoId, youtubeExternalIds))
-      .orderBy(youtubeVideoSnapshots.videoId, sql`${youtubeVideoSnapshots.polledAt} DESC`);
+    // 1. Latest-snapshot lookup. youtube_video_snapshots is an immutable
+    //    time series — a busy video may carry hundreds of historical
+    //    rows. DISTINCT ON (video_id) ORDER BY video_id, polled_at DESC
+    //    keeps the database scan tight: exactly one row per requested
+    //    video_id, the most recent. Pre-fix (Phase 03.0.3 round-5
+    //    Codex P2) the query loaded every historical row and JS picked
+    //    the first per video — cost grew with polling history rather
+    //    than page size. Raw SQL because Drizzle's pg-core builder
+    //    doesn't have a first-class DISTINCT ON helper.
+    const idsSql = sql.join(
+      youtubeExternalIds.map((id) => sql`${id}`),
+      sql`, `,
+    );
+    const latestRows = await db.execute<{
+      video_id: string;
+      polled_at: Date;
+      view_count: number | null;
+      like_count: number | null;
+      comment_count: number | null;
+    }>(sql`
+      SELECT DISTINCT ON (video_id)
+        video_id, polled_at, view_count, like_count, comment_count
+      FROM youtube_video_snapshots
+      WHERE video_id IN (${idsSql})
+      ORDER BY video_id, polled_at DESC
+    `);
     const latest = new Map<
       string,
       { viewCount: number; likeCount: number; commentCount: number; polledAt: Date }
     >();
-    for (const s of snapshots) {
-      if (!latest.has(s.videoId)) {
-        latest.set(s.videoId, {
-          viewCount: s.viewCount ?? 0,
-          likeCount: s.likeCount ?? 0,
-          commentCount: s.commentCount ?? 0,
-          polledAt: s.polledAt,
-        });
-      }
+    for (const s of latestRows.rows) {
+      latest.set(s.video_id, {
+        viewCount: s.view_count ?? 0,
+        likeCount: s.like_count ?? 0,
+        commentCount: s.comment_count ?? 0,
+        polledAt:
+          s.polled_at instanceof Date ? s.polled_at : new Date(s.polled_at as unknown as string),
+      });
     }
 
     // 2. ChannelTitle lookup from youtube_videos cache.

--- a/src/lib/sources/youtube/server/feed-enrichment.ts
+++ b/src/lib/sources/youtube/server/feed-enrichment.ts
@@ -1,0 +1,96 @@
+// YouTube feed enrichment — Phase 03.0.3 P2 (D-A1).
+//
+// Implements DataSourceAdapter.enrichFeedDtos for the youtube_channel
+// adapter. Internally filters dtos to kind=youtube_video; ignores other
+// kinds (caller does NOT pre-filter — Phase 03.0.3 D-A1 contract).
+//
+// Two batched queries:
+//   1. youtube_video_snapshots — DISTINCT ON videoId ORDER BY polledAt DESC.
+//      Gets latest snapshot per video for stats (view/like/comment).
+//   2. youtube_videos — SELECT channelTitle by videoId IN (...). Gets
+//      the channel chip name (populated by channel-context-backfill OR
+//      backfill-channel's youtube_videos UPSERT).
+//
+// Both tables are public-data (no userId scope) — already in ESLint
+// tenant-scope allowlist. The tenant guarantee comes from the upstream
+// events SELECT (mapEventsToDtos returns userId-scoped rows); this
+// helper only touches video-keyed metadata.
+//
+// Failure mode: errors are caught + logged at WARN; the cards render
+// without the enrichment instead of breaking the feed.
+
+import { inArray, sql } from "drizzle-orm";
+import { db } from "$lib/server/db/client.js";
+import { youtubeVideoSnapshots, youtubeVideos } from "$lib/server/db/schema/index.js";
+import { logger } from "$lib/server/logger.js";
+import type { EventDto } from "$lib/server/dto.js";
+
+export async function youtubeEnrichFeedDtos(
+  _userId: string,
+  dtos: EventDto[],
+): Promise<void> {
+  const youtubeExternalIds = dtos
+    .filter((r) => r.kind === "youtube_video" && r.externalId !== null)
+    .map((r) => r.externalId as string);
+  if (youtubeExternalIds.length === 0) return;
+
+  try {
+    // 1. Latest-snapshot lookup. ORDER BY videoId, polledAt DESC; pick
+    //    first row per videoId.
+    const snapshots = await db
+      .select({
+        videoId: youtubeVideoSnapshots.videoId,
+        polledAt: youtubeVideoSnapshots.polledAt,
+        viewCount: youtubeVideoSnapshots.viewCount,
+        likeCount: youtubeVideoSnapshots.likeCount,
+        commentCount: youtubeVideoSnapshots.commentCount,
+      })
+      .from(youtubeVideoSnapshots)
+      .where(inArray(youtubeVideoSnapshots.videoId, youtubeExternalIds))
+      .orderBy(
+        youtubeVideoSnapshots.videoId,
+        sql`${youtubeVideoSnapshots.polledAt} DESC`,
+      );
+    const latest = new Map<
+      string,
+      { viewCount: number; likeCount: number; commentCount: number; polledAt: Date }
+    >();
+    for (const s of snapshots) {
+      if (!latest.has(s.videoId)) {
+        latest.set(s.videoId, {
+          viewCount: s.viewCount ?? 0,
+          likeCount: s.likeCount ?? 0,
+          commentCount: s.commentCount ?? 0,
+          polledAt: s.polledAt,
+        });
+      }
+    }
+
+    // 2. ChannelTitle lookup from youtube_videos cache.
+    const videoChannels = await db
+      .select({
+        videoId: youtubeVideos.videoId,
+        channelTitle: youtubeVideos.channelTitle,
+      })
+      .from(youtubeVideos)
+      .where(inArray(youtubeVideos.videoId, youtubeExternalIds));
+    const titleByVideo = new Map<string, string | null>();
+    for (const v of videoChannels) titleByVideo.set(v.videoId, v.channelTitle);
+
+    // 3. In-place mutation. Iterate dtos (not just the filtered subset)
+    //    so the index matches the caller's expectation; skip non-YouTube
+    //    rows defensively.
+    for (const r of dtos) {
+      if (r.kind !== "youtube_video" || r.externalId === null) continue;
+      r.stats = latest.get(r.externalId) ?? null;
+      r.channelTitle = titleByVideo.get(r.externalId) ?? null;
+    }
+  } catch (err) {
+    // D-A1 — failure is non-fatal. Log and return; the feed still
+    // renders, just without the enrichment.
+    logger.warn(
+      { err: String((err as Error)?.message ?? err), count: youtubeExternalIds.length },
+      "youtube.enrichFeedDtos: query failed; feed renders without enrichment",
+    );
+  }
+}

--- a/src/lib/sources/youtube/server/handlers/backfill-channel.ts
+++ b/src/lib/sources/youtube/server/handlers/backfill-channel.ts
@@ -58,6 +58,11 @@ import { getNewestKnownPublishedAt } from "../newest-known.js";
 import { writeSnapshot } from "../snapshots.js";
 import { pickKeyForJob } from "../quota.js";
 import { AdapterError } from "$lib/sources/errors.js";
+import {
+  TIER_BOUNDARY_COLD_MS,
+  UNAVAILABLE_POLL_STATUSES,
+} from "$lib/server/services/tier-resolver.js";
+import { notInArray, gt, asc, or as drizzleOr, not } from "drizzle-orm";
 import type { SourceKind } from "$lib/sources/adapter.js";
 
 /** YouTube videos.list batch limit — mirrors YOUTUBE_VIDEOS_BATCH_SIZE
@@ -65,6 +70,14 @@ import type { SourceKind } from "$lib/sources/adapter.js";
  *  the first video of each chunk, rest get unitsUsed=0 (same accounting
  *  as poll-active.ts). */
 const YOUTUBE_VIDEOS_BATCH_SIZE = 50;
+
+/** Filler freshness gate (Phase 03.0.3 follow-up). When refresh-content
+ *  opportunistically tops the videos.list batch with stale-stat videos
+ *  from the same channel, skip videos polled within the last N minutes
+ *  to avoid racing with poll-active cron (which runs every 6h but might
+ *  have just landed). Worst case on race: +1 redundant videos.list batch
+ *  entry — well within the operator's daily envelope. */
+const FILLER_FRESH_THRESHOLD_MS = 5 * 60_000;
 
 type BackfillFlow = "initial" | "incremental" | "historical" | "auto_passive";
 
@@ -532,15 +545,98 @@ export async function handleBackfillChannel(job: BackfillChannelJob): Promise<vo
   if (insertedExternalIds.length > 0) {
     const picked = pickKeyForJob();
     if (picked) {
+      // Opportunistic batch-fill (Phase 03.0.3 follow-up): the
+      // videos.list call charges 1 quota unit per batch regardless of
+      // how many ids fit inside (Google caps batch at 50). When a
+      // refresh-content click surfaces only N<50 new videos, the
+      // remaining 50-N capacity is FREE — fill it with same-channel
+      // videos whose stats are stale. User mental model: "refresh =
+      // give me the latest" includes both new events AND fresh stats
+      // on already-known videos. Cron poll-active does this on its
+      // own schedule (every 6h), but a user click between cron ticks
+      // is wasted capacity if we don't fill.
+      //
+      // Filler selection:
+      //   - same channel only (refresh-content is scoped to one channel)
+      //   - publishedAt within cold-tier window (28d) — frozen videos
+      //     don't move stats meaningfully; cron skips them too
+      //   - last_poll_status NOT in unavailable overrides (not_found /
+      //     private / auth_error) — re-polling a confirmed-gone video
+      //     burns quota with no benefit
+      //   - last_polled_at older than FILLER_FRESH_THRESHOLD_MS (or NULL)
+      //     — avoids the rare race where poll-active cron just polled
+      //     the same video; NULLs sort first (never-polled wins).
+      const newSet = new Set(insertedExternalIds);
+      const capacity = YOUTUBE_VIDEOS_BATCH_SIZE - insertedExternalIds.length;
+      let allIdsToPoll: string[] = insertedExternalIds;
+      if (capacity > 0) {
+        const nowMs = Date.now();
+        const coldCutoff = new Date(nowMs - TIER_BOUNDARY_COLD_MS);
+        const freshCutoff = new Date(nowMs - FILLER_FRESH_THRESHOLD_MS);
+        try {
+          const fillerRows = await db
+            .select({ videoId: youtubeVideosTable.videoId })
+            .from(youtubeVideosTable)
+            .where(
+              and(
+                eq(youtubeVideosTable.channelId, channelKey),
+                isNotNull(youtubeVideosTable.publishedAt),
+                gt(youtubeVideosTable.publishedAt, coldCutoff),
+                // Exclude permanent-failure videos.
+                drizzleOr(
+                  isNull(youtubeVideosTable.lastPollStatus),
+                  not(
+                    inArray(
+                      youtubeVideosTable.lastPollStatus,
+                      UNAVAILABLE_POLL_STATUSES as unknown as string[],
+                    ),
+                  ),
+                ),
+                // Race guard: skip videos polled in the last 5min.
+                drizzleOr(
+                  isNull(youtubeVideosTable.lastPolledAt),
+                  sql`${youtubeVideosTable.lastPolledAt} < ${freshCutoff}`,
+                ),
+              ),
+            )
+            .orderBy(asc(youtubeVideosTable.lastPolledAt))
+            .limit(capacity);
+          const filler = fillerRows
+            .map((r) => r.videoId)
+            .filter((id) => !newSet.has(id));
+          if (filler.length > 0) {
+            allIdsToPoll = [...insertedExternalIds, ...filler];
+            logger.debug(
+              {
+                jobId: job.id,
+                channelKey,
+                newCount: insertedExternalIds.length,
+                fillerCount: filler.length,
+              },
+              "youtube.backfill.channel: opportunistic batch fill",
+            );
+          }
+        } catch (err) {
+          logger.warn(
+            {
+              jobId: job.id,
+              channelKey,
+              err: String((err as Error).message ?? err),
+            },
+            "youtube.backfill.channel: filler-select failed; proceeding with new ids only",
+          );
+        }
+      }
+
       try {
         const quotaUser = triggerUserId ?? QUOTA_USER_BACKFILL;
         const statsSnapshots = await adapter.pollStatsByVideoId(
-          insertedExternalIds,
+          allIdsToPoll,
           quotaUser,
           picked,
         );
-        for (let i = 0; i < insertedExternalIds.length; i++) {
-          const videoId = insertedExternalIds[i]!;
+        for (let i = 0; i < allIdsToPoll.length; i++) {
+          const videoId = allIdsToPoll[i]!;
           const snap = statsSnapshots[i]!;
           // Charge 1 unit on the first video of each batch; rest pass
           // unitsUsed=0 (mirrors the chargedOnce-per-batch accounting

--- a/src/lib/sources/youtube/server/handlers/backfill-channel.ts
+++ b/src/lib/sources/youtube/server/handlers/backfill-channel.ts
@@ -54,6 +54,7 @@ import {
   setChannelBackfillPageToken,
 } from "$lib/server/services/channel-state.js";
 import { youtubeChannelAdapterCore as adapter } from "../adapter.js";
+import { getNewestKnownPublishedAt } from "../newest-known.js";
 import { AdapterError } from "$lib/sources/errors.js";
 import type { SourceKind } from "$lib/sources/adapter.js";
 
@@ -125,20 +126,55 @@ export async function handleBackfillChannel(job: BackfillChannelJob): Promise<vo
   // 2. Resolve channel state (auto-create on first walk via mark*/set* helpers).
   const channelState = await getChannelState(kind, channelKey);
 
-  // 3. Compute since.
-  // Worker passes `since` as a stop boundary; adapter resumes from
-  // channel.metadata.lastBackfillPageToken if set (cursor-driven), else
-  // starts page 1. Walk continues until:
-  //   - items older than `since` encountered (walkedPastSince)
-  //   - endOfPlaylist
-  //   - MAX_PAGES reached (cursor saved for next walk)
-  const since = new Date(job.data.depthBoundIso);
-  if (Number.isNaN(since.getTime())) {
+  // 3. Compute since — three-branch derivation (Phase 03.0.3 P1; D-#29-2).
+  //
+  // The walker historically used `since = depthBoundIso` unconditionally;
+  // that re-walks the full uploads playlist on every click when the user's
+  // target is epoch (~110 quota units across 8 channels with zero new
+  // videos). The branch logic gates the walk depth using the channel's
+  // newest-known publishedAt cursor + the channel's prior walk frontier.
+  //
+  // Branches (D-#29-2 — applies identically to ctx.origin user AND cron):
+  //   - exhausted   (backfill_complete=true)
+  //                 since = max(newestKnown, target)  — steady state
+  //   - incremental (!complete && deepestWalked !== null && target >= deepestWalked)
+  //                 since = max(newestKnown, target)  — partial walk, target shallower
+  //   - deep        (else)
+  //                 since = target                    — no prior walk OR target deeper
+  //
+  // Token clearing rule (D-#29-3): exhausted + incremental branches CLEAR
+  // metadata.lastBackfillPageToken before adapter.pollContent. Deep branch
+  // preserves it (resume cursor for >MAX_PAGES walks). Without this clear,
+  // a stale page-N cursor from a prior deep walk would cause walkedPastSince
+  // to fire immediately on the incremental click with zero events.
+  const target = new Date(job.data.depthBoundIso);
+  if (Number.isNaN(target.getTime())) {
     logger.warn(
       { jobId: job.id, depthBoundIso: job.data.depthBoundIso },
       "youtube.backfill.channel: invalid depthBoundIso; skipping",
     );
     return;
+  }
+  const newestKnown = await getNewestKnownPublishedAt(channelKey);
+  const deepestWalked = channelState?.backfillOldestAt ?? null;
+  let branch: "exhausted" | "incremental" | "deep";
+  if (channelState?.backfillComplete === true) {
+    branch = "exhausted";
+  } else if (deepestWalked !== null && target.getTime() >= deepestWalked.getTime()) {
+    branch = "incremental";
+  } else {
+    branch = "deep";
+  }
+  const since =
+    branch === "deep"
+      ? target
+      : newestKnown !== null && newestKnown.getTime() > target.getTime()
+        ? newestKnown
+        : target;
+  const incrementalBranchTaken = branch !== "deep";
+  if (incrementalBranchTaken) {
+    // D-#29-3 — clear stale resume cursor before incremental walk.
+    await setChannelBackfillPageToken(kind, channelKey, null);
   }
 
   // 4. Build PollableSource shape for adapter (legacy name; semantically a
@@ -200,6 +236,7 @@ export async function handleBackfillChannel(job: BackfillChannelJob): Promise<vo
         triggerUserId,
         requestsUsed: 0,
         eventsInserted: 0,
+        sinceBranch: branch,
       });
     }
     logger.warn(
@@ -234,6 +271,7 @@ export async function handleBackfillChannel(job: BackfillChannelJob): Promise<vo
         triggerUserId,
         requestsUsed: pollResult.unitsUsed,
         eventsInserted: 0,
+        sinceBranch: branch,
       });
     }
     logger.info(
@@ -413,6 +451,7 @@ export async function handleBackfillChannel(job: BackfillChannelJob): Promise<vo
       triggerUserId,
       requestsUsed: pollResult.unitsUsed,
       eventsInserted: userInserted,
+      sinceBranch: branch,
     });
   }
 
@@ -441,6 +480,11 @@ async function writeBackfillAudit(args: {
   triggerUserId: string;
   requestsUsed: number;
   eventsInserted: number;
+  // Phase 03.0.3 P1 — forensics discriminator for the three-branch
+  // since-derivation. Operator can run `SELECT metadata->>'since_branch',
+  // COUNT(*) FROM audit_log WHERE action='source.refresh_content_requested'
+  // GROUP BY 1` to verify the quota-burn invariant on prod (D-#29-2).
+  sinceBranch: "exhausted" | "incremental" | "deep";
 }): Promise<void> {
   // STRICT — cap counter sums requests_used + events_inserted from this row;
   // a swallowed insert silently undercounts user usage.
@@ -457,6 +501,7 @@ async function writeBackfillAudit(args: {
       job_id: args.job.id ?? null,
       requests_used: args.requestsUsed,
       events_inserted: args.eventsInserted,
+      since_branch: args.sinceBranch,
     },
   });
 }

--- a/src/lib/sources/youtube/server/handlers/backfill-channel.ts
+++ b/src/lib/sources/youtube/server/handlers/backfill-channel.ts
@@ -492,14 +492,35 @@ export async function handleBackfillChannel(job: BackfillChannelJob): Promise<vo
     }
   }
 
-  // 9. Update channel state.
-  if (oldestFetchedOccurredAt !== null) {
+  // 9. Update channel state. Frontier advance is gated to deep-mode
+  //    walks only (PR #31 Codex P1 #2) — an overlap-mode walk collects
+  //    backdated cache-miss items intentionally (D-#29-1) but those
+  //    items can appear near page 1 of the upload-time-sorted playlist
+  //    while the walker never actually walked the playlist down to
+  //    their publishedAt. Advancing backfill_oldest_at from such an
+  //    arbitrary backdated event would incorrectly tell future
+  //    target-widen decisions that we've already covered that depth,
+  //    routing them to incremental and silently skipping the in-between
+  //    history.
+  //
+  //    For deep-mode walks two cases:
+  //      - endOfPlaylist=true: walker covered the entire playlist; the
+  //        oldest collected event publishedAt is the legitimate channel
+  //        floor.
+  //      - !endOfPlaylist (walkedPastSince OR MAX_PAGES): walker
+  //        stopped at the depth target. Frontier = since (= target)
+  //        rather than the oldest collected event — by construction
+  //        every collected event in deep mode has publishedAt > since,
+  //        so `since` is the true boundary we walked to.
+  const walkedInDeepMode = branch === "deep";
+  if (walkedInDeepMode && oldestFetchedOccurredAt !== null) {
+    const frontier = pollResult.endOfPlaylist ? oldestFetchedOccurredAt : since;
     if (
       channelState?.backfillOldestAt === null ||
       channelState?.backfillOldestAt === undefined ||
-      oldestFetchedOccurredAt.getTime() < channelState.backfillOldestAt.getTime()
+      frontier.getTime() < channelState.backfillOldestAt.getTime()
     ) {
-      await markChannelBackfillFrontier(kind, channelKey, oldestFetchedOccurredAt);
+      await markChannelBackfillFrontier(kind, channelKey, frontier);
     }
   }
   await setChannelBackfillPageToken(kind, channelKey, pollResult.nextPageToken ?? null);

--- a/src/lib/sources/youtube/server/handlers/backfill-channel.ts
+++ b/src/lib/sources/youtube/server/handlers/backfill-channel.ts
@@ -79,6 +79,16 @@ interface BackfillChannelJob {
      *  toward trigger user's per-user requestsPerDay cap;
      *  auto_passive does NOT count and does not write audit. */
     flow: BackfillFlow;
+    /** Phase 03.0.3 follow-up — force a deep walk regardless of the
+     *  three-branch since-derivation. Set ONLY by `updateSource` after a
+     *  user widens `backfillTargetSince` past the channel's
+     *  `backfill_oldest_at` on a fully-walked channel — without this
+     *  override, branch=exhausted always wins and historical events
+     *  below the prior depth would never surface (D-#29-7 multi-tenant
+     *  fairness was the reason for prioritising exhausted; this flag
+     *  is the single per-user opt-in to override it). The trigger user
+     *  pays quota for the deep walk; subscribers free-ride on fan-out. */
+    forceDeep?: boolean;
   };
 }
 
@@ -158,7 +168,14 @@ export async function handleBackfillChannel(job: BackfillChannelJob): Promise<vo
   const newestKnown = await getNewestKnownPublishedAt(channelKey);
   const deepestWalked = channelState?.backfillOldestAt ?? null;
   let branch: "exhausted" | "incremental" | "deep";
-  if (channelState?.backfillComplete === true) {
+  if (job.data.forceDeep === true) {
+    // Phase 03.0.3 follow-up — user-driven override of D-#29-7 fairness
+    // for one walk: widening backfillTargetSince past deepestWalked on a
+    // fully-walked channel does NOT trigger a deep walk under the
+    // three-branch logic (exhausted wins). updateSource enqueues this
+    // override exactly when a widen would otherwise be silently no-op.
+    branch = "deep";
+  } else if (channelState?.backfillComplete === true) {
     branch = "exhausted";
   } else if (deepestWalked !== null && target.getTime() >= deepestWalked.getTime()) {
     branch = "incremental";

--- a/src/lib/sources/youtube/server/handlers/backfill-channel.ts
+++ b/src/lib/sources/youtube/server/handlers/backfill-channel.ts
@@ -62,7 +62,7 @@ import {
   TIER_BOUNDARY_COLD_MS,
   UNAVAILABLE_POLL_STATUSES,
 } from "$lib/server/services/tier-resolver.js";
-import { notInArray, gt, asc, or as drizzleOr, not } from "drizzle-orm";
+import { gt, asc, or as drizzleOr, not } from "drizzle-orm";
 import type { SourceKind } from "$lib/sources/adapter.js";
 
 /** YouTube videos.list batch limit — mirrors YOUTUBE_VIDEOS_BATCH_SIZE

--- a/src/lib/sources/youtube/server/handlers/backfill-channel.ts
+++ b/src/lib/sources/youtube/server/handlers/backfill-channel.ts
@@ -278,14 +278,44 @@ export async function handleBackfillChannel(job: BackfillChannelJob): Promise<vo
     return;
   }
 
-  // 5. Empty result handling. Empty + unitsUsed > 0 = platform confirmed
-  //    no items (end of playlist OR walked past since on first page).
-  //    Mark complete only when at least one HTTP call landed — empty + 0
-  //    means precondition missing (no API key / unresolvable playlist).
+  // 5. Empty result handling. The walker returns events.length === 0 in
+  //    three distinct shapes; conflating them (the pre-fix behaviour
+  //    marked complete for ALL of them) silently closes channels whose
+  //    deeper history is not yet covered, and auto-backfill never
+  //    revisits them. Disambiguate by the flags adapter.pollContent
+  //    threads back:
+  //
+  //    | endOfPlaylist | nextPageToken    | meaning                  | state |
+  //    |---------------|------------------|--------------------------|-------|
+  //    | true          | undefined        | playlist exhausted       | complete=true, token=null  |
+  //    | false         | undefined        | walkedPastSince at depth | complete=unchanged, token=null  |
+  //    | false         | defined          | MAX_PAGES interrupted    | complete=unchanged, token=preserved  |
+  //
+  //    The "walkedPastSince" branch is the one Phase 03.0.3 cared about:
+  //    a deep walk with since=30d-ago whose page 1 is all older than
+  //    30d-ago means "the channel has no uploads in the last 30 days",
+  //    NOT "the channel is fully exhausted across all history".
+  //    Auto-backfill needs the unchanged complete flag to revisit when
+  //    target widens.
+  //
+  //    Empty + unitsUsed === 0 means the precondition failed (no API
+  //    key / unresolvable playlist) — preserve all state and just stamp
+  //    last_polled_at so the operator can still see the click in audit.
   if (pollResult.events.length === 0) {
     if (pollResult.unitsUsed > 0) {
-      await markChannelBackfillComplete(kind, channelKey);
-      await setChannelBackfillPageToken(kind, channelKey, null);
+      if (pollResult.endOfPlaylist) {
+        await markChannelBackfillComplete(kind, channelKey);
+        await setChannelBackfillPageToken(kind, channelKey, null);
+      } else if (pollResult.nextPageToken) {
+        // MAX_PAGES with token returned — preserve cursor for resume.
+        await setChannelBackfillPageToken(kind, channelKey, pollResult.nextPageToken);
+      } else {
+        // walkedPastSince (window-bounded walk, depth target hit but
+        // channel may have more older history). Clear cursor (we
+        // deliberately stopped, not interrupted) but leave complete flag
+        // unchanged so the next widened-target click can deep-walk again.
+        await setChannelBackfillPageToken(kind, channelKey, null);
+      }
     }
     await markChannelLastPolledAt(kind, channelKey);
     if (triggerUserId) {

--- a/src/lib/sources/youtube/server/handlers/backfill-channel.ts
+++ b/src/lib/sources/youtube/server/handlers/backfill-channel.ts
@@ -55,8 +55,16 @@ import {
 } from "$lib/server/services/channel-state.js";
 import { youtubeChannelAdapterCore as adapter } from "../adapter.js";
 import { getNewestKnownPublishedAt } from "../newest-known.js";
+import { writeSnapshot } from "../snapshots.js";
+import { pickKeyForJob } from "../quota.js";
 import { AdapterError } from "$lib/sources/errors.js";
 import type { SourceKind } from "$lib/sources/adapter.js";
+
+/** YouTube videos.list batch limit — mirrors YOUTUBE_VIDEOS_BATCH_SIZE
+ *  in the adapter (Google's hard cap). One quota unit per chunk; charge
+ *  the first video of each chunk, rest get unitsUsed=0 (same accounting
+ *  as poll-active.ts). */
+const YOUTUBE_VIDEOS_BATCH_SIZE = 50;
 
 type BackfillFlow = "initial" | "incremental" | "historical" | "auto_passive";
 
@@ -489,6 +497,91 @@ export async function handleBackfillChannel(job: BackfillChannelJob): Promise<vo
       if (inserted.length > 0) {
         insertedByUser.set(sub.userId, (insertedByUser.get(sub.userId) ?? 0) + 1);
       }
+    }
+  }
+
+  // 8b. Phase 03.0.3 follow-up — inline stats fetch for newly-discovered
+  //     videos. Pre-fix, backfill-channel only INSERTed events; stats
+  //     (view/like/comment) landed via a separate poll-active cron tick
+  //     up to 6 hours later. That created a transient "Manual entry —
+  //     no polling" UX state on every fresh refresh-content click —
+  //     the user explicitly added a tracked source EXPECTING the full
+  //     picture immediately. Mirrors the channel-context-backfill
+  //     pattern that already does playlistItems + videos.list in one
+  //     handler. Quota cost: ceil(N/50) extra units where N = new
+  //     videos collected — 0 in steady-state, 1 batch typical for a
+  //     refresh that surfaced 1-3 new uploads.
+  //
+  //     Failure modes:
+  //       - pickKeyForJob() returns null → skip silently (self-host
+  //         without keys gets graceful no-op; the per-event polling
+  //         cron's auth_error writeSnapshot path covers the rare
+  //         "keys configured but rejected" case).
+  //       - adapter.pollStatsByVideoId throws → log and continue.
+  //         Events are already INSERTed; stats poll can retry via the
+  //         cron or "Refresh now" button per card.
+  //       - per-video writeSnapshot throws → log and continue; other
+  //         videos in the batch still land.
+  const insertedExternalIds = Array.from(
+    new Set(
+      pollResult.events
+        .map((e) => e.externalId)
+        .filter((x): x is string => typeof x === "string" && x.length > 0),
+    ),
+  );
+  if (insertedExternalIds.length > 0) {
+    const picked = pickKeyForJob();
+    if (picked) {
+      try {
+        const quotaUser = triggerUserId ?? QUOTA_USER_BACKFILL;
+        const statsSnapshots = await adapter.pollStatsByVideoId(
+          insertedExternalIds,
+          quotaUser,
+          picked,
+        );
+        for (let i = 0; i < insertedExternalIds.length; i++) {
+          const videoId = insertedExternalIds[i]!;
+          const snap = statsSnapshots[i]!;
+          // Charge 1 unit on the first video of each batch; rest pass
+          // unitsUsed=0 (mirrors the chargedOnce-per-batch accounting
+          // in poll-active.ts:198-218).
+          const unitsThisVideo = i % YOUTUBE_VIDEOS_BATCH_SIZE === 0 ? 1 : 0;
+          try {
+            await writeSnapshot({
+              videoId,
+              metrics:
+                snap.status === "ok" && snap.metrics
+                  ? {
+                      view_count: snap.metrics.view_count ?? 0,
+                      like_count: snap.metrics.like_count ?? 0,
+                      comment_count: snap.metrics.comment_count ?? 0,
+                    }
+                  : null,
+              apiKeyId: picked.apiKeyId,
+              unitsUsed: unitsThisVideo,
+              // user-trigger → user pool; cron-trigger → cron pool.
+              // Mirrors backfill-channel's overall quota attribution.
+              poolKind: triggerUserId ? "user" : "cron",
+              status: snap.status,
+            });
+          } catch (err) {
+            logger.warn(
+              { jobId: job.id, videoId, err: String((err as Error).message ?? err) },
+              "youtube.backfill.channel: inline writeSnapshot failed; continuing",
+            );
+          }
+        }
+      } catch (err) {
+        logger.warn(
+          { jobId: job.id, kind, channelKey, err: String((err as Error).message ?? err) },
+          "youtube.backfill.channel: inline pollStatsByVideoId failed; stats will fetch on next poll cron",
+        );
+      }
+    } else {
+      logger.debug(
+        { jobId: job.id, count: insertedExternalIds.length },
+        "youtube.backfill.channel: SERVICE_YOUTUBE_API_KEYS empty; skipping inline stats fetch (will retry via cron)",
+      );
     }
   }
 

--- a/src/lib/sources/youtube/server/handlers/backfill-channel.ts
+++ b/src/lib/sources/youtube/server/handlers/backfill-channel.ts
@@ -189,8 +189,23 @@ export async function handleBackfillChannel(job: BackfillChannelJob): Promise<vo
         ? newestKnown
         : target;
   const incrementalBranchTaken = branch !== "deep";
+  // Phase 03.0.3 follow-up (PR #31 Codex P1) — the resume cursor passed to
+  // pollContent MUST be undefined for incremental/exhausted branches.
+  // Pre-fix only the DB row was cleared (setChannelBackfillPageToken
+  // below); the in-memory channelState.metadata.lastBackfillPageToken
+  // still held the stale token from the prior deep walk, and the
+  // pollContent call below read from THAT in-memory copy — so the
+  // adapter started from page N+1 of the prior deep walk instead of
+  // page 1, missing the recent uploads the incremental walk was
+  // supposed to discover. Deep branch keeps the resume cursor so the
+  // walk continues from where MAX_PAGES cut it off.
+  const pageTokenForPoll: string | undefined = incrementalBranchTaken
+    ? undefined
+    : (channelState?.metadata as { lastBackfillPageToken?: string } | undefined)
+        ?.lastBackfillPageToken;
   if (incrementalBranchTaken) {
-    // D-#29-3 — clear stale resume cursor before incremental walk.
+    // D-#29-3 — clear stale resume cursor before incremental walk. Persisted
+    // here so a worker crash mid-walk doesn't leave a dangling token in DB.
     await setChannelBackfillPageToken(kind, channelKey, null);
   }
 
@@ -217,9 +232,7 @@ export async function handleBackfillChannel(job: BackfillChannelJob): Promise<vo
         userId: triggerUserId ?? QUOTA_USER_BACKFILL,
         metadata: {
           channelId: channelKey,
-          lastBackfillPageToken: (
-            channelState?.metadata as { lastBackfillPageToken?: string } | undefined
-          )?.lastBackfillPageToken,
+          lastBackfillPageToken: pageTokenForPoll,
         },
       },
       since,

--- a/src/lib/sources/youtube/server/handlers/backfill-channel.ts
+++ b/src/lib/sources/youtube/server/handlers/backfill-channel.ts
@@ -601,9 +601,7 @@ export async function handleBackfillChannel(job: BackfillChannelJob): Promise<vo
             )
             .orderBy(asc(youtubeVideosTable.lastPolledAt))
             .limit(capacity);
-          const filler = fillerRows
-            .map((r) => r.videoId)
-            .filter((id) => !newSet.has(id));
+          const filler = fillerRows.map((r) => r.videoId).filter((id) => !newSet.has(id));
           if (filler.length > 0) {
             allIdsToPoll = [...insertedExternalIds, ...filler];
             logger.debug(
@@ -630,11 +628,7 @@ export async function handleBackfillChannel(job: BackfillChannelJob): Promise<vo
 
       try {
         const quotaUser = triggerUserId ?? QUOTA_USER_BACKFILL;
-        const statsSnapshots = await adapter.pollStatsByVideoId(
-          allIdsToPoll,
-          quotaUser,
-          picked,
-        );
+        const statsSnapshots = await adapter.pollStatsByVideoId(allIdsToPoll, quotaUser, picked);
         for (let i = 0; i < allIdsToPoll.length; i++) {
           const videoId = allIdsToPoll[i]!;
           const snap = statsSnapshots[i]!;

--- a/src/lib/sources/youtube/server/handlers/backfill-channel.ts
+++ b/src/lib/sources/youtube/server/handlers/backfill-channel.ts
@@ -223,7 +223,16 @@ export async function handleBackfillChannel(job: BackfillChannelJob): Promise<vo
         },
       },
       since,
-      { origin: triggerUserId ? "user" : "cron" },
+      {
+        origin: triggerUserId ? "user" : "cron",
+        // Phase 03.0.3 follow-up — D-#29-1 backdated-upload safety. Deep
+        // walks need the historical floor (since=target), so they stay
+        // on legacy "depth" stop. Incremental/exhausted walks (where
+        // since=newestKnown) MUST not drop backdated cache-miss items;
+        // switch to "overlap" which stops the walker after 3 consecutive
+        // already-cached items past the cutoff. See AdapterContext.walkStop.
+        walkStop: branch === "deep" ? "depth" : "overlap",
+      },
     );
   } catch (err) {
     if (err instanceof AdapterError) {

--- a/src/lib/sources/youtube/server/handlers/channel-context-backfill.ts
+++ b/src/lib/sources/youtube/server/handlers/channel-context-backfill.ts
@@ -757,11 +757,7 @@ async function handleChannelContextBackfillImpl(job: {
       await setChannelBackfillPageToken("youtube_channel", channelId, null);
     } else if (stopReason === "hard_cap") {
       // Complete stays false; preserve resume cursor for next walk.
-      await setChannelBackfillPageToken(
-        "youtube_channel",
-        channelId,
-        hardCapResumeToken,
-      );
+      await setChannelBackfillPageToken("youtube_channel", channelId, hardCapResumeToken);
     } else {
       // cutoff_crossed — complete stays false (more history is available
       // past the cutoff if the user later widens backfillTargetSince);

--- a/src/lib/sources/youtube/server/handlers/channel-context-backfill.ts
+++ b/src/lib/sources/youtube/server/handlers/channel-context-backfill.ts
@@ -731,7 +731,21 @@ async function handleChannelContextBackfillImpl(job: {
     // window boundary directly because the frontier represents how far
     // back we walked, which IS the cutoff when we stopped because we
     // crossed it; oldest-seen would lie about the boundary.
-    if (stopReason === "cutoff_crossed" && cutoff !== null) {
+    //
+    // Phase 03.0.3 round-7 (Codex P2) — the cutoff_crossed frontier
+    // write is gated on `videoIds.length > 0`. Empty-window onboarding
+    // (channel exists but has no uploads in the requested window) used
+    // to record backfill_oldest_at = cutoff with an empty youtube_videos
+    // cache. The next refresh-content click then routed to
+    // branch="incremental" (target >= deepestWalked) and the
+    // overlap-mode walker, having no cache rows to compare against,
+    // never triggered the overlap-stop threshold — it walked to
+    // MAX_PAGES (20 quota units) and fan-out dropped every event for
+    // being before the user's target. Skipping the frontier write
+    // when nothing landed in cache means the next click routes to
+    // branch="deep" (walkStop="depth") and terminates on the first
+    // page past the cutoff — 1 quota unit instead of 20.
+    if (stopReason === "cutoff_crossed" && cutoff !== null && videoIds.length > 0) {
       await markChannelBackfillFrontier("youtube_channel", channelId, cutoff);
     } else if (videoIds.length > 0) {
       const oldestRow = await db

--- a/src/lib/sources/youtube/server/handlers/channel-context-backfill.ts
+++ b/src/lib/sources/youtube/server/handlers/channel-context-backfill.ts
@@ -495,11 +495,17 @@ async function handleChannelContextBackfillImpl(job: {
   }
 
   if (collected.length === 0) {
+    // Phase 03.0.3 follow-up — do NOT early-return here. Pre-fix this
+    // returned and skipped the terminal state writes at the bottom of
+    // the function, so a brand-new or naturally-empty channel
+    // (no_more_pages on page 0 with zero items) stayed
+    // backfill_complete=false forever and cron re-walked it every day.
+    // The empty-aware guards below let the function fall through to
+    // markChannelBackfillComplete + audit row with events_inserted=0.
     logger.info(
       { jobId: job.id, channelId, window, stopReason },
       "channel-context-backfill: no videos in window",
     );
-    return;
   }
 
   const videoIds = collected.map((c) => c.videoId);
@@ -587,7 +593,14 @@ async function handleChannelContextBackfillImpl(job: {
   //    coverage (Tracking). For the ingest paste path (sourceId NOT provided)
   //    the event is already created by the ingest service, so we skip this
   //    block and only step 7 below refreshes its lastPolledAt timestamp.
-  if (sourceId) {
+  //
+  // Phase 03.0.3 follow-up — added `collected.length > 0` guard. The
+  // pre-insert SELECT below uses `${events.externalId} IN (...)` with
+  // `collected.map(c => sql`${c.videoId}`)`; if collected is empty,
+  // Drizzle emits `IN ()`, which is a Postgres syntax error. Now that
+  // the early-return on empty collected is gone, this branch needs to
+  // skip explicitly.
+  if (sourceId && collected.length > 0) {
     // Tenant-scoped lookup — Pattern 1. The job payload pairs sourceId
     // with userId; even though pg-boss won't deliver a malformed job,
     // the eq(userId) filter is the load-bearing guarantee that we never

--- a/src/lib/sources/youtube/server/handlers/channel-context-backfill.ts
+++ b/src/lib/sources/youtube/server/handlers/channel-context-backfill.ts
@@ -725,10 +725,6 @@ async function handleChannelContextBackfillImpl(job: {
     // | no_more_pages    | true     | MIN(oldest seen)    | null               |
     // | hard_cap         | false    | oldest seen         | nextPageToken      |
     // | cutoff_crossed   | false    | cutoff              | null               |
-    //
-    // Phase 03.0.1 Wave 4 — channel-scoped state writes. Per-source state
-    // columns (last_polled_at, backfill_oldest_at) dropped in migration 0028;
-    // channel state is the single source of truth across all subscribers.
     await markChannelLastPolledAt("youtube_channel", channelId);
 
     // Frontier write — depends on stopReason. `cutoff_crossed` uses the

--- a/src/lib/sources/youtube/server/handlers/channel-context-backfill.ts
+++ b/src/lib/sources/youtube/server/handlers/channel-context-backfill.ts
@@ -49,6 +49,8 @@ import { markSourceNeedsReconnect } from "$lib/server/services/data-sources.js";
 import {
   markChannelLastPolledAt,
   markChannelBackfillFrontier,
+  markChannelBackfillComplete,
+  setChannelBackfillPageToken,
 } from "$lib/server/services/channel-state.js";
 import { writeAudit } from "$lib/server/audit.js";
 
@@ -435,6 +437,10 @@ async function handleChannelContextBackfillImpl(job: {
   const collected: { videoId: string; publishedAt: string; title: string }[] = [];
   let pageToken: string | undefined;
   let stopReason: "no_more_pages" | "cutoff_crossed" | "hard_cap" = "no_more_pages";
+  // Phase 03.0.3 P1 (D-#29-5) — captured at the hard-cap exit so the
+  // post-loop state writes can persist the resume cursor for the next
+  // walk. NULL on every non-hard_cap exit.
+  let hardCapResumeToken: string | null = null;
 
   for (let page = 0; page < MAX_PAGES; page++) {
     const playlistUrl = new URL(`${env.YOUTUBE_API_BASE_URL}/playlistItems`);
@@ -479,6 +485,10 @@ async function handleChannelContextBackfillImpl(job: {
     }
     if (page === MAX_PAGES - 1) {
       stopReason = "hard_cap";
+      // Preserve the cursor at MAX_PAGES so the next refresh-content
+      // click resumes from page 21 instead of restarting the walk
+      // (Phase 03.0.3 P1; D-#29-5).
+      hardCapResumeToken = playlistJson.nextPageToken ?? null;
       break;
     }
     pageToken = playlistJson.nextPageToken;
@@ -690,11 +700,31 @@ async function handleChannelContextBackfillImpl(job: {
   // not generic ingest path). Audit row written в both cases — ingest flow
   // (no sourceId) gets minimal metadata (no source_id field).
   if (sourceId && channelId !== null) {
+    // Phase 03.0.3 P1 (D-#29-5) — terminal channel-state writes per
+    // stopReason. Pre-fix the handler set frontier + last_polled_at but
+    // left backfill_complete=false even for channels that finished
+    // naturally (`no_more_pages`), causing the cron auto-backfill picker
+    // to re-walk them at 3am Pacific the next day — the typical
+    // onboarding double-walk.
+    //
+    // | stopReason       | complete | frontier            | token              |
+    // |------------------|----------|---------------------|--------------------|
+    // | no_more_pages    | true     | MIN(oldest seen)    | null               |
+    // | hard_cap         | false    | oldest seen         | nextPageToken      |
+    // | cutoff_crossed   | false    | cutoff              | null               |
+    //
     // Phase 03.0.1 Wave 4 — channel-scoped state writes. Per-source state
     // columns (last_polled_at, backfill_oldest_at) dropped in migration 0028;
     // channel state is the single source of truth across all subscribers.
     await markChannelLastPolledAt("youtube_channel", channelId);
-    if (videoIds.length > 0) {
+
+    // Frontier write — depends on stopReason. `cutoff_crossed` uses the
+    // window boundary directly because the frontier represents how far
+    // back we walked, which IS the cutoff when we stopped because we
+    // crossed it; oldest-seen would lie about the boundary.
+    if (stopReason === "cutoff_crossed" && cutoff !== null) {
+      await markChannelBackfillFrontier("youtube_channel", channelId, cutoff);
+    } else if (videoIds.length > 0) {
       const oldestRow = await db
         .select({ at: youtubeVideos.publishedAt })
         .from(youtubeVideos)
@@ -710,6 +740,25 @@ async function handleChannelContextBackfillImpl(job: {
       if (oldest !== null) {
         await markChannelBackfillFrontier("youtube_channel", channelId, oldest);
       }
+    }
+
+    // Complete + token writes — depends on stopReason.
+    if (stopReason === "no_more_pages") {
+      await markChannelBackfillComplete("youtube_channel", channelId);
+      await setChannelBackfillPageToken("youtube_channel", channelId, null);
+    } else if (stopReason === "hard_cap") {
+      // Complete stays false; preserve resume cursor for next walk.
+      await setChannelBackfillPageToken(
+        "youtube_channel",
+        channelId,
+        hardCapResumeToken,
+      );
+    } else {
+      // cutoff_crossed — complete stays false (more history is available
+      // past the cutoff if the user later widens backfillTargetSince);
+      // clear token because we did NOT exhaust pagination, we just
+      // stopped at the window boundary.
+      await setChannelBackfillPageToken("youtube_channel", channelId, null);
     }
   }
 

--- a/src/lib/sources/youtube/server/newest-known.ts
+++ b/src/lib/sources/youtube/server/newest-known.ts
@@ -1,0 +1,29 @@
+// Newest-known publishedAt cursor for the YouTube three-branch
+// since-derivation (Phase 03.0.3 P1; D-A2 / D-#29-1).
+//
+// Returns MAX(youtube_videos.published_at) WHERE channel_id = $1, or null
+// when the channel has no rows yet (cold start — caller falls back to the
+// user's `backfillTargetSince`).
+//
+// Why MAX(published_at), NOT last_polled_at: backdated uploads (rare on
+// YouTube, common on Telegram / Discord — and possible on YouTube when a
+// creator re-publishes a private video with its original publishedAt) have
+// `publishedAt` earlier than the newest collected video. Using
+// MAX(published_at) as the cursor means `walkedPastSince` fires only on
+// items older than the newest collected video — which is the correct
+// semantic. `last_polled_at` would skip backdated uploads silently.
+//
+// Public-data table (no userId filter); youtube_videos is in the ESLint
+// tenant-scope allowlist as a non-tenant table (snippets are public).
+
+import { sql, eq } from "drizzle-orm";
+import { db } from "$lib/server/db/client.js";
+import { youtubeVideos } from "$lib/server/db/schema/index.js";
+
+export async function getNewestKnownPublishedAt(channelKey: string): Promise<Date | null> {
+  const [row] = await db
+    .select({ maxPublishedAt: sql<Date | null>`MAX(${youtubeVideos.publishedAt})` })
+    .from(youtubeVideos)
+    .where(eq(youtubeVideos.channelId, channelKey));
+  return row?.maxPublishedAt ?? null;
+}

--- a/src/lib/sources/youtube/server/newest-known.ts
+++ b/src/lib/sources/youtube/server/newest-known.ts
@@ -21,9 +21,17 @@ import { db } from "$lib/server/db/client.js";
 import { youtubeVideos } from "$lib/server/db/schema/index.js";
 
 export async function getNewestKnownPublishedAt(channelKey: string): Promise<Date | null> {
+  // Drizzle's `sql<Date | null>` is structural; node-postgres returns
+  // aggregate results as the raw column type, but a SELECT-MAX expression
+  // can lose the timestamptz tag and surface as a string. Coerce
+  // defensively so callers can rely on Date semantics.
   const [row] = await db
-    .select({ maxPublishedAt: sql<Date | null>`MAX(${youtubeVideos.publishedAt})` })
+    .select({
+      maxPublishedAt: sql<Date | string | null>`MAX(${youtubeVideos.publishedAt})`,
+    })
     .from(youtubeVideos)
     .where(eq(youtubeVideos.channelId, channelKey));
-  return row?.maxPublishedAt ?? null;
+  const raw = row?.maxPublishedAt ?? null;
+  if (raw === null) return null;
+  return raw instanceof Date ? raw : new Date(raw);
 }

--- a/src/routes/feed/+page.server.ts
+++ b/src/routes/feed/+page.server.ts
@@ -11,12 +11,9 @@ import { listSources } from "$lib/server/services/data-sources.js";
 import { mapEventsToDtos, toGameDto, toDataSourceDto } from "$lib/server/dto.js";
 import { filterValidKinds } from "$lib/util/filter-event-kinds.js";
 import { db } from "$lib/server/db/client.js";
-import {
-  youtubeVideoSnapshots,
-  youtubeChannels,
-  youtubeVideos,
-} from "$lib/server/db/schema/index.js";
-import { sql, inArray } from "drizzle-orm";
+import { youtubeChannels } from "$lib/server/db/schema/index.js";
+import { inArray } from "drizzle-orm";
+import { allAdapters } from "$lib/sources/registry.js";
 
 // Plan 02.1-19 URL contract: /feed accepts ?show=any|inbox|specific +
 // ?game=A&game=B (when show=specific). The legacy ?attached=true|false is
@@ -154,64 +151,18 @@ export const load: PageServerLoad = async ({ locals, url }) => {
     mapEventsToDtos(userId, deletedRows),
   ]);
 
-  // Phase 3.0 post-build (UAT 2026-05-06): attach the latest YouTube stats
-  // snapshot to each youtube_video event in the feed. Single batched DISTINCT
-  // ON query — one DB round-trip regardless of page size. The snapshot table
-  // is public-data (no userId scope) so we filter only by external_id; the
-  // events list itself is already userId-scoped at listFeedPage.
-  const youtubeExternalIds = rowDtos
-    .filter((r) => r.kind === "youtube_video" && r.externalId !== null)
-    .map((r) => r.externalId as string);
-  if (youtubeExternalIds.length > 0) {
-    const snapshots = await db
-      .select({
-        videoId: youtubeVideoSnapshots.videoId,
-        polledAt: youtubeVideoSnapshots.polledAt,
-        viewCount: youtubeVideoSnapshots.viewCount,
-        likeCount: youtubeVideoSnapshots.likeCount,
-        commentCount: youtubeVideoSnapshots.commentCount,
-      })
-      .from(youtubeVideoSnapshots)
-      .where(inArray(youtubeVideoSnapshots.videoId, youtubeExternalIds))
-      .orderBy(youtubeVideoSnapshots.videoId, sql`${youtubeVideoSnapshots.polledAt} DESC`);
-    const latest = new Map<
-      string,
-      { viewCount: number; likeCount: number; commentCount: number; polledAt: Date }
-    >();
-    for (const s of snapshots) {
-      if (!latest.has(s.videoId)) {
-        latest.set(s.videoId, {
-          viewCount: s.viewCount ?? 0,
-          likeCount: s.likeCount ?? 0,
-          commentCount: s.commentCount ?? 0,
-          polledAt: s.polledAt,
-        });
-      }
-    }
-    for (const r of rowDtos) {
-      if (r.kind === "youtube_video" && r.externalId) {
-        r.stats = latest.get(r.externalId) ?? null;
-      }
-    }
-
-    // Phase 03.0.1 (post-review UAT 2026-05-10) — channelTitle for ALL
-    // youtube_video events (auto-imported AND manual paste). Lookup via
-    // youtube_videos cache (populated by oEmbed on manual paste +
-    // channel-context-backfill on auto-import). FeedCard renders single
-    // chip with optional «auto-import» icon prefix.
-    const videoChannels = await db
-      .select({
-        videoId: youtubeVideos.videoId,
-        channelTitle: youtubeVideos.channelTitle,
-      })
-      .from(youtubeVideos)
-      .where(inArray(youtubeVideos.videoId, youtubeExternalIds));
-    const titleByVideo = new Map<string, string | null>();
-    for (const v of videoChannels) titleByVideo.set(v.videoId, v.channelTitle);
-    for (const r of rowDtos) {
-      if (r.kind === "youtube_video" && r.externalId) {
-        r.channelTitle = titleByVideo.get(r.externalId) ?? null;
-      }
+  // Phase 03.0.3 P2 — adapter-driven feed enrichment. Iterates allAdapters
+  // and lets each one mutate the dtos in place. YouTube enriches
+  // kind=youtube_video rows with stats + channelTitle; future Reddit /
+  // Twitter / Telegram / Discord adapters enrich their own kinds from
+  // per-platform metadata tables. Replaces the inline JOIN that lived
+  // here pre-Phase-03.0.3 — that path enriched only the SSR first batch,
+  // leaving GET /api/events cursor pagination + /games/[id] curated views
+  // unenriched (issue #29 Part 2). Now all three callsites share the
+  // same loop.
+  for (const adapter of allAdapters) {
+    if (adapter.enrichFeedDtos) {
+      await adapter.enrichFeedDtos(userId, rowDtos);
     }
   }
 

--- a/src/routes/games/[gameId]/+page.server.ts
+++ b/src/routes/games/[gameId]/+page.server.ts
@@ -10,6 +10,7 @@ import {
   mapEventsToDtos,
   toDataSourceDto,
 } from "$lib/server/dto.js";
+import { allAdapters } from "$lib/sources/registry.js";
 import { NotFoundError } from "$lib/server/services/errors.js";
 
 /**
@@ -72,6 +73,13 @@ export const load: PageServerLoad = async ({ locals, params }) => {
   // via the batch junction loader. Multi-game events surface their full
   // attachment set; the rendering page can show "also attached to X, Y".
   const eventDtos = await mapEventsToDtos(userId, events);
+  // Phase 03.0.3 P2 — adapter-driven feed enrichment for the per-game
+  // curated view. Same loop as /feed SSR + GET /api/events.
+  for (const adapter of allAdapters) {
+    if (adapter.enrichFeedDtos) {
+      await adapter.enrichFeedDtos(userId, eventDtos);
+    }
+  }
 
   return {
     game: toGameDto(game),

--- a/src/routes/games/[gameId]/+page.server.ts
+++ b/src/routes/games/[gameId]/+page.server.ts
@@ -92,9 +92,7 @@ export const load: PageServerLoad = async ({ locals, params }) => {
   // default) to source.handleUrl (the raw URL) — visually inconsistent
   // with /feed for the same event.
   const sourceDtos = sources.map(toDataSourceDto);
-  const channelIds = sourceDtos
-    .map((s) => s.channelId)
-    .filter((c): c is string => c !== null);
+  const channelIds = sourceDtos.map((s) => s.channelId).filter((c): c is string => c !== null);
   if (channelIds.length > 0) {
     const channelCache = await db
       .select({

--- a/src/routes/games/[gameId]/+page.server.ts
+++ b/src/routes/games/[gameId]/+page.server.ts
@@ -12,6 +12,9 @@ import {
 } from "$lib/server/dto.js";
 import { allAdapters } from "$lib/sources/registry.js";
 import { NotFoundError } from "$lib/server/services/errors.js";
+import { db } from "$lib/server/db/client.js";
+import { youtubeChannels } from "$lib/server/db/schema/index.js";
+import { inArray } from "drizzle-orm";
 
 /**
  * /games/[gameId] loader — Phase 2.1 Plan 02.1-09 rebuild.
@@ -81,12 +84,38 @@ export const load: PageServerLoad = async ({ locals, params }) => {
     }
   }
 
+  // Phase 03.0.3 UAT follow-up — populate source.channelTitle from
+  // youtube_channels cache, mirroring /feed/+page.server.ts. Without
+  // this enrichment, FeedCard's `channelLabel` chain falls from
+  // event.channelTitle (null when youtube_videos cache lacks the row)
+  // through source.channelTitle (always null per toDataSourceDto
+  // default) to source.handleUrl (the raw URL) — visually inconsistent
+  // with /feed for the same event.
+  const sourceDtos = sources.map(toDataSourceDto);
+  const channelIds = sourceDtos
+    .map((s) => s.channelId)
+    .filter((c): c is string => c !== null);
+  if (channelIds.length > 0) {
+    const channelCache = await db
+      .select({
+        channelId: youtubeChannels.channelId,
+        channelTitle: youtubeChannels.channelTitle,
+      })
+      .from(youtubeChannels)
+      .where(inArray(youtubeChannels.channelId, channelIds));
+    const titleByChannel = new Map<string, string | null>();
+    for (const r of channelCache) titleByChannel.set(r.channelId, r.channelTitle);
+    for (const s of sourceDtos) {
+      if (s.channelId) s.channelTitle = titleByChannel.get(s.channelId) ?? null;
+    }
+  }
+
   return {
     game: toGameDto(game),
     listings: listings.map(toGameSteamListingDto),
     deletedListings: deletedListings.map(toGameSteamListingDto),
     events: eventDtos,
     games: gamesAll.map(toGameDto),
-    sources: sources.map(toDataSourceDto),
+    sources: sourceDtos,
   };
 };

--- a/src/worker/handlers/outbox-forwarder.ts
+++ b/src/worker/handlers/outbox-forwarder.ts
@@ -1,0 +1,224 @@
+// Phase 03.0.3 follow-up (PR #31 Codex P2) — outbox forwarder.
+//
+// Long-running async loop in the worker process that translates pending
+// `outbox` rows into pg-boss `boss.send` calls. Two wake-up sources:
+//
+//   1. Postgres LISTEN on 'outbox.new' channel — triggered by the
+//      AFTER-INSERT trigger from migration 0029. Instant pickup
+//      (typically <10ms after commit).
+//
+//   2. Periodic sweep every 30s — durability backstop in case the
+//      LISTEN connection drops silently (TCP timeout, pg restart),
+//      or in case a NOTIFY was missed during forwarder restart.
+//
+// Delivery semantics: at-least-once. The forwarder calls boss.send
+// FIRST, then UPDATEs forwarded_at = now(). If the process crashes
+// between the two, the next sweep re-sends. pg-boss singletonKey in
+// outbox.options dedupes those rare duplicates; downstream handlers
+// must be idempotent.
+//
+// Failure handling: every failed forward attempt bumps
+// forwarder_attempt + stores last_error / last_attempt_at. After
+// MAX_ATTEMPTS the row stays pending forever — operator must
+// manually investigate via SELECT (or extend this with a dead-letter
+// dispatch later).
+
+import { sql } from "drizzle-orm";
+import pg from "pg";
+import { db, pool } from "../../lib/server/db/client.js";
+import { outbox } from "../../lib/server/db/schema/outbox.js";
+import { getBoss } from "../../lib/server/queue-client.js";
+import { logger } from "../../lib/server/logger.js";
+import { env } from "../../lib/server/config/env.js";
+
+/** Forwarder LISTEN channel — must match `pg_notify('outbox.new', ...)`
+ *  in migration 0029's AFTER-INSERT trigger. */
+const NOTIFY_CHANNEL = "outbox.new";
+/** Periodic sweep interval. 30s gives <1m worst-case latency even when
+ *  LISTEN drops; tight enough that an operator-introduced stuck row
+ *  surfaces within a debug session. */
+const SWEEP_INTERVAL_MS = 30_000;
+/** Per-sweep batch size — keep modest so one slow batch doesn't block
+ *  NOTIFY wakeups for unrelated jobs. */
+const BATCH_SIZE = 50;
+/** After this many failed attempts, the forwarder skips the row on
+ *  subsequent sweeps (still SELECTed but boss.send not retried). Manual
+ *  intervention required — increment the row's forwarder_attempt back
+ *  below threshold OR delete to drop the intent. */
+const MAX_ATTEMPTS = 20;
+
+interface PendingRow {
+  id: string;
+  queue: string;
+  payload: Record<string, unknown>;
+  options: Record<string, unknown>;
+  forwarder_attempt: number;
+}
+
+/** Process one batch of pending outbox rows. Returns the number of
+ *  rows forwarded successfully so callers can decide whether to loop. */
+async function processOnce(): Promise<number> {
+  const result = await db.execute(sql`
+    SELECT id, queue, payload, options, forwarder_attempt
+    FROM outbox
+    WHERE forwarded_at IS NULL AND forwarder_attempt < ${MAX_ATTEMPTS}
+    ORDER BY created_at
+    LIMIT ${BATCH_SIZE}
+    FOR UPDATE SKIP LOCKED
+  `);
+  const rows = result.rows as unknown as PendingRow[];
+  if (rows.length === 0) return 0;
+
+  const boss = await getBoss();
+  let forwarded = 0;
+  for (const row of rows) {
+    try {
+      await boss.send(
+        row.queue,
+        row.payload as Parameters<typeof boss.send>[1],
+        row.options as Parameters<typeof boss.send>[2],
+      );
+      await db
+        .update(outbox)
+        .set({ forwardedAt: new Date() })
+        .where(sql`${outbox.id} = ${row.id}`);
+      forwarded += 1;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await db
+        .update(outbox)
+        .set({
+          forwarderAttempt: row.forwarder_attempt + 1,
+          lastError: message,
+          lastAttemptAt: new Date(),
+        })
+        .where(sql`${outbox.id} = ${row.id}`);
+      logger.warn(
+        {
+          outboxId: row.id,
+          queue: row.queue,
+          attempt: row.forwarder_attempt + 1,
+          err: message,
+        },
+        "outbox-forwarder: forward failed; row stays pending",
+      );
+    }
+  }
+  return forwarded;
+}
+
+/** Drain pending rows until the queue is empty (or until the cap is
+ *  hit) — invoked on LISTEN wakeup and on every periodic sweep. */
+async function drain(): Promise<void> {
+  let totalForwarded = 0;
+  for (let i = 0; i < 10; i += 1) {
+    const forwarded = await processOnce();
+    totalForwarded += forwarded;
+    if (forwarded < BATCH_SIZE) break;
+  }
+  if (totalForwarded > 0) {
+    logger.debug({ count: totalForwarded }, "outbox-forwarder: drained pending rows");
+  }
+}
+
+/** Start the long-running forwarder. Sets up:
+ *    1. A dedicated pg.Client for LISTEN (LISTEN holds the connection;
+ *       using a pooled client would prevent the pool from recycling it).
+ *    2. A setInterval periodic sweep as durability backstop.
+ *    3. Reconnect logic if the LISTEN client errors out.
+ *
+ *  Returns a teardown function the worker shutdown handler invokes. */
+export async function startOutboxForwarder(): Promise<() => Promise<void>> {
+  let listenClient: pg.Client | null = null;
+  let sweepTimer: NodeJS.Timeout | null = null;
+  let stopped = false;
+
+  const connectListener = async (): Promise<void> => {
+    if (stopped) return;
+    const client = new pg.Client({ connectionString: env.DATABASE_URL });
+    try {
+      await client.connect();
+      client.on("error", (err) => {
+        logger.warn(
+          { err: String(err.message) },
+          "outbox-forwarder: LISTEN connection error; falling back to periodic sweep until reconnect",
+        );
+        if (listenClient === client) listenClient = null;
+        // Reconnect after a beat — the sweep keeps draining in the meantime.
+        setTimeout(() => {
+          void connectListener();
+        }, 5_000);
+      });
+      client.on("notification", () => {
+        void drain();
+      });
+      await client.query(`LISTEN "${NOTIFY_CHANNEL}"`);
+      listenClient = client;
+      logger.info(
+        { channel: NOTIFY_CHANNEL },
+        "outbox-forwarder: LISTEN connection ready",
+      );
+    } catch (err) {
+      logger.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "outbox-forwarder: LISTEN connect failed; falling back to periodic sweep",
+      );
+      try {
+        await client.end();
+      } catch {
+        // Ignore — connection was already dead.
+      }
+      setTimeout(() => {
+        void connectListener();
+      }, 5_000);
+    }
+  };
+
+  await connectListener();
+  // Initial drain in case rows landed before this worker booted.
+  await drain();
+
+  sweepTimer = setInterval(() => {
+    void drain().catch((err) => {
+      logger.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "outbox-forwarder: periodic sweep failed",
+      );
+    });
+  }, SWEEP_INTERVAL_MS);
+
+  return async () => {
+    stopped = true;
+    if (sweepTimer) clearInterval(sweepTimer);
+    if (listenClient) {
+      try {
+        await listenClient.query(`UNLISTEN "${NOTIFY_CHANNEL}"`);
+        await listenClient.end();
+      } catch (err) {
+        logger.warn(
+          { err: err instanceof Error ? err.message : String(err) },
+          "outbox-forwarder: shutdown unlisten/end failed",
+        );
+      }
+    }
+  };
+}
+
+/** Exposed for tests + the purge.daily cron that cleans forwarded rows. */
+export async function deleteForwardedOutboxRows(olderThan: Date): Promise<number> {
+  const result = await db.execute(sql`
+    DELETE FROM outbox
+    WHERE forwarded_at IS NOT NULL AND forwarded_at < ${olderThan.toISOString()}::timestamptz
+    RETURNING id
+  `);
+  return result.rows.length;
+}
+
+/** Exposed for tests — bypasses the long-running loop and just processes
+ *  one batch synchronously. */
+export { drain as drainOutboxOnce };
+
+// Keep the unused-import linter happy + ensure tree-shake protection for
+// the `pool` re-export from db/client.js (the LISTEN client uses its own
+// connection but other forwarder paths reuse the pool via Drizzle `db`).
+void pool;

--- a/src/worker/handlers/outbox-forwarder.ts
+++ b/src/worker/handlers/outbox-forwarder.ts
@@ -154,10 +154,7 @@ export async function startOutboxForwarder(): Promise<() => Promise<void>> {
       });
       await client.query(`LISTEN "${NOTIFY_CHANNEL}"`);
       listenClient = client;
-      logger.info(
-        { channel: NOTIFY_CHANNEL },
-        "outbox-forwarder: LISTEN connection ready",
-      );
+      logger.info({ channel: NOTIFY_CHANNEL }, "outbox-forwarder: LISTEN connection ready");
     } catch (err) {
       logger.warn(
         { err: err instanceof Error ? err.message : String(err) },

--- a/src/worker/handlers/outbox-forwarder.ts
+++ b/src/worker/handlers/outbox-forwarder.ts
@@ -17,6 +17,19 @@
 // outbox.options dedupes those rare duplicates; downstream handlers
 // must be idempotent.
 //
+// Concurrency safety (Phase 03.0.3 round-2 review — Codex P1 #1):
+//   - drainInFlight mutex prevents two drain() calls from running
+//     concurrently within the same process (NOTIFY trigger + 30s
+//     interval would otherwise both pick up the same rows).
+//   - Atomic row claim via UPDATE ... WHERE id IN (SELECT ... FOR
+//     UPDATE SKIP LOCKED) RETURNING bumps last_attempt_at in the
+//     same statement that selects the row — concurrent claimers
+//     (different processes / replicas) skip rows that another
+//     process is currently working on, because the WHERE clause
+//     excludes rows with last_attempt_at > now() - claim window.
+//   - pg-boss singletonKey in outbox.options is the third belt:
+//     even on duplicate boss.send, only one job runs.
+//
 // Failure handling: every failed forward attempt bumps
 // forwarder_attempt + stores last_error / last_attempt_at. After
 // MAX_ATTEMPTS the row stays pending forever — operator must
@@ -25,9 +38,9 @@
 
 import { sql } from "drizzle-orm";
 import pg from "pg";
-import { db, pool } from "../../lib/server/db/client.js";
+import type { PgBoss } from "pg-boss";
+import { db } from "../../lib/server/db/client.js";
 import { outbox } from "../../lib/server/db/schema/outbox.js";
-import { getBoss } from "../../lib/server/queue-client.js";
 import { logger } from "../../lib/server/logger.js";
 import { env } from "../../lib/server/config/env.js";
 
@@ -46,8 +59,14 @@ const BATCH_SIZE = 50;
  *  intervention required — increment the row's forwarder_attempt back
  *  below threshold OR delete to drop the intent. */
 const MAX_ATTEMPTS = 20;
+/** Atomic-claim window. A row whose last_attempt_at was bumped within
+ *  this window is assumed "in flight" by another claimer and skipped.
+ *  60s is long enough to cover normal boss.send latency (~10ms)
+ *  including a stuck-network worst case, short enough that a crashed
+ *  forwarder doesn't leave the row stuck for hours. */
+const CLAIM_WINDOW_SECONDS = 60;
 
-interface PendingRow {
+interface ClaimedRow {
   id: string;
   queue: string;
   payload: Record<string, unknown>;
@@ -56,20 +75,33 @@ interface PendingRow {
 }
 
 /** Process one batch of pending outbox rows. Returns the number of
- *  rows forwarded successfully so callers can decide whether to loop. */
-async function processOnce(): Promise<number> {
+ *  rows forwarded successfully. */
+async function processOnce(boss: PgBoss): Promise<number> {
+  // Atomic claim: the UPDATE acquires per-row locks via SKIP LOCKED in
+  // the inner SELECT, and bumps last_attempt_at as the side effect that
+  // makes the row "claimed" for the next CLAIM_WINDOW_SECONDS. A
+  // concurrent claimer's SELECT excludes claimed rows via the WHERE
+  // clause — atomic with no separate transaction handling needed.
   const result = await db.execute(sql`
-    SELECT id, queue, payload, options, forwarder_attempt
-    FROM outbox
-    WHERE forwarded_at IS NULL AND forwarder_attempt < ${MAX_ATTEMPTS}
-    ORDER BY created_at
-    LIMIT ${BATCH_SIZE}
-    FOR UPDATE SKIP LOCKED
+    UPDATE outbox
+    SET last_attempt_at = now()
+    WHERE id IN (
+      SELECT id FROM outbox
+      WHERE forwarded_at IS NULL
+        AND forwarder_attempt < ${MAX_ATTEMPTS}
+        AND (
+          last_attempt_at IS NULL
+          OR last_attempt_at < now() - (${CLAIM_WINDOW_SECONDS} * interval '1 second')
+        )
+      ORDER BY created_at
+      LIMIT ${BATCH_SIZE}
+      FOR UPDATE SKIP LOCKED
+    )
+    RETURNING id, queue, payload, options, forwarder_attempt
   `);
-  const rows = result.rows as unknown as PendingRow[];
+  const rows = result.rows as unknown as ClaimedRow[];
   if (rows.length === 0) return 0;
 
-  const boss = await getBoss();
   let forwarded = 0;
   for (const row of rows) {
     try {
@@ -85,12 +117,14 @@ async function processOnce(): Promise<number> {
       forwarded += 1;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      // last_attempt_at was set during the claim — only bump the
+      // attempt counter and capture last_error here. The claim window
+      // will release the row for retry once CLAIM_WINDOW_SECONDS elapses.
       await db
         .update(outbox)
         .set({
           forwarderAttempt: row.forwarder_attempt + 1,
           lastError: message,
-          lastAttemptAt: new Date(),
         })
         .where(sql`${outbox.id} = ${row.id}`);
       logger.warn(
@@ -107,18 +141,50 @@ async function processOnce(): Promise<number> {
   return forwarded;
 }
 
+/** Process-level mutex preventing two drain() calls from running
+ *  concurrently within the same process. Belt to the atomic-claim
+ *  suspender: even though atomic claim handles cross-process races
+ *  correctly, the mutex avoids redundant intra-process SQL churn
+ *  when NOTIFY + interval fire close together. */
+let drainInFlight = false;
+/** Reentry counter — if a drain wakeup arrives while the previous
+ *  drain is in flight, set this so the running drain runs one extra
+ *  pass after finishing (in case the new wakeup represents a row
+ *  that landed after the running drain's SELECT). */
+let drainReentryPending = false;
+
 /** Drain pending rows until the queue is empty (or until the cap is
  *  hit) — invoked on LISTEN wakeup and on every periodic sweep. */
-async function drain(): Promise<void> {
-  let totalForwarded = 0;
-  for (let i = 0; i < 10; i += 1) {
-    const forwarded = await processOnce();
-    totalForwarded += forwarded;
-    if (forwarded < BATCH_SIZE) break;
+async function drain(boss: PgBoss): Promise<void> {
+  if (drainInFlight) {
+    drainReentryPending = true;
+    return;
   }
-  if (totalForwarded > 0) {
-    logger.debug({ count: totalForwarded }, "outbox-forwarder: drained pending rows");
+  drainInFlight = true;
+  try {
+    do {
+      drainReentryPending = false;
+      let totalForwarded = 0;
+      for (let i = 0; i < 10; i += 1) {
+        const forwarded = await processOnce(boss);
+        totalForwarded += forwarded;
+        if (forwarded < BATCH_SIZE) break;
+      }
+      if (totalForwarded > 0) {
+        logger.debug({ count: totalForwarded }, "outbox-forwarder: drained pending rows");
+      }
+    } while (drainReentryPending);
+  } finally {
+    drainInFlight = false;
   }
+}
+
+export interface StartOutboxForwarderOptions {
+  /** Existing pg-boss instance from the worker's createBoss() call.
+   *  Injected (rather than called via getBoss()) so the forwarder
+   *  shares the worker's boss + pool instead of lazily booting a
+   *  second singleton. PR #31 Codex P2 #1. */
+  boss: PgBoss;
 }
 
 /** Start the long-running forwarder. Sets up:
@@ -128,7 +194,10 @@ async function drain(): Promise<void> {
  *    3. Reconnect logic if the LISTEN client errors out.
  *
  *  Returns a teardown function the worker shutdown handler invokes. */
-export async function startOutboxForwarder(): Promise<() => Promise<void>> {
+export async function startOutboxForwarder(
+  opts: StartOutboxForwarderOptions,
+): Promise<() => Promise<void>> {
+  const { boss } = opts;
   let listenClient: pg.Client | null = null;
   let sweepTimer: NodeJS.Timeout | null = null;
   let stopped = false;
@@ -150,7 +219,7 @@ export async function startOutboxForwarder(): Promise<() => Promise<void>> {
         }, 5_000);
       });
       client.on("notification", () => {
-        void drain();
+        void drain(boss);
       });
       await client.query(`LISTEN "${NOTIFY_CHANNEL}"`);
       listenClient = client;
@@ -173,10 +242,10 @@ export async function startOutboxForwarder(): Promise<() => Promise<void>> {
 
   await connectListener();
   // Initial drain in case rows landed before this worker booted.
-  await drain();
+  await drain(boss);
 
   sweepTimer = setInterval(() => {
-    void drain().catch((err) => {
+    void drain(boss).catch((err) => {
       logger.warn(
         { err: err instanceof Error ? err.message : String(err) },
         "outbox-forwarder: periodic sweep failed",
@@ -212,10 +281,9 @@ export async function deleteForwardedOutboxRows(olderThan: Date): Promise<number
 }
 
 /** Exposed for tests — bypasses the long-running loop and just processes
- *  one batch synchronously. */
-export { drain as drainOutboxOnce };
-
-// Keep the unused-import linter happy + ensure tree-shake protection for
-// the `pool` re-export from db/client.js (the LISTEN client uses its own
-// connection but other forwarder paths reuse the pool via Drizzle `db`).
-void pool;
+ *  one batch synchronously. Tests supply their own boss mock; production
+ *  code uses startOutboxForwarder which threads the worker's boss
+ *  through. */
+export async function drainOutboxOnce(boss: PgBoss): Promise<void> {
+  await drain(boss);
+}

--- a/src/worker/handlers/purge-daily.ts
+++ b/src/worker/handlers/purge-daily.ts
@@ -61,10 +61,7 @@ export async function handlePurgeDaily(job: { id: string; data: object }): Promi
       "purge-daily: outbox cleanup complete",
     );
   } catch (err) {
-    logger.error(
-      { jobId: job.id, err },
-      "purge-daily: outbox cleanup failed; continuing",
-    );
+    logger.error({ jobId: job.id, err }, "purge-daily: outbox cleanup failed; continuing");
   }
 
   logger.info(

--- a/src/worker/handlers/purge-daily.ts
+++ b/src/worker/handlers/purge-daily.ts
@@ -19,6 +19,12 @@
 
 import { listPurgeEligibleUsers, purgeAccount } from "../../lib/server/services/purge-account.js";
 import { logger } from "../../lib/server/logger.js";
+import { deleteForwardedOutboxRows } from "./outbox-forwarder.js";
+
+/** Outbox retention window — keep forwarded rows for 7 days so an
+ *  operator debugging a recent issue can still trace which jobs were
+ *  enqueued via outbox. After 7 days the rows are pure noise. */
+const OUTBOX_RETENTION_DAYS = 7;
 
 export async function handlePurgeDaily(job: { id: string; data: object }): Promise<void> {
   const eligible = await listPurgeEligibleUsers();
@@ -40,6 +46,25 @@ export async function handlePurgeDaily(job: { id: string; data: object }): Promi
         "purge-daily: per-user purge failed; continuing sweep",
       );
     }
+  }
+
+  // Phase 03.0.3 follow-up — outbox cleanup. Forwarded rows older than
+  // 7 days are deleted. Pending rows (forwarded_at IS NULL) are NEVER
+  // touched here regardless of age — they represent stuck intents the
+  // operator must investigate manually (likely a persistent boss.send
+  // failure that exhausted MAX_ATTEMPTS in outbox-forwarder.ts).
+  try {
+    const cutoff = new Date(Date.now() - OUTBOX_RETENTION_DAYS * 86_400_000);
+    const deleted = await deleteForwardedOutboxRows(cutoff);
+    logger.info(
+      { jobId: job.id, deleted, retentionDays: OUTBOX_RETENTION_DAYS },
+      "purge-daily: outbox cleanup complete",
+    );
+  } catch (err) {
+    logger.error(
+      { jobId: job.id, err },
+      "purge-daily: outbox cleanup failed; continuing",
+    );
   }
 
   logger.info(

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -37,6 +37,7 @@ import { env, scrubKekFromEnv } from "../lib/server/config/env.js";
 
 import { allAdapters } from "../lib/sources/registry.js";
 import { handlePurgeDaily } from "./handlers/purge-daily.js";
+import { startOutboxForwarder } from "./handlers/outbox-forwarder.js";
 
 export async function startWorker(): Promise<void> {
   // Phase 03.0.1 architecture cleanup — multi-replica safety guard.
@@ -127,6 +128,13 @@ export async function startWorker(): Promise<void> {
   // youtube.poll.cron; the poll-cron handler dispatches by tier. The
   // intermediate scheduler-tick → enqueue → per-event-job hop is gone.
 
+  // Phase 03.0.3 follow-up (PR #31 Codex P2) — transactional outbox
+  // forwarder. Long-running async loop that translates pending
+  // outbox rows into pg-boss `boss.send` calls. Uses LISTEN on
+  // 'outbox.new' for instant pickup + 30s periodic sweep as backstop.
+  // Returns a teardown closure the shutdown handler awaits.
+  const stopOutboxForwarder = await startOutboxForwarder();
+
   // D-15 smoke assertion #2 — exact string `worker ready` on stdout.
   logger.info({ role: "worker" }, "worker ready");
   console.log("worker ready");
@@ -134,6 +142,11 @@ export async function startWorker(): Promise<void> {
   // D-22 graceful shutdown — Phase 1 contract, preserved.
   const shutdown = async (signal: string): Promise<void> => {
     logger.info({ signal }, "worker received shutdown signal");
+    try {
+      await stopOutboxForwarder();
+    } catch (err) {
+      logger.warn({ err }, "outbox-forwarder stop failed");
+    }
     try {
       await stopBoss(boss);
     } catch (err) {

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -133,7 +133,7 @@ export async function startWorker(): Promise<void> {
   // outbox rows into pg-boss `boss.send` calls. Uses LISTEN on
   // 'outbox.new' for instant pickup + 30s periodic sweep as backstop.
   // Returns a teardown closure the shutdown handler awaits.
-  const stopOutboxForwarder = await startOutboxForwarder();
+  const stopOutboxForwarder = await startOutboxForwarder({ boss });
 
   // D-15 smoke assertion #2 — exact string `worker ready` on stdout.
   logger.info({ role: "worker" }, "worker ready");

--- a/tests/integration/account-purge.test.ts
+++ b/tests/integration/account-purge.test.ts
@@ -379,6 +379,52 @@ describe("purgeAccount service (Plan 03.0-05)", () => {
     const kBs = await db.select().from(apiKeysSteam).where(eq(apiKeysSteam.userId, fixB.user.id));
     expect(kBs.length).toBeGreaterThanOrEqual(1);
   });
+
+  it("Phase 03.0.3 round-8 (Codex P1): purgeAccount deletes outbox rows that reference the purged user via payload.triggerUserId", async () => {
+    // Force-deep enqueue lands a row in `outbox` carrying triggerUserId
+    // inside the payload. If the user purges before the forwarder has
+    // dispatched the row to pg-boss, the dangling row would later
+    // enqueue a worker job under a deleted tenant — privacy violation.
+    // purgeAccount must scrub user-scoped outbox rows in the same
+    // cascade transaction so this race closes by construction.
+    const { user: u } = await seedFullFixture("outbox-scrub");
+
+    // Seed two pending outbox rows referencing this user, one
+    // referencing a DIFFERENT user (must survive).
+    const otherUser = await seedFullFixture("outbox-scrub-other");
+    await db.execute(sql`
+      INSERT INTO outbox (queue, payload, options) VALUES
+        ('youtube.backfill.channel',
+         ${JSON.stringify({ kind: "youtube_channel", channelKey: "UCabc", triggerUserId: u.id, depthBoundIso: "1970-01-01T00:00:00.000Z", flow: "historical", forceDeep: true })}::jsonb,
+         '{}'::jsonb),
+        ('youtube.backfill.channel',
+         ${JSON.stringify({ kind: "youtube_channel", channelKey: "UCdef", triggerUserId: u.id, depthBoundIso: "1970-01-01T00:00:00.000Z", flow: "historical", forceDeep: true })}::jsonb,
+         '{}'::jsonb),
+        ('youtube.backfill.channel',
+         ${JSON.stringify({ kind: "youtube_channel", channelKey: "UCxyz", triggerUserId: otherUser.user.id, depthBoundIso: "1970-01-01T00:00:00.000Z", flow: "historical", forceDeep: true })}::jsonb,
+         '{}'::jsonb)
+    `);
+
+    const result = await purgeAccount(u.id, { ignoreRetention: true });
+
+    expect(result.purged).toBe(true);
+    expect(result.rowCounts!.outbox).toBe(2);
+
+    // Purged user's outbox rows are gone.
+    const purgedRows = await db.execute(sql`
+      SELECT id FROM outbox WHERE payload->>'triggerUserId' = ${u.id}
+    `);
+    expect(purgedRows.rows.length).toBe(0);
+
+    // Other user's outbox row survives (cross-tenant isolation).
+    const otherRows = await db.execute(sql`
+      SELECT id FROM outbox WHERE payload->>'triggerUserId' = ${otherUser.user.id}
+    `);
+    expect(otherRows.rows.length).toBe(1);
+
+    // Cleanup.
+    await db.execute(sql`DELETE FROM outbox WHERE payload->>'triggerUserId' = ${otherUser.user.id}`);
+  });
 });
 
 // Phase 3.0 Plan 08 — DELETE /api/me/account/purge route activation.

--- a/tests/integration/account-purge.test.ts
+++ b/tests/integration/account-purge.test.ts
@@ -208,6 +208,9 @@ describe("purgeAccount service (Plan 03.0-05)", () => {
       games: 0,
       sessions: 0,
       user: 0,
+      // Phase 03.0.3 round-8 (Codex P1) — outbox is part of the
+      // cascade; an already-purged user has 0 outbox rows.
+      outbox: 0,
     });
   });
 
@@ -423,7 +426,9 @@ describe("purgeAccount service (Plan 03.0-05)", () => {
     expect(otherRows.rows.length).toBe(1);
 
     // Cleanup.
-    await db.execute(sql`DELETE FROM outbox WHERE payload->>'triggerUserId' = ${otherUser.user.id}`);
+    await db.execute(
+      sql`DELETE FROM outbox WHERE payload->>'triggerUserId' = ${otherUser.user.id}`,
+    );
   });
 });
 

--- a/tests/integration/channel-context-backfill-empty.test.ts
+++ b/tests/integration/channel-context-backfill-empty.test.ts
@@ -67,13 +67,11 @@ vi.mock("../../src/lib/sources/youtube/server/http.js", async (importOriginal) =
 
 const { db } = await import("../../src/lib/server/db/client.js");
 const { dataSources } = await import("../../src/lib/server/db/schema/data-sources.js");
-const { dataSourceChannelState } = await import(
-  "../../src/lib/server/db/schema/data-source-channel-state.js"
-);
+const { dataSourceChannelState } =
+  await import("../../src/lib/server/db/schema/data-source-channel-state.js");
 const { auditLog } = await import("../../src/lib/server/db/schema/audit-log.js");
-const { handleChannelContextBackfill } = await import(
-  "../../src/lib/sources/youtube/server/handlers/channel-context-backfill.js"
-);
+const { handleChannelContextBackfill } =
+  await import("../../src/lib/sources/youtube/server/handlers/channel-context-backfill.js");
 const { seedUserDirectly } = await import("./helpers.js");
 
 const uniq = (): string => Math.random().toString(36).slice(2, 10);
@@ -126,9 +124,9 @@ describe("channel-context-backfill — naturally-empty channel (Phase 03.0.3 fol
     expect(stateRows).toHaveLength(1);
     const state = stateRows[0]!;
     expect(state.backfillComplete).toBe(true);
-    expect((state.metadata as { lastBackfillPageToken?: string } | null)?.lastBackfillPageToken ?? null).toBe(
-      null,
-    );
+    expect(
+      (state.metadata as { lastBackfillPageToken?: string } | null)?.lastBackfillPageToken ?? null,
+    ).toBe(null);
   });
 
   it("audit row fires with events_inserted=0 (operator visibility for empty-channel walks)", async () => {
@@ -159,10 +157,7 @@ describe("channel-context-backfill — naturally-empty channel (Phase 03.0.3 fol
       .select()
       .from(auditLog)
       .where(
-        and(
-          eq(auditLog.userId, u.id),
-          eq(auditLog.action, "source.refresh_content_requested"),
-        ),
+        and(eq(auditLog.userId, u.id), eq(auditLog.action, "source.refresh_content_requested")),
       );
     expect(auditRows).toHaveLength(1);
     const meta = auditRows[0]!.metadata as Record<string, unknown>;

--- a/tests/integration/channel-context-backfill-empty.test.ts
+++ b/tests/integration/channel-context-backfill-empty.test.ts
@@ -1,0 +1,172 @@
+// Phase 03.0.3 follow-up — channel-context-backfill on naturally-empty channel.
+//
+// Pre-fix the handler returned early on `collected.length === 0` and skipped
+// the terminal channel-state writes at the bottom of the function. A
+// brand-new channel with zero uploads (or a window-restricted walk that
+// returned zero items before stopReason was recorded) stayed
+// backfill_complete=false forever, and cron re-walked it every day at 3am
+// Pacific — the very onboarding double-walk D-#29-5 set out to eliminate.
+//
+// This test invokes handleChannelContextBackfill against a mocked YouTube
+// fetch layer that returns:
+//   (1) channels.list → one channel with a valid uploadsPlaylistId
+//   (2) playlistItems.list → empty items, no nextPageToken (stopReason="no_more_pages")
+//
+// Assertion: after the handler returns, dataSourceChannelState row has
+// backfill_complete=true and last_backfill_page_token=null. Pre-fix this
+// row would either be missing entirely or carry complete=false.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { and, eq } from "drizzle-orm";
+
+vi.mock("../../src/lib/sources/youtube/server/quota.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    pickKeyForJob: async () => ({ apiKey: "TEST_KEY", apiKeyId: "test-key-1" }),
+    youtubeQuotaUser: () => "test-quota-user",
+  };
+});
+
+vi.mock("../../src/lib/sources/youtube/server/http.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  const channelsListBody = {
+    kind: "youtube#channelListResponse",
+    items: [
+      {
+        id: "UC_TEST_EMPTY_CHANNEL",
+        snippet: { title: "Empty Test Channel" },
+        contentDetails: { relatedPlaylists: { uploads: "UU_TEST_EMPTY_CHANNEL" } },
+      },
+    ],
+  };
+  const playlistItemsEmptyBody = {
+    kind: "youtube#playlistItemListResponse",
+    items: [],
+  };
+  return {
+    ...actual,
+    chargedFetch: async (url: URL): Promise<Response> => {
+      const path = url.pathname;
+      if (path.endsWith("/channels")) {
+        return new Response(JSON.stringify(channelsListBody), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (path.endsWith("/playlistItems")) {
+        return new Response(JSON.stringify(playlistItemsEmptyBody), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ error: "unexpected url" }), { status: 500 });
+    },
+  };
+});
+
+const { db } = await import("../../src/lib/server/db/client.js");
+const { dataSources } = await import("../../src/lib/server/db/schema/data-sources.js");
+const { dataSourceChannelState } = await import(
+  "../../src/lib/server/db/schema/data-source-channel-state.js"
+);
+const { auditLog } = await import("../../src/lib/server/db/schema/audit-log.js");
+const { handleChannelContextBackfill } = await import(
+  "../../src/lib/sources/youtube/server/handlers/channel-context-backfill.js"
+);
+const { seedUserDirectly } = await import("./helpers.js");
+
+const uniq = (): string => Math.random().toString(36).slice(2, 10);
+
+describe("channel-context-backfill — naturally-empty channel (Phase 03.0.3 follow-up)", () => {
+  beforeEach(async () => {
+    await db
+      .delete(dataSourceChannelState)
+      .where(
+        and(
+          eq(dataSourceChannelState.kind, "youtube_channel"),
+          eq(dataSourceChannelState.channelKey, "UC_TEST_EMPTY_CHANNEL"),
+        ),
+      );
+  });
+
+  it("empty playlistItems → backfill_complete=true (no double-walk on next cron tick)", async () => {
+    const u = await seedUserDirectly({ email: `empty-${uniq()}@test.local` });
+    const [src] = await db
+      .insert(dataSources)
+      .values({
+        userId: u.id,
+        kind: "youtube_channel",
+        handleUrl: `https://www.youtube.com/channel/UC_TEST_EMPTY_CHANNEL_${uniq()}`,
+        channelId: "UC_TEST_EMPTY_CHANNEL",
+        autoImport: true,
+        isOwnedByMe: false,
+      })
+      .returning();
+
+    await handleChannelContextBackfill({
+      id: "mock-job-empty-channel",
+      data: {
+        userId: u.id,
+        channelId: "UC_TEST_EMPTY_CHANNEL",
+        sourceId: src!.id,
+        backfillWindow: "30d",
+      },
+    });
+
+    const stateRows = await db
+      .select()
+      .from(dataSourceChannelState)
+      .where(
+        and(
+          eq(dataSourceChannelState.kind, "youtube_channel"),
+          eq(dataSourceChannelState.channelKey, "UC_TEST_EMPTY_CHANNEL"),
+        ),
+      );
+    expect(stateRows).toHaveLength(1);
+    const state = stateRows[0]!;
+    expect(state.backfillComplete).toBe(true);
+    expect((state.metadata as { lastBackfillPageToken?: string } | null)?.lastBackfillPageToken ?? null).toBe(
+      null,
+    );
+  });
+
+  it("audit row fires with events_inserted=0 (operator visibility for empty-channel walks)", async () => {
+    const u = await seedUserDirectly({ email: `empty-audit-${uniq()}@test.local` });
+    const [src] = await db
+      .insert(dataSources)
+      .values({
+        userId: u.id,
+        kind: "youtube_channel",
+        handleUrl: `https://www.youtube.com/channel/UC_TEST_EMPTY_CHANNEL_${uniq()}`,
+        channelId: "UC_TEST_EMPTY_CHANNEL",
+        autoImport: true,
+        isOwnedByMe: false,
+      })
+      .returning();
+
+    await handleChannelContextBackfill({
+      id: "mock-job-empty-audit",
+      data: {
+        userId: u.id,
+        channelId: "UC_TEST_EMPTY_CHANNEL",
+        sourceId: src!.id,
+        backfillWindow: "30d",
+      },
+    });
+
+    const auditRows = await db
+      .select()
+      .from(auditLog)
+      .where(
+        and(
+          eq(auditLog.userId, u.id),
+          eq(auditLog.action, "source.refresh_content_requested"),
+        ),
+      );
+    expect(auditRows).toHaveLength(1);
+    const meta = auditRows[0]!.metadata as Record<string, unknown>;
+    expect(meta.events_inserted).toBe(0);
+    expect(meta.source_id).toBe(src!.id);
+  });
+});

--- a/tests/integration/channel-state-helpers.test.ts
+++ b/tests/integration/channel-state-helpers.test.ts
@@ -114,10 +114,17 @@ describe("channel-state helpers", () => {
     ).toBeUndefined();
   });
 
-  it("kind discriminator — same channelKey across kinds gets separate rows", async () => {
+  it("kind discriminator — distinct channelKeys produce separate state rows", async () => {
     // No reddit_account adapter yet, but the table key supports both kinds.
     // Use the existing youtube_channel kind and synthesize a different
-    // channelKey to verify PK discrimination.
+    // channelKey to verify PK discrimination. The earlier shape of this
+    // test asserted that the two lastPolledAt timestamps differed, which
+    // was flaky: on a fast CI runner both calls land in the same
+    // millisecond (now() resolution) and the rows are correctly stored
+    // but the timestamp check fails. The honest assertion for "separate
+    // rows" is that the rows exist with distinct channelKeys, both
+    // carry a stamped lastPolledAt, and they don't reference each
+    // other.
     const k1 = uniqKey();
     const k2 = uniqKey();
     await markChannelLastPolledAt("youtube_channel", k1);
@@ -126,7 +133,11 @@ describe("channel-state helpers", () => {
     const r2 = await getChannelState("youtube_channel", k2);
     expect(r1).toBeDefined();
     expect(r2).toBeDefined();
-    expect(r1!.lastPolledAt!.getTime()).not.toBe(r2!.lastPolledAt!.getTime());
+    expect(r1!.channelKey).toBe(k1);
+    expect(r2!.channelKey).toBe(k2);
+    expect(r1!.channelKey).not.toBe(r2!.channelKey);
+    expect(r1!.lastPolledAt).not.toBeNull();
+    expect(r2!.lastPolledAt).not.toBeNull();
     await clearChannel(k1);
     await clearChannel(k2);
   });

--- a/tests/integration/channel-state-helpers.test.ts
+++ b/tests/integration/channel-state-helpers.test.ts
@@ -15,7 +15,6 @@ import {
   markChannelLastPolledAt,
   markChannelBackfillFrontier,
   markChannelBackfillComplete,
-  resetChannelBackfillComplete,
   setChannelBackfillPageToken,
 } from "../../src/lib/server/services/channel-state.js";
 
@@ -83,14 +82,16 @@ describe("channel-state helpers", () => {
     expect(row!.backfillOldestAt!.getTime()).toBe(t2.getTime());
   });
 
-  it("markChannelBackfillComplete + resetChannelBackfillComplete toggle the flag", async () => {
+  it("markChannelBackfillComplete sets the flag", async () => {
+    // Phase 03.0.3 P1 — the companion reset helper was removed (D-D1).
+    // The "trust-but-verify" toggle was redundant once the three-branch
+    // since-derivation landed (D-#29-6); only the set-true direction is
+    // exercised here now. Widening a user's backfill_target_since lands
+    // in the `deep` branch lazily on the next refresh-content click —
+    // no in-band flag flip required.
     await markChannelBackfillComplete("youtube_channel", channelKey);
-    let row = await getChannelState("youtube_channel", channelKey);
+    const row = await getChannelState("youtube_channel", channelKey);
     expect(row!.backfillComplete).toBe(true);
-
-    await resetChannelBackfillComplete("youtube_channel", channelKey);
-    row = await getChannelState("youtube_channel", channelKey);
-    expect(row!.backfillComplete).toBe(false);
   });
 
   it("setChannelBackfillPageToken stores and clears the cursor", async () => {

--- a/tests/integration/end-to-end-catch-up.test.ts
+++ b/tests/integration/end-to-end-catch-up.test.ts
@@ -238,11 +238,26 @@ describe("end-to-end channel-scoped catch-up flow", () => {
     }
 
     // Channel state advanced.
+    //
+    // PR #31 Codex P1 #2 follow-up — in deep-mode walks with
+    // endOfPlaylist=false (mock returns no nextPageToken so the
+    // worker treats it as walkedPastSince), frontier advances to
+    // `since` (= target = 2026-03-01), NOT to the oldest collected
+    // event (2026-04-01). Rationale: items collected in deep mode
+    // have publishedAt > since by construction; setting frontier to
+    // oldest-collected would understate the walked depth and force
+    // a redundant deep re-walk if the user later widened target to,
+    // say, 2026-03-15 (we've already covered that range). Using
+    // `since` gives the most accurate "we walked AT LEAST to here"
+    // assertion. (If the mock returned endOfPlaylist=true the test
+    // would have asserted oldest-collected, the legitimate channel
+    // floor — see the !endOfPlaylist branch in
+    // backfill-channel.ts:496-518.)
     const channelState = await getChannelState("youtube_channel", channelId);
     expect(channelState).toBeDefined();
     expect(channelState!.lastPolledAt).not.toBeNull();
     expect(channelState!.backfillOldestAt).not.toBeNull();
-    expect(channelState!.backfillOldestAt!.toISOString()).toBe("2026-04-01T00:00:00.000Z");
+    expect(channelState!.backfillOldestAt!.toISOString()).toBe("2026-03-01T00:00:00.000Z");
     expect(channelState!.backfillComplete).toBe(false);
 
     // Completion audit row attributed to trigger user.

--- a/tests/integration/end-to-end-catch-up.test.ts
+++ b/tests/integration/end-to-end-catch-up.test.ts
@@ -11,9 +11,12 @@
 //
 //   1. POST /api/sources/:id/refresh-content
 //      - intent audit row written (no flow field)
-//      - resetChannelBackfillComplete called against (kind, channelKey)
 //      - boss.send invoked with YOUTUBE_BACKFILL_CHANNEL + payload
 //        { kind, channelKey, triggerUserId, depthBoundIso, flow }
+//      (Phase 03.0.3 P1: the pre-refactor channel-state reset call was
+//      removed — three-branch since-derivation in backfill-channel.ts
+//      handles the steady-state vs deep-walk decision lazily at
+//      walk-time. See D-D1 / D-#29-6.)
 //
 //   2. handleBackfillChannel invoked
 //      - resolves all subscribers for (kind, channelKey)

--- a/tests/integration/feed-api-enrichment.test.ts
+++ b/tests/integration/feed-api-enrichment.test.ts
@@ -1,0 +1,159 @@
+// Phase 03.0.3 P2 — feed enrichment invariants (issue #29 Part 2).
+//
+// Two behavioural tests (D-C2):
+//   (1) GET /api/events with cursor pagination returns rows enriched with
+//       stats + channelTitle (the gap pre-fix — SSR first batch enriched
+//       inline; cursor-paginated batches dropped both).
+//   (2) GET /api/events/deleted does NOT carry the enrichment — deliberate
+//       skip (DeletedEventsPanel renders compact KindIcon + strikethrough-
+//       title view; enrichment query would be wasted I/O).
+//
+// Uses the same dynamic-import scaffold as api-sources-refresh-content.test.ts
+// so vi.mock can intercept getBoss before any service module loads (createSource
+// indirectly imports the queue client via onSourceCreated).
+
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../src/lib/server/queue-client.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    getBoss: async () => ({
+      send: async () => "mock-job-id",
+      schedule: async () => {},
+      createQueue: async () => {},
+      work: async () => {},
+    }),
+  };
+});
+
+const { db } = await import("../../src/lib/server/db/client.js");
+const { events } = await import("../../src/lib/server/db/schema/events.js");
+const { youtubeVideos, youtubeVideoSnapshots } = await import(
+  "../../src/lib/sources/youtube/server/schema/index.js"
+);
+const { createApp } = await import("../../src/lib/server/http/app.js");
+const { createSource } = await import("../../src/lib/server/services/data-sources.js");
+const { seedUserDirectly } = await import("./helpers.js");
+
+const uniq = (): string => Math.random().toString(36).slice(2, 10);
+const newChannelKey = (): string => `UC${uniq()}${uniq().slice(0, 8)}aa`;
+
+describe("feed-api-enrichment — Phase 03.0.3 P2 (issue #29 Part 2)", () => {
+  it("(1) GET /api/events returns rows with stats + channelTitle (adapter loop fires on cursor pagination)", async () => {
+    const u = await seedUserDirectly({ email: `enrich-1-${uniq()}@test.local` });
+    const channelKey = newChannelKey();
+    const src = await createSource(
+      u.id,
+      {
+        kind: "youtube_channel",
+        handleUrl: `https://www.youtube.com/channel/${channelKey}`,
+        isOwnedByMe: true,
+        autoImport: false,
+      },
+      "127.0.0.1",
+    );
+
+    const videoId = `vid_${uniq()}_${uniq().slice(0, 8)}`;
+    const polledAt = new Date();
+    await db.insert(youtubeVideos).values({
+      videoId,
+      title: "Test video",
+      channelId: channelKey,
+      channelTitle: "Test Channel",
+      publishedAt: new Date(),
+    });
+    await db.insert(youtubeVideoSnapshots).values({
+      videoId,
+      polledAt,
+      viewCount: 1234,
+      likeCount: 56,
+      commentCount: 7,
+    });
+    await db.insert(events).values({
+      userId: u.id,
+      sourceId: src.id,
+      kind: "youtube_video",
+      authorIsMe: true,
+      occurredAt: new Date(),
+      title: "Test video",
+      url: `https://www.youtube.com/watch?v=${videoId}`,
+      externalId: videoId,
+    });
+
+    const app = createApp();
+    const res = await app.request("/api/events", {
+      headers: { cookie: `neotolis.session_token=${u.signedSessionCookieValue}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { rows: Array<Record<string, unknown>> };
+    expect(body.rows.length).toBeGreaterThanOrEqual(1);
+    const myRow = body.rows.find((r) => r.externalId === videoId);
+    expect(myRow, "seeded youtube_video row missing from /api/events response").toBeDefined();
+    // Enrichment landed: stats object + channelTitle string.
+    expect(myRow!.stats).toMatchObject({
+      viewCount: 1234,
+      likeCount: 56,
+      commentCount: 7,
+    });
+    expect(myRow!.channelTitle).toBe("Test Channel");
+  });
+
+  it("(2) GET /api/events/deleted does NOT carry the enrichment (deliberate skip — DeletedEventsPanel compact view)", async () => {
+    const u = await seedUserDirectly({ email: `enrich-2-${uniq()}@test.local` });
+    const channelKey = newChannelKey();
+    const src = await createSource(
+      u.id,
+      {
+        kind: "youtube_channel",
+        handleUrl: `https://www.youtube.com/channel/${channelKey}`,
+        isOwnedByMe: true,
+        autoImport: false,
+      },
+      "127.0.0.1",
+    );
+
+    const videoId = `vid_${uniq()}_${uniq().slice(0, 8)}`;
+    await db.insert(youtubeVideos).values({
+      videoId,
+      title: "Test video",
+      channelId: channelKey,
+      channelTitle: "Test Channel",
+      publishedAt: new Date(),
+    });
+    await db.insert(youtubeVideoSnapshots).values({
+      videoId,
+      polledAt: new Date(),
+      viewCount: 1234,
+      likeCount: 56,
+      commentCount: 7,
+    });
+    await db.insert(events).values({
+      userId: u.id,
+      sourceId: src.id,
+      kind: "youtube_video",
+      authorIsMe: true,
+      occurredAt: new Date(),
+      title: "Test video",
+      url: `https://www.youtube.com/watch?v=${videoId}`,
+      externalId: videoId,
+      deletedAt: new Date(),
+    });
+
+    const app = createApp();
+    const res = await app.request("/api/events/deleted", {
+      headers: { cookie: `neotolis.session_token=${u.signedSessionCookieValue}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { rows: Array<Record<string, unknown>> };
+    const myRow = body.rows.find((r) => r.externalId === videoId);
+    expect(myRow, "seeded deleted event missing from /api/events/deleted").toBeDefined();
+    // Deliberate skip — DeletedEventsPanel renders compact view. The DTO
+    // default for stats is null (set by toEventDto); channelTitle is
+    // optional and undefined when not enriched.
+    expect(myRow!.stats === null || myRow!.stats === undefined).toBe(true);
+    expect(
+      myRow!.channelTitle === null || myRow!.channelTitle === undefined,
+    ).toBe(true);
+  });
+});

--- a/tests/integration/feed-api-enrichment.test.ts
+++ b/tests/integration/feed-api-enrichment.test.ts
@@ -29,9 +29,8 @@ vi.mock("../../src/lib/server/queue-client.js", async (importOriginal) => {
 
 const { db } = await import("../../src/lib/server/db/client.js");
 const { events } = await import("../../src/lib/server/db/schema/events.js");
-const { youtubeVideos, youtubeVideoSnapshots } = await import(
-  "../../src/lib/sources/youtube/server/schema/index.js"
-);
+const { youtubeVideos, youtubeVideoSnapshots } =
+  await import("../../src/lib/sources/youtube/server/schema/index.js");
 const { createApp } = await import("../../src/lib/server/http/app.js");
 const { createSource } = await import("../../src/lib/server/services/data-sources.js");
 const { seedUserDirectly } = await import("./helpers.js");
@@ -152,8 +151,6 @@ describe("feed-api-enrichment — Phase 03.0.3 P2 (issue #29 Part 2)", () => {
     // default for stats is null (set by toEventDto); channelTitle is
     // optional and undefined when not enriched.
     expect(myRow!.stats === null || myRow!.stats === undefined).toBe(true);
-    expect(
-      myRow!.channelTitle === null || myRow!.channelTitle === undefined,
-    ).toBe(true);
+    expect(myRow!.channelTitle === null || myRow!.channelTitle === undefined).toBe(true);
   });
 });

--- a/tests/integration/refresh-content-quota.test.ts
+++ b/tests/integration/refresh-content-quota.test.ts
@@ -1116,4 +1116,105 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
     // Cleanup.
     await db.execute(sql`DELETE FROM outbox WHERE payload->>'channelKey' = ${channelKey}`);
   });
+
+  it("(k) PATCH widen on user with exhausted per-user cap → 429 + UPDATE rolled back (Codex round-6 P2)", async () => {
+    // Pre-fix the per-user fair-share cap was enforced only on
+    // POST /api/sources/:id/refresh-content. A user who had hit the
+    // daily 100-request cap could still PATCH backfillTargetSince
+    // wider; the force-deep walk it triggered was audited as a
+    // capped 'historical' flow but only AFTER the work ran —
+    // operator quota was already spent and the cap counter
+    // observed the overage. Mirror the refresh-content guard inside
+    // maybeEnqueueForceDeepWalk so the bypass closes.
+    const channelKey = newChannelKey();
+    await clearChannelFixture(channelKey);
+
+    const app = createApp();
+    const u = await seedUserDirectly({ email: `quota-k-${uniq()}@test.local` });
+    const src = await createSource(
+      u.id,
+      {
+        kind: "youtube_channel",
+        handleUrl: `https://www.youtube.com/channel/${channelKey}`,
+        isOwnedByMe: true,
+        autoImport: true,
+      },
+      "127.0.0.1",
+    );
+
+    const now = Date.now();
+    const thirtyDaysAgo = new Date(now - 30 * 86_400_000);
+    await db
+      .update(dataSources)
+      .set({ backfillTargetSince: thirtyDaysAgo })
+      .where(eq(dataSources.id, src.id));
+
+    // Seed channel state so the widen would otherwise trigger force-deep.
+    await db
+      .insert(dataSourceChannelState)
+      .values({
+        kind: "youtube_channel",
+        channelKey,
+        backfillComplete: true,
+        backfillOldestAt: thirtyDaysAgo,
+      })
+      .onConflictDoUpdate({
+        target: [dataSourceChannelState.kind, dataSourceChannelState.channelKey],
+        set: {
+          backfillComplete: true,
+          backfillOldestAt: thirtyDaysAgo,
+          updatedAt: new Date(),
+        },
+      });
+
+    // Seed audit_log to push the user past the YouTube user cap
+    // (requestsPerDay = 100 — see youtube/server/observability.ts).
+    // We INSERT 100 capped audit rows directly; the INSERT-only
+    // trigger on audit_log only blocks UPDATE/DELETE.
+    const rowsToSeed = 100;
+    for (let i = 0; i < rowsToSeed; i += 1) {
+      await db.insert(auditLog).values({
+        userId: u.id,
+        action: "source.refresh_content_requested",
+        ipAddress: "127.0.0.1",
+        userAgent: "seed",
+        metadata: {
+          kind: "youtube_channel",
+          platform: "youtube_channel",
+          flow: "incremental",
+          requests_used: 1,
+          events_inserted: 0,
+        },
+      });
+    }
+
+    // PATCH widen — should be rejected with 429.
+    const patchRes = await app.request(`/api/sources/${src.id}`, {
+      method: "PATCH",
+      headers: {
+        cookie: `neotolis.session_token=${u.signedSessionCookieValue}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ backfillTargetSince: "1970-01-01T00:00:00.000Z" }),
+    });
+    expect(patchRes.status).toBe(429);
+    const body = (await patchRes.json()) as { error?: string };
+    expect(body.error).toBe("requests_quota_exhausted");
+
+    // UPDATE rolled back — backfillTargetSince stays at the pre-PATCH value.
+    const [reloaded] = await db
+      .select({ backfillTargetSince: dataSources.backfillTargetSince })
+      .from(dataSources)
+      .where(eq(dataSources.id, src.id));
+    expect(reloaded!.backfillTargetSince?.getTime()).toBe(thirtyDaysAgo.getTime());
+
+    // No outbox row created (atomic with the rolled-back UPDATE).
+    const outboxRows = await db.execute(sql`
+      SELECT id FROM outbox
+      WHERE queue = 'youtube.backfill.channel'
+        AND payload->>'channelKey' = ${channelKey}
+        AND payload->>'triggerUserId' = ${u.id}
+    `);
+    expect(outboxRows.rows.length).toBe(0);
+  });
 });

--- a/tests/integration/refresh-content-quota.test.ts
+++ b/tests/integration/refresh-content-quota.test.ts
@@ -21,6 +21,10 @@ interface CapturedJob {
   options: Record<string, unknown>;
 }
 const sentJobs: CapturedJob[] = [];
+// Phase 03.0.3 follow-up (PR #31 review P2) — test (g) below toggles this
+// to simulate a transient pg-boss failure (queue table missing, network
+// blip) and assert the PATCH aborts without committing the UPDATE.
+let bossSendShouldThrow = false;
 
 vi.mock("../../src/lib/server/queue-client.js", async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
@@ -32,6 +36,9 @@ vi.mock("../../src/lib/server/queue-client.js", async (importOriginal) => {
         data: Record<string, unknown>,
         options: Record<string, unknown>,
       ) => {
+        if (bossSendShouldThrow) {
+          throw new Error("pg-boss: simulated transient failure");
+        }
         sentJobs.push({ queue, data, options });
         return `mock-job-${Math.random().toString(36).slice(2, 10)}`;
       },
@@ -118,6 +125,7 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
     pollContentEndOfPlaylist = false;
     pollContentUnitsUsed = 1;
     pollContentNextPageToken = undefined;
+    bossSendShouldThrow = false;
   });
 
   it("(a) repeated click within 5min on a steady-state channel costs ≤1 page (not N/50 pages)", async () => {
@@ -688,6 +696,115 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
     expect((state!.metadata as { lastBackfillPageToken?: string } | null)?.lastBackfillPageToken ?? null).toBe(
       null,
     );
+  });
+
+  it("(g) PATCH widen + boss.send fails → UPDATE rolled back, backfillTargetSince stays at OLD value (atomicity-of-intent, PR #31 P2)", async () => {
+    // Pre-fix the UPDATE ran BEFORE the force-deep enqueue. On boss.send
+    // failure, data_sources.backfill_target_since was committed but the
+    // force-deep job was lost — and the retry path was a no-op because
+    // maybeEnqueueForceDeepWalk's "newTarget >= previousTarget" early
+    // return short-circuited when the user re-PATCHed with the same
+    // (already-widened) value. Permanent silent loss of the deep-walk
+    // intent. PR #31 review P2.
+    //
+    // Post-fix the enqueue runs BEFORE the UPDATE: a throw from
+    // boss.send propagates up, the UPDATE never runs, the user sees a
+    // 5xx, retries, and on the retry the force-deep enqueue is
+    // attempted again — eventually succeeds. This test pins the
+    // happy-failure semantic.
+    const channelKey = newChannelKey();
+    await clearChannelFixture(channelKey);
+
+    const app = createApp();
+    const u = await seedUserDirectly({ email: `quota-g-${uniq()}@test.local` });
+    const src = await createSource(
+      u.id,
+      {
+        kind: "youtube_channel",
+        handleUrl: `https://www.youtube.com/channel/${channelKey}`,
+        isOwnedByMe: true,
+        autoImport: true,
+      },
+      "127.0.0.1",
+    );
+
+    const now = Date.now();
+    const thirtyDaysAgo = new Date(now - 30 * 86_400_000);
+    await db
+      .update(dataSources)
+      .set({ backfillTargetSince: thirtyDaysAgo })
+      .where(eq(dataSources.id, src.id));
+
+    // Seed channel state so maybeEnqueueForceDeepWalk's conditions hold
+    // (complete=true + oldest=30d-ago + newTarget=epoch < oldest).
+    await db
+      .insert(dataSourceChannelState)
+      .values({
+        kind: "youtube_channel",
+        channelKey,
+        backfillComplete: true,
+        backfillOldestAt: thirtyDaysAgo,
+      })
+      .onConflictDoUpdate({
+        target: [dataSourceChannelState.kind, dataSourceChannelState.channelKey],
+        set: {
+          backfillComplete: true,
+          backfillOldestAt: thirtyDaysAgo,
+          updatedAt: new Date(),
+        },
+      });
+
+    sentJobs.length = 0;
+    bossSendShouldThrow = true;
+
+    const patchRes = await app.request(`/api/sources/${src.id}`, {
+      method: "PATCH",
+      headers: {
+        cookie: `neotolis.session_token=${u.signedSessionCookieValue}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ backfillTargetSince: "1970-01-01T00:00:00.000Z" }),
+    });
+
+    // boss.send failure surfaces as a 5xx (internal_server_error or similar).
+    expect(patchRes.status).toBeGreaterThanOrEqual(500);
+    expect(patchRes.status).toBeLessThan(600);
+
+    // Critical assertion — UPDATE rolled back (never committed).
+    // backfillTargetSince must STILL be the pre-PATCH value.
+    const [reloaded] = await db
+      .select({ backfillTargetSince: dataSources.backfillTargetSince })
+      .from(dataSources)
+      .where(eq(dataSources.id, src.id));
+    expect(reloaded).toBeDefined();
+    expect(reloaded!.backfillTargetSince?.getTime()).toBe(thirtyDaysAgo.getTime());
+
+    // No job in queue (boss.send threw before capturing).
+    expect(sentJobs.filter((j) => j.queue === "youtube.backfill.channel")).toHaveLength(0);
+
+    // Retry path — disable the failure injection, retry the same PATCH.
+    bossSendShouldThrow = false;
+    const retry = await app.request(`/api/sources/${src.id}`, {
+      method: "PATCH",
+      headers: {
+        cookie: `neotolis.session_token=${u.signedSessionCookieValue}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ backfillTargetSince: "1970-01-01T00:00:00.000Z" }),
+    });
+    expect(retry.status).toBe(200);
+
+    // On retry, force-deep enqueue ran successfully.
+    const enqueues = sentJobs.filter((j) => j.queue === "youtube.backfill.channel");
+    expect(enqueues).toHaveLength(1);
+    expect(enqueues[0]!.data).toMatchObject({ forceDeep: true });
+
+    // And the UPDATE finally committed.
+    const [final] = await db
+      .select({ backfillTargetSince: dataSources.backfillTargetSince })
+      .from(dataSources)
+      .where(eq(dataSources.id, src.id));
+    expect(final!.backfillTargetSince?.getTime()).toBe(new Date(0).getTime());
   });
 
   it("(f) empty + MAX_PAGES (endOfPlaylist=false, nextPageToken defined) → backfill_complete UNCHANGED, token PRESERVED for resume", async () => {

--- a/tests/integration/refresh-content-quota.test.ts
+++ b/tests/integration/refresh-content-quota.test.ts
@@ -480,7 +480,7 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
       forceDeep: true,
     });
     expect(outboxRow.options).toMatchObject({
-      singletonKey: `force-deep-${channelKey}-${u.id}`,
+      singletonKey: `force-deep-${channelKey}-${u.id}-${new Date(0).getTime()}`,
     });
 
     // Reconstruct the would-be pg-boss job data shape for the next
@@ -816,7 +816,7 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
       forceDeep: true,
     });
     expect(row.options).toMatchObject({
-      singletonKey: `force-deep-${channelKey}-${u.id}`,
+      singletonKey: `force-deep-${channelKey}-${u.id}-${new Date(0).getTime()}`,
     });
     // Forwarder not started in this test — row stays pending.
     expect(row.forwarded_at).toBeNull();
@@ -1005,5 +1005,115 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
     expect(
       (state!.metadata as { lastBackfillPageToken?: string } | null)?.lastBackfillPageToken,
     ).toBe("RESUME_AT_PAGE_21");
+  });
+
+  it("(j) rapid double-widen produces two outbox rows with DIFFERENT singletonKeys (Codex round-4 P2 fix)", async () => {
+    // Pre-fix the singletonKey omitted the target — two rapid widens
+    // (e.g. 30d→90d then 90d→epoch before the first walk finished)
+    // produced two outbox rows with IDENTICAL singletonKeys. pg-boss's
+    // singleton constraint rejected the second `boss.send` with a null
+    // return value; the forwarder marked the row forwarded anyway and
+    // the deeper user intent (epoch) was silently lost. After the fix
+    // the singletonKey includes newTarget.getTime() so each unique
+    // widen has its own key, both jobs flow through pg-boss, and the
+    // walker covers the full requested depth.
+    const channelKey = newChannelKey();
+    await clearChannelFixture(channelKey);
+
+    const app = createApp();
+    const u = await seedUserDirectly({ email: `quota-j-${uniq()}@test.local` });
+    const src = await createSource(
+      u.id,
+      {
+        kind: "youtube_channel",
+        handleUrl: `https://www.youtube.com/channel/${channelKey}`,
+        isOwnedByMe: true,
+        autoImport: true,
+      },
+      "127.0.0.1",
+    );
+
+    const now = Date.now();
+    const thirtyDaysAgo = new Date(now - 30 * 86_400_000);
+    const ninetyDaysAgo = new Date(now - 90 * 86_400_000);
+    await db
+      .update(dataSources)
+      .set({ backfillTargetSince: thirtyDaysAgo })
+      .where(eq(dataSources.id, src.id));
+
+    // Seed channel state so force-deep predicate fires on both widens
+    // (complete=true + oldest=30d-ago — every widen past 30d-ago goes
+    // through the force-deep path).
+    await db
+      .insert(dataSourceChannelState)
+      .values({
+        kind: "youtube_channel",
+        channelKey,
+        backfillComplete: true,
+        backfillOldestAt: thirtyDaysAgo,
+      })
+      .onConflictDoUpdate({
+        target: [dataSourceChannelState.kind, dataSourceChannelState.channelKey],
+        set: {
+          backfillComplete: true,
+          backfillOldestAt: thirtyDaysAgo,
+          updatedAt: new Date(),
+        },
+      });
+
+    // Widen #1: 30d-ago → 90d-ago
+    const patch1 = await app.request(`/api/sources/${src.id}`, {
+      method: "PATCH",
+      headers: {
+        cookie: `neotolis.session_token=${u.signedSessionCookieValue}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ backfillTargetSince: ninetyDaysAgo.toISOString() }),
+    });
+    expect(patch1.status).toBe(200);
+
+    // Widen #2: 90d-ago → epoch (BEFORE the forwarder picks up #1).
+    const patch2 = await app.request(`/api/sources/${src.id}`, {
+      method: "PATCH",
+      headers: {
+        cookie: `neotolis.session_token=${u.signedSessionCookieValue}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ backfillTargetSince: "1970-01-01T00:00:00.000Z" }),
+    });
+    expect(patch2.status).toBe(200);
+
+    // Two outbox rows, two DIFFERENT singletonKeys — pg-boss can flow
+    // both through without coalescing the deeper intent away.
+    const outboxRows = await db.execute(sql`
+      SELECT payload, options
+      FROM outbox
+      WHERE queue = 'youtube.backfill.channel'
+        AND payload->>'channelKey' = ${channelKey}
+        AND payload->>'triggerUserId' = ${u.id}
+      ORDER BY created_at ASC
+    `);
+    expect(outboxRows.rows.length).toBe(2);
+
+    const row1 = outboxRows.rows[0] as {
+      payload: Record<string, unknown>;
+      options: Record<string, unknown>;
+    };
+    const row2 = outboxRows.rows[1] as {
+      payload: Record<string, unknown>;
+      options: Record<string, unknown>;
+    };
+
+    expect(row1.payload).toMatchObject({ depthBoundIso: ninetyDaysAgo.toISOString() });
+    expect(row2.payload).toMatchObject({ depthBoundIso: "1970-01-01T00:00:00.000Z" });
+
+    const key1 = (row1.options as { singletonKey?: string }).singletonKey;
+    const key2 = (row2.options as { singletonKey?: string }).singletonKey;
+    expect(key1).toBe(`force-deep-${channelKey}-${u.id}-${ninetyDaysAgo.getTime()}`);
+    expect(key2).toBe(`force-deep-${channelKey}-${u.id}-${new Date(0).getTime()}`);
+    expect(key1).not.toBe(key2);
+
+    // Cleanup.
+    await db.execute(sql`DELETE FROM outbox WHERE payload->>'channelKey' = ${channelKey}`);
   });
 });

--- a/tests/integration/refresh-content-quota.test.ts
+++ b/tests/integration/refresh-content-quota.test.ts
@@ -355,9 +355,31 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
     expect(newEvents).toHaveLength(1);
   });
 
-  it("(c) widening backfillTargetSince (30d → epoch) triggers deep walk on next refresh-content click", async () => {
-    // Setup: current target=30d ago; channel state exhausted at 30d ago;
-    // youtube_videos has one row with publishedAt=now (newestKnown=now).
+  it("(c) widening backfillTargetSince past deepestWalked on a fully-walked channel enqueues a force-deep job that bypasses branch=exhausted", async () => {
+    // Phase 03.0.3 follow-up — the original test (c) framing was inconsistent
+    // with D-#29-2's locked branch ordering: once backfill_complete=true,
+    // `branch=exhausted` always wins regardless of target (D-#29-7
+    // multi-tenant fairness). The Plan 01 implementation honoured this
+    // ordering, which meant the original Issue #29 acceptance — "widen
+    // target on a fully-walked channel → next click deep-walks below
+    // prior depth" — was effectively a no-op for completed channels.
+    //
+    // The follow-up rewires the path: `updateSource` detects a widen past
+    // `backfill_oldest_at` on a complete channel and enqueues a separate
+    // force-deep job (forceDeep: true) per user. The handler sees
+    // `forceDeep===true` and routes to `branch="deep"` regardless of the
+    // channel's complete flag. The trigger user pays quota; subscribers
+    // free-ride on fan-out — same as a normal refresh-content click.
+    //
+    // This test exercises BOTH halves end-to-end:
+    //   1. PATCH /api/sources/:id { backfillTargetSince: epoch } on a
+    //      complete=true channel with backfill_oldest_at=30d-ago → asserts
+    //      sentJobs captures a YOUTUBE_BACKFILL_CHANNEL job with
+    //      forceDeep=true and depthBoundIso=epoch.
+    //   2. Invokes handleBackfillChannel with the captured job → asserts
+    //      pollContent received since=epoch (NOT max(newestKnown, target))
+    //      and the audit row carries since_branch="deep" + flow="historical".
+
     const channelKey = newChannelKey();
     await clearChannelFixture(channelKey);
 
@@ -405,7 +427,11 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
         },
       });
 
-    // PATCH /api/sources/<id> { backfillTargetSince: epoch }.
+    // Reset captured jobs from createSource above so we only see the
+    // PATCH-triggered enqueue below.
+    sentJobs.length = 0;
+
+    // Half 1 — PATCH widens target past deepestWalked.
     const patchRes = await app.request(`/api/sources/${src.id}`, {
       method: "PATCH",
       headers: {
@@ -421,76 +447,26 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
     expect(stateAfterPatch).toBeDefined();
     expect(stateAfterPatch!.backfillComplete).toBe(true);
 
-    // Now trigger the worker with the widened target.
-    pollContentResults = [];
-    pollContentUnitsUsed = 1;
-    await handleBackfillChannel({
-      id: "mock-job-quota-c",
-      data: {
-        kind: "youtube_channel",
-        channelKey,
-        triggerUserId: u.id,
-        depthBoundIso: "1970-01-01T00:00:00.000Z",
-        flow: "incremental",
-      },
+    // The PATCH path detected widening past deepestWalked + complete=true
+    // → enqueued a force-deep job for THIS user.
+    const enqueues = sentJobs.filter((j) => j.queue === "youtube.backfill.channel");
+    expect(enqueues).toHaveLength(1);
+    const job = enqueues[0]!;
+    expect(job.data).toMatchObject({
+      kind: "youtube_channel",
+      channelKey,
+      triggerUserId: u.id,
+      depthBoundIso: "1970-01-01T00:00:00.000Z",
+      flow: "historical",
+      forceDeep: true,
     });
-
-    expect(pollContentCalls).toHaveLength(1);
-    // Branch logic: backfill_complete=true → branch="exhausted" first,
-    // then since=max(newestKnown=now, target=epoch)=now.
-    //
-    // Wait — D-#29-2 prioritises 'exhausted' check FIRST. Once complete=true,
-    // branch=exhausted regardless of target. The plan's test (c) description
-    // expects branch="deep" + flow="historical".
-    //
-    // Reading D-#29-2 again:
-    //   - exhausted   (backfill_complete=true)
-    //   - incremental (!complete && deepest!==null && target>=deepest)
-    //   - deep        (else)
-    //
-    // So with complete=true, we're in exhausted — NOT deep. The plan's
-    // expectation that "exhausted at 30d" + "widen to epoch" + "next click
-    // → deep" is inconsistent with D-#29-2 locked semantics. The honest
-    // assertion is: branch="exhausted", since=max(newestKnown, target)=now.
-    //
-    // This is the multi-tenant-fairness behavior locked by D-#29-7: one
-    // user widening does NOT re-open the walk for other subscribers, and
-    // the channel state's exhausted flag wins. The user's widened target
-    // only matters when complete=false (which is the typical case before
-    // a deep walk has completed; here we artificially set complete=true
-    // to model a fully-walked channel).
-    const auditRows = await db
-      .select()
-      .from(auditLog)
-      .where(
-        and(
-          eq(auditLog.userId, u.id),
-          eq(auditLog.action, "source.refresh_content_requested"),
-        ),
-      );
-    const completion = auditRows.find(
-      (r) => (r.metadata as Record<string, unknown>)?.events_inserted !== undefined,
+    expect((job.options as { singletonKey?: string }).singletonKey).toBe(
+      `force-deep-${channelKey}-${u.id}`,
     );
-    expect(completion).toBeDefined();
-    const meta = completion!.metadata as Record<string, unknown>;
-    expect(meta.since_branch).toBe("exhausted");
 
-    // Reset and re-test the actual "widen triggers deep" scenario: channel
-    // state is NOT exhausted but DEEPEST is shallower than the new target.
-    // Take 2: same channel, flip complete=false and re-trigger.
-    await db
-      .update(dataSourceChannelState)
-      .set({ backfillComplete: false })
-      .where(
-        and(
-          eq(dataSourceChannelState.kind, "youtube_channel"),
-          eq(dataSourceChannelState.channelKey, channelKey),
-        ),
-      );
-    pollContentCalls.length = 0;
-    // Seed a historical event so the success path runs (the
-    // historical-flow upgrade lives in the events-collected branch,
-    // not the empty-result branch).
+    // Half 2 — invoke the handler with the captured job. Seed a historical
+    // event so the success path runs (the historical-flow upgrade lives in
+    // the events-collected branch).
     const histEventId = `vid_c_hist_${uniq()}`;
     pollContentResults = [
       {
@@ -501,23 +477,21 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
         metadata: { channelId: channelKey },
       },
     ];
+    pollContentUnitsUsed = 1;
+    pollContentCalls.length = 0;
+
     await handleBackfillChannel({
-      id: "mock-job-quota-c-2",
-      data: {
-        kind: "youtube_channel",
-        channelKey,
-        triggerUserId: u.id,
-        depthBoundIso: "1970-01-01T00:00:00.000Z",
-        flow: "incremental",
-      },
+      id: "mock-job-quota-c",
+      data: job.data as Parameters<typeof handleBackfillChannel>[0]["data"],
     });
 
     expect(pollContentCalls).toHaveLength(1);
-    // target=epoch (0 ms); deepestWalked=30d ago. target.getTime() (=0) <
-    // deepestWalked.getTime() (positive) → branch="deep". since=target=epoch.
+    // forceDeep=true → branch="deep" → since=target=epoch (NOT
+    // max(newestKnown=now, target=epoch)=now — the deep branch uses target
+    // directly).
     expect(pollContentCalls[0]!.since.getTime()).toBe(0);
 
-    const auditRows2 = await db
+    const auditRows = await db
       .select()
       .from(auditLog)
       .where(
@@ -526,15 +500,80 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
           eq(auditLog.action, "source.refresh_content_requested"),
         ),
       );
-    // Latest completion row should be the deep one.
-    const deepCompletion = auditRows2
+    const completion = auditRows
       .filter((r) => (r.metadata as Record<string, unknown>)?.events_inserted !== undefined)
       .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())[0];
-    expect(deepCompletion).toBeDefined();
-    const deepMeta = deepCompletion!.metadata as Record<string, unknown>;
-    expect(deepMeta.since_branch).toBe("deep");
+    expect(completion).toBeDefined();
+    const meta = completion!.metadata as Record<string, unknown>;
+    expect(meta.since_branch).toBe("deep");
     // historical-flow upgrade fires when since.getTime() < deepestWalked.getTime()
-    // and flow=incremental, which is the case here (0 < 30d-ago.getTime()).
-    expect(deepMeta.flow).toBe("historical");
+    // and flow=historical (passed in via the job). Both hold here.
+    expect(meta.flow).toBe("historical");
+  });
+
+  it("(c2) widening backfillTargetSince to a value ≥ deepestWalked does NOT enqueue a force-deep job", async () => {
+    // Negative case for the force-deep predicate — narrowing from epoch
+    // toward present is already blocked by `cannot_narrow_window`; this
+    // test verifies the no-op path: a widen that does NOT cross
+    // backfill_oldest_at must not burn quota on a redundant deep walk.
+    const channelKey = newChannelKey();
+    await clearChannelFixture(channelKey);
+
+    const app = createApp();
+    const u = await seedUserDirectly({ email: `quota-c2-${uniq()}@test.local` });
+    const src = await createSource(
+      u.id,
+      {
+        kind: "youtube_channel",
+        handleUrl: `https://www.youtube.com/channel/${channelKey}`,
+        isOwnedByMe: true,
+        autoImport: true,
+      },
+      "127.0.0.1",
+    );
+
+    const now = Date.now();
+    const ninetyDaysAgo = new Date(now - 90 * 86_400_000);
+    const sixtyDaysAgo = new Date(now - 60 * 86_400_000);
+    const thirtyDaysAgo = new Date(now - 30 * 86_400_000);
+
+    // Channel was walked deeper (90d-ago) than current target (30d-ago).
+    await db
+      .update(dataSources)
+      .set({ backfillTargetSince: thirtyDaysAgo })
+      .where(eq(dataSources.id, src.id));
+    await db
+      .insert(dataSourceChannelState)
+      .values({
+        kind: "youtube_channel",
+        channelKey,
+        backfillComplete: true,
+        backfillOldestAt: ninetyDaysAgo,
+      })
+      .onConflictDoUpdate({
+        target: [dataSourceChannelState.kind, dataSourceChannelState.channelKey],
+        set: {
+          backfillComplete: true,
+          backfillOldestAt: ninetyDaysAgo,
+          updatedAt: new Date(),
+        },
+      });
+
+    sentJobs.length = 0;
+
+    // Widening from 30d to 60d — STILL shallower than the deepestWalked
+    // (90d-ago); nothing new to find, so no force-deep needed.
+    const patchRes = await app.request(`/api/sources/${src.id}`, {
+      method: "PATCH",
+      headers: {
+        cookie: `neotolis.session_token=${u.signedSessionCookieValue}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ backfillTargetSince: sixtyDaysAgo.toISOString() }),
+    });
+    expect(patchRes.status).toBe(200);
+
+    const enqueues = sentJobs.filter((j) => j.queue === "youtube.backfill.channel");
+    expect(enqueues).toHaveLength(0);
   });
 });

--- a/tests/integration/refresh-content-quota.test.ts
+++ b/tests/integration/refresh-content-quota.test.ts
@@ -206,19 +206,36 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
     expect(Number(meta.requests_used)).toBeLessThanOrEqual(1);
   });
 
-  it("(b) backdated upload (publishedAt < newestKnown but > prior session) is collected on the next click", async () => {
-    // Setup: target = 60d-ago (the subscriber's window — events newer
-    // than 60d-ago are kept). Prior partial walk to 90d-ago (deeper).
-    // D-#29-2 locked algebra: target.getTime() >= deepestWalked.getTime()
-    // — for "ms since epoch", 60d-ago has a LARGER number (= more recent
-    // instant) than 90d-ago, so the comparison routes to
-    // branch="incremental". newestKnown=now via a seeded youtube_videos
-    // row → since = max(newestKnown, target) = now. The walker would
-    // normally walkedPastSince anything older; our mocked pollContent
-    // returns one backdated event at 45d-ago (within the user's 60d
-    // window) — the collected row exists post-walk, demonstrating
-    // D-#29-1's promise (no silent drop of backdated uploads relative
-    // to newestKnown).
+  it("(b) incremental branch: since=max(newestKnown, target) + token cleared + adapter events fan out to events.user_id rows", async () => {
+    // What this test actually verifies (Phase 03.0.3 code-review follow-up):
+    //   1. branch selection — backfillComplete=false + deepestWalked=90d-ago
+    //      + target=60d-ago routes to branch="incremental" (D-#29-2:
+    //      `target.getTime() >= deepestWalked.getTime()` is true because
+    //      60d-ago is a more-recent instant than 90d-ago).
+    //   2. since derivation — since=max(newestKnown=now, target=60d-ago)=now.
+    //   3. fan-out — whatever events the adapter yields (mocked here with
+    //      one backdated event at 45d-ago) get INSERTed into `events` keyed
+    //      by (user_id, external_id) without being dropped at the fan-out
+    //      layer.
+    //
+    // What this test does NOT verify: walker-level walkedPastSince
+    // behavior. `pollContent` is mocked at the adapter boundary, so the
+    // mock returns the backdated event regardless of the `since` arg it
+    // receives. The production walker decides whether to yield a backdated
+    // item based on its position relative to `since` in the uploads
+    // playlist; that decision happens INSIDE pollContent and is not
+    // covered here. The plan's original framing (D-#29-1's promise that
+    // walkedPastSince does not silently drop backdated uploads) requires
+    // a separate unit test against the YouTube adapter's pollContent
+    // implementation with a synthetic playlist fixture — filed as
+    // follow-up TODO below.
+    //
+    // TODO(03.0.3 follow-up): add tests/unit/youtube-channel-adapter.test.ts
+    // case that drives pollContent against an in-memory playlist with
+    // one backdated item and asserts the adapter yields it instead of
+    // short-circuiting on walkedPastSince. Requires unmocking the
+    // adapter and feeding fake HTTP responses; out of scope for the
+    // integration suite.
     const channelKey = newChannelKey();
     await clearChannelFixture(channelKey);
 
@@ -325,14 +342,12 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
     expect(meta.since_branch).toBe("incremental");
     expect(Number(meta.requests_used)).toBe(1);
 
-    // The backdated event was collected even though its publishedAt
-    // (45d-ago) is older than newestKnown (now) — D-#29-1's promise:
-    // walkedPastSince does not silently drop backdated uploads relative
-    // to newestKnown. (The walker would normally short-circuit on the
-    // first event older than `since`, but the mock returns events
-    // directly; the assertion below is what the production walker
-    // delivers when the page contains a backdated item before crossing
-    // the cutoff.)
+    // Fan-out assertion: the adapter's backdated event (45d-ago, returned
+    // unconditionally by the mocked pollContent) appears in `events`
+    // keyed by (user_id, external_id). Demonstrates the fan-out layer
+    // does NOT drop adapter events on its own. Does NOT demonstrate that
+    // the production walker yields backdated uploads — that lives behind
+    // the mock boundary (see TODO above).
     const newEvents = await db
       .select()
       .from(events)

--- a/tests/integration/refresh-content-quota.test.ts
+++ b/tests/integration/refresh-content-quota.test.ts
@@ -8,16 +8,19 @@
 //   (c) widening backfillTargetSince (30d → epoch) triggers deep walk on
 //       next refresh-content click — branch="deep" (no eager reset; D-#29-6).
 //
-// Live bodies land in Task 5 of plan 03.0.3-01. Wave 0 scaffold: 3 it.skip
-// placeholders verbatim with the test names from issue #29 / D-C1.
+// Mocks getBoss (no live pg-boss) and youtubeChannelAdapterCore.pollContent
+// (deterministic event payload, captures `since` arg) — same pattern as
+// end-to-end-catch-up.test.ts.
 
-import { describe, it, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { and, eq } from "drizzle-orm";
 
-const sentJobs: Array<{
+interface CapturedJob {
   queue: string;
   data: Record<string, unknown>;
   options: Record<string, unknown>;
-}> = [];
+}
+const sentJobs: CapturedJob[] = [];
 
 vi.mock("../../src/lib/server/queue-client.js", async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
@@ -30,32 +33,493 @@ vi.mock("../../src/lib/server/queue-client.js", async (importOriginal) => {
         options: Record<string, unknown>,
       ) => {
         sentJobs.push({ queue, data, options });
-        return "mock-job-id";
+        return `mock-job-${Math.random().toString(36).slice(2, 10)}`;
       },
+      schedule: async () => {},
+      createQueue: async () => {},
+      work: async () => {},
     }),
   };
 });
 
+interface RawEventStub {
+  externalId: string;
+  occurredAt: Date;
+  title: string;
+  url: string;
+  metadata: Record<string, unknown>;
+}
+
+const pollContentCalls: { since: Date }[] = [];
+let pollContentResults: RawEventStub[] = [];
+let pollContentEndOfPlaylist = false;
+let pollContentUnitsUsed = 1;
+
+vi.mock("../../src/lib/sources/youtube/server/adapter.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  const core = actual.youtubeChannelAdapterCore as Record<string, unknown>;
+  return {
+    ...actual,
+    youtubeChannelAdapterCore: {
+      ...core,
+      pollContent: async (_source: unknown, since: Date) => {
+        pollContentCalls.push({ since });
+        return {
+          events: pollContentResults.slice(),
+          unitsUsed: pollContentUnitsUsed,
+          endOfPlaylist: pollContentEndOfPlaylist,
+        };
+      },
+    },
+  };
+});
+
+const { db } = await import("../../src/lib/server/db/client.js");
+const { dataSources } = await import("../../src/lib/server/db/schema/data-sources.js");
+const { dataSourceChannelState } = await import(
+  "../../src/lib/server/db/schema/data-source-channel-state.js"
+);
+const { youtubeVideos } = await import("../../src/lib/sources/youtube/server/schema/index.js");
+const { events } = await import("../../src/lib/server/db/schema/events.js");
+const { auditLog } = await import("../../src/lib/server/db/schema/audit-log.js");
+const { createApp } = await import("../../src/lib/server/http/app.js");
+const { createSource } = await import("../../src/lib/server/services/data-sources.js");
+const { handleBackfillChannel } = await import(
+  "../../src/lib/sources/youtube/server/handlers/backfill-channel.js"
+);
+const { getChannelState } = await import("../../src/lib/server/services/channel-state.js");
+const { seedUserDirectly } = await import("./helpers.js");
+
+const uniq = (): string => Math.random().toString(36).slice(2, 10);
+const newChannelKey = (): string => `UC${uniq()}${uniq().slice(0, 8)}aa`;
+
+async function clearChannelFixture(channelKey: string): Promise<void> {
+  await db.delete(youtubeVideos).where(eq(youtubeVideos.channelId, channelKey));
+  await db
+    .delete(dataSourceChannelState)
+    .where(
+      and(
+        eq(dataSourceChannelState.kind, "youtube_channel"),
+        eq(dataSourceChannelState.channelKey, channelKey),
+      ),
+    );
+}
+
 describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
-  it.skip(
-    "(a) repeated click within 5min on a steady-state channel costs ≤1 page (not N/50 pages)",
-    () => {
-      // Live body lands in Task 5 — exercises branch="exhausted".
-    },
-  );
+  beforeEach(() => {
+    sentJobs.length = 0;
+    pollContentCalls.length = 0;
+    pollContentResults = [];
+    pollContentEndOfPlaylist = false;
+    pollContentUnitsUsed = 1;
+  });
 
-  it.skip(
-    "(b) backdated upload (publishedAt < newestKnown but > prior session) is collected on the next click",
-    () => {
-      // Live body lands in Task 5 — exercises branch="incremental".
-    },
-  );
+  it("(a) repeated click within 5min on a steady-state channel costs ≤1 page (not N/50 pages)", async () => {
+    // Setup: admin/'all-history' user (target=epoch); channel previously
+    // walked to exhaustion (backfill_complete=true). Mock pollContent
+    // returns empty + unitsUsed=1 (the typical playlistItems.list cost for
+    // a steady-state no-new-uploads channel).
+    const channelKey = newChannelKey();
+    await clearChannelFixture(channelKey);
 
-  it.skip(
-    "(c) widening backfillTargetSince (30d → epoch) triggers deep walk on next refresh-content click",
-    () => {
-      // Live body lands in Task 5 — exercises branch="deep" and D-#29-6
-      // (no eager state reset on PATCH).
-    },
-  );
+    const u = await seedUserDirectly({ email: `quota-a-${uniq()}@test.local` });
+    const src = await createSource(
+      u.id,
+      {
+        kind: "youtube_channel",
+        handleUrl: `https://www.youtube.com/channel/${channelKey}`,
+        isOwnedByMe: true,
+        autoImport: true,
+      },
+      "127.0.0.1",
+    );
+    // Admin / all-history profile.
+    await db
+      .update(dataSources)
+      .set({ backfillTargetSince: new Date(0) })
+      .where(eq(dataSources.id, src.id));
+
+    // Seed youtube_videos with ≥10 rows so newestKnown !== null.
+    const now = Date.now();
+    const seededVideos = Array.from({ length: 10 }, (_, i) => ({
+      videoId: `vid_a_${uniq()}_${i}`,
+      title: `Old Video ${i}`,
+      channelId: channelKey,
+      publishedAt: new Date(now - (i + 1) * 5 * 86_400_000),
+    }));
+    await db.insert(youtubeVideos).values(seededVideos);
+    const seededNewest = seededVideos[0]!.publishedAt;
+    const seededOldest = seededVideos.at(-1)!.publishedAt;
+
+    // Prior exhausted walk: backfillComplete=true, frontier=oldest seeded.
+    await db
+      .insert(dataSourceChannelState)
+      .values({
+        kind: "youtube_channel",
+        channelKey,
+        backfillComplete: true,
+        backfillOldestAt: seededOldest,
+      })
+      .onConflictDoUpdate({
+        target: [dataSourceChannelState.kind, dataSourceChannelState.channelKey],
+        set: { backfillComplete: true, backfillOldestAt: seededOldest, updatedAt: new Date() },
+      });
+
+    // Steady-state — adapter returns empty (no new videos).
+    pollContentResults = [];
+    pollContentUnitsUsed = 1;
+
+    await handleBackfillChannel({
+      id: "mock-job-quota-a",
+      data: {
+        kind: "youtube_channel",
+        channelKey,
+        triggerUserId: u.id,
+        depthBoundIso: new Date(0).toISOString(),
+        flow: "incremental",
+      },
+    });
+
+    expect(pollContentCalls).toHaveLength(1);
+    // since arg lifted to newestKnown floor (branch="exhausted" with
+    // newestKnown > target=epoch).
+    expect(pollContentCalls[0]!.since.getTime()).toBeGreaterThanOrEqual(
+      seededNewest.getTime(),
+    );
+
+    // Audit row carries since_branch="exhausted" + requests_used <= 1.
+    const auditRows = await db
+      .select()
+      .from(auditLog)
+      .where(
+        and(
+          eq(auditLog.userId, u.id),
+          eq(auditLog.action, "source.refresh_content_requested"),
+        ),
+      );
+    const completion = auditRows.find(
+      (r) => (r.metadata as Record<string, unknown>)?.events_inserted !== undefined,
+    );
+    expect(completion, "completion audit row missing").toBeDefined();
+    const meta = completion!.metadata as Record<string, unknown>;
+    expect(meta.since_branch).toBe("exhausted");
+    expect(Number(meta.requests_used)).toBeLessThanOrEqual(1);
+  });
+
+  it("(b) backdated upload (publishedAt < newestKnown but > prior session) is collected on the next click", async () => {
+    // Setup: target = 60d-ago (the subscriber's window — events newer
+    // than 60d-ago are kept). Prior partial walk to 90d-ago (deeper).
+    // D-#29-2 locked algebra: target.getTime() >= deepestWalked.getTime()
+    // — for "ms since epoch", 60d-ago has a LARGER number (= more recent
+    // instant) than 90d-ago, so the comparison routes to
+    // branch="incremental". newestKnown=now via a seeded youtube_videos
+    // row → since = max(newestKnown, target) = now. The walker would
+    // normally walkedPastSince anything older; our mocked pollContent
+    // returns one backdated event at 45d-ago (within the user's 60d
+    // window) — the collected row exists post-walk, demonstrating
+    // D-#29-1's promise (no silent drop of backdated uploads relative
+    // to newestKnown).
+    const channelKey = newChannelKey();
+    await clearChannelFixture(channelKey);
+
+    const u = await seedUserDirectly({ email: `quota-b-${uniq()}@test.local` });
+    const src = await createSource(
+      u.id,
+      {
+        kind: "youtube_channel",
+        handleUrl: `https://www.youtube.com/channel/${channelKey}`,
+        isOwnedByMe: true,
+        autoImport: true,
+      },
+      "127.0.0.1",
+    );
+
+    const now = Date.now();
+    const ninetyDaysAgo = new Date(now - 90 * 86_400_000);
+    const sixtyDaysAgo = new Date(now - 60 * 86_400_000);
+    const fortyFiveDaysAgo = new Date(now - 45 * 86_400_000);
+
+    await db
+      .update(dataSources)
+      .set({ backfillTargetSince: sixtyDaysAgo })
+      .where(eq(dataSources.id, src.id));
+
+    await db.insert(youtubeVideos).values([
+      {
+        videoId: `vid_b_new_${uniq()}`,
+        title: "Newest",
+        channelId: channelKey,
+        publishedAt: new Date(now),
+      },
+      {
+        videoId: `vid_b_mid_${uniq()}`,
+        title: "Mid",
+        channelId: channelKey,
+        publishedAt: ninetyDaysAgo,
+      },
+    ]);
+    const seededNewest = new Date(now);
+
+    // Prior partial walk — not complete, deepestWalked=90d ago.
+    // target=60d-ago is SHALLOWER than deepestWalked=90d-ago, so the
+    // incremental branch applies.
+    await db
+      .insert(dataSourceChannelState)
+      .values({
+        kind: "youtube_channel",
+        channelKey,
+        backfillComplete: false,
+        backfillOldestAt: ninetyDaysAgo,
+      })
+      .onConflictDoUpdate({
+        target: [dataSourceChannelState.kind, dataSourceChannelState.channelKey],
+        set: {
+          backfillComplete: false,
+          backfillOldestAt: ninetyDaysAgo,
+          updatedAt: new Date(),
+        },
+      });
+
+    const backdatedExternalId = `vid_b_backdated_${uniq()}`;
+    pollContentResults = [
+      {
+        externalId: backdatedExternalId,
+        occurredAt: fortyFiveDaysAgo,
+        title: "Backdated video",
+        url: `https://www.youtube.com/watch?v=${backdatedExternalId}`,
+        metadata: { channelId: channelKey },
+      },
+    ];
+    pollContentUnitsUsed = 1;
+
+    await handleBackfillChannel({
+      id: "mock-job-quota-b",
+      data: {
+        kind: "youtube_channel",
+        channelKey,
+        triggerUserId: u.id,
+        depthBoundIso: sixtyDaysAgo.toISOString(),
+        flow: "incremental",
+      },
+    });
+
+    expect(pollContentCalls).toHaveLength(1);
+    // since arg = max(newestKnown=now, target=60d-ago) = now — branch=incremental.
+    expect(pollContentCalls[0]!.since.getTime()).toBe(seededNewest.getTime());
+
+    // Audit row carries since_branch="incremental".
+    const auditRows = await db
+      .select()
+      .from(auditLog)
+      .where(
+        and(
+          eq(auditLog.userId, u.id),
+          eq(auditLog.action, "source.refresh_content_requested"),
+        ),
+      );
+    const completion = auditRows.find(
+      (r) => (r.metadata as Record<string, unknown>)?.events_inserted !== undefined,
+    );
+    expect(completion).toBeDefined();
+    const meta = completion!.metadata as Record<string, unknown>;
+    expect(meta.since_branch).toBe("incremental");
+    expect(Number(meta.requests_used)).toBe(1);
+
+    // The backdated event was collected even though its publishedAt
+    // (45d-ago) is older than newestKnown (now) — D-#29-1's promise:
+    // walkedPastSince does not silently drop backdated uploads relative
+    // to newestKnown. (The walker would normally short-circuit on the
+    // first event older than `since`, but the mock returns events
+    // directly; the assertion below is what the production walker
+    // delivers when the page contains a backdated item before crossing
+    // the cutoff.)
+    const newEvents = await db
+      .select()
+      .from(events)
+      .where(and(eq(events.userId, u.id), eq(events.externalId, backdatedExternalId)));
+    expect(newEvents).toHaveLength(1);
+  });
+
+  it("(c) widening backfillTargetSince (30d → epoch) triggers deep walk on next refresh-content click", async () => {
+    // Setup: current target=30d ago; channel state exhausted at 30d ago;
+    // youtube_videos has one row with publishedAt=now (newestKnown=now).
+    const channelKey = newChannelKey();
+    await clearChannelFixture(channelKey);
+
+    const app = createApp();
+    const u = await seedUserDirectly({ email: `quota-c-${uniq()}@test.local` });
+    const src = await createSource(
+      u.id,
+      {
+        kind: "youtube_channel",
+        handleUrl: `https://www.youtube.com/channel/${channelKey}`,
+        isOwnedByMe: true,
+        autoImport: true,
+      },
+      "127.0.0.1",
+    );
+
+    const now = Date.now();
+    const thirtyDaysAgo = new Date(now - 30 * 86_400_000);
+    await db
+      .update(dataSources)
+      .set({ backfillTargetSince: thirtyDaysAgo })
+      .where(eq(dataSources.id, src.id));
+
+    await db.insert(youtubeVideos).values({
+      videoId: `vid_c_${uniq()}`,
+      title: "Just one",
+      channelId: channelKey,
+      publishedAt: new Date(now),
+    });
+
+    await db
+      .insert(dataSourceChannelState)
+      .values({
+        kind: "youtube_channel",
+        channelKey,
+        backfillComplete: true,
+        backfillOldestAt: thirtyDaysAgo,
+      })
+      .onConflictDoUpdate({
+        target: [dataSourceChannelState.kind, dataSourceChannelState.channelKey],
+        set: {
+          backfillComplete: true,
+          backfillOldestAt: thirtyDaysAgo,
+          updatedAt: new Date(),
+        },
+      });
+
+    // PATCH /api/sources/<id> { backfillTargetSince: epoch }.
+    const patchRes = await app.request(`/api/sources/${src.id}`, {
+      method: "PATCH",
+      headers: {
+        cookie: `neotolis.session_token=${u.signedSessionCookieValue}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ backfillTargetSince: "1970-01-01T00:00:00.000Z" }),
+    });
+    expect(patchRes.status).toBe(200);
+
+    // D-#29-6 — no eager reset. backfill_complete is STILL true after PATCH.
+    const stateAfterPatch = await getChannelState("youtube_channel", channelKey);
+    expect(stateAfterPatch).toBeDefined();
+    expect(stateAfterPatch!.backfillComplete).toBe(true);
+
+    // Now trigger the worker with the widened target.
+    pollContentResults = [];
+    pollContentUnitsUsed = 1;
+    await handleBackfillChannel({
+      id: "mock-job-quota-c",
+      data: {
+        kind: "youtube_channel",
+        channelKey,
+        triggerUserId: u.id,
+        depthBoundIso: "1970-01-01T00:00:00.000Z",
+        flow: "incremental",
+      },
+    });
+
+    expect(pollContentCalls).toHaveLength(1);
+    // Branch logic: backfill_complete=true → branch="exhausted" first,
+    // then since=max(newestKnown=now, target=epoch)=now.
+    //
+    // Wait — D-#29-2 prioritises 'exhausted' check FIRST. Once complete=true,
+    // branch=exhausted regardless of target. The plan's test (c) description
+    // expects branch="deep" + flow="historical".
+    //
+    // Reading D-#29-2 again:
+    //   - exhausted   (backfill_complete=true)
+    //   - incremental (!complete && deepest!==null && target>=deepest)
+    //   - deep        (else)
+    //
+    // So with complete=true, we're in exhausted — NOT deep. The plan's
+    // expectation that "exhausted at 30d" + "widen to epoch" + "next click
+    // → deep" is inconsistent with D-#29-2 locked semantics. The honest
+    // assertion is: branch="exhausted", since=max(newestKnown, target)=now.
+    //
+    // This is the multi-tenant-fairness behavior locked by D-#29-7: one
+    // user widening does NOT re-open the walk for other subscribers, and
+    // the channel state's exhausted flag wins. The user's widened target
+    // only matters when complete=false (which is the typical case before
+    // a deep walk has completed; here we artificially set complete=true
+    // to model a fully-walked channel).
+    const auditRows = await db
+      .select()
+      .from(auditLog)
+      .where(
+        and(
+          eq(auditLog.userId, u.id),
+          eq(auditLog.action, "source.refresh_content_requested"),
+        ),
+      );
+    const completion = auditRows.find(
+      (r) => (r.metadata as Record<string, unknown>)?.events_inserted !== undefined,
+    );
+    expect(completion).toBeDefined();
+    const meta = completion!.metadata as Record<string, unknown>;
+    expect(meta.since_branch).toBe("exhausted");
+
+    // Reset and re-test the actual "widen triggers deep" scenario: channel
+    // state is NOT exhausted but DEEPEST is shallower than the new target.
+    // Take 2: same channel, flip complete=false and re-trigger.
+    await db
+      .update(dataSourceChannelState)
+      .set({ backfillComplete: false })
+      .where(
+        and(
+          eq(dataSourceChannelState.kind, "youtube_channel"),
+          eq(dataSourceChannelState.channelKey, channelKey),
+        ),
+      );
+    pollContentCalls.length = 0;
+    // Seed a historical event so the success path runs (the
+    // historical-flow upgrade lives in the events-collected branch,
+    // not the empty-result branch).
+    const histEventId = `vid_c_hist_${uniq()}`;
+    pollContentResults = [
+      {
+        externalId: histEventId,
+        occurredAt: new Date(now - 100 * 86_400_000),
+        title: "Deep history",
+        url: `https://www.youtube.com/watch?v=${histEventId}`,
+        metadata: { channelId: channelKey },
+      },
+    ];
+    await handleBackfillChannel({
+      id: "mock-job-quota-c-2",
+      data: {
+        kind: "youtube_channel",
+        channelKey,
+        triggerUserId: u.id,
+        depthBoundIso: "1970-01-01T00:00:00.000Z",
+        flow: "incremental",
+      },
+    });
+
+    expect(pollContentCalls).toHaveLength(1);
+    // target=epoch (0 ms); deepestWalked=30d ago. target.getTime() (=0) <
+    // deepestWalked.getTime() (positive) → branch="deep". since=target=epoch.
+    expect(pollContentCalls[0]!.since.getTime()).toBe(0);
+
+    const auditRows2 = await db
+      .select()
+      .from(auditLog)
+      .where(
+        and(
+          eq(auditLog.userId, u.id),
+          eq(auditLog.action, "source.refresh_content_requested"),
+        ),
+      );
+    // Latest completion row should be the deep one.
+    const deepCompletion = auditRows2
+      .filter((r) => (r.metadata as Record<string, unknown>)?.events_inserted !== undefined)
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())[0];
+    expect(deepCompletion).toBeDefined();
+    const deepMeta = deepCompletion!.metadata as Record<string, unknown>;
+    expect(deepMeta.since_branch).toBe("deep");
+    // historical-flow upgrade fires when since.getTime() < deepestWalked.getTime()
+    // and flow=incremental, which is the case here (0 < 30d-ago.getTime()).
+    expect(deepMeta.flow).toBe("historical");
+  });
 });

--- a/tests/integration/refresh-content-quota.test.ts
+++ b/tests/integration/refresh-content-quota.test.ts
@@ -834,7 +834,13 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
     // pending → forwarded transition. boss.send is mocked at the
     // queue-client layer (see the top-of-file vi.mock); the forwarder
     // collects via the same mock that records into sentJobs.
+    //
+    // PR #31 Codex P2 #1 — the forwarder takes the boss instance
+    // injected by the worker. Tests reach for the same mocked boss via
+    // getBoss() (which the queue-client.ts mock exposes).
     const { drainOutboxOnce } = await import("../../src/worker/handlers/outbox-forwarder.js");
+    const { getBoss } = await import("../../src/lib/server/queue-client.js");
+    const mockBoss = await getBoss();
 
     sentJobs.length = 0;
 
@@ -857,7 +863,7 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
     `);
 
     // First drain — should forward exactly once.
-    await drainOutboxOnce();
+    await drainOutboxOnce(mockBoss);
     const after1 = await db.execute(sql`
       SELECT forwarded_at, forwarder_attempt
       FROM outbox
@@ -872,7 +878,7 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
     // Second drain — row is forwarded, must NOT be picked up again
     // (idempotency: at-most-one boss.send per row, modulo crash-replay
     // which is dedup'd by singletonKey at the pg-boss layer).
-    await drainOutboxOnce();
+    await drainOutboxOnce(mockBoss);
     expect(sentJobs.filter((j) => j.queue === "youtube.backfill.channel")).toHaveLength(1);
 
     // Cleanup.
@@ -881,6 +887,8 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
 
   it("(i) outbox forwarder retries on boss.send failure — row stays pending, attempt counter bumps", async () => {
     const { drainOutboxOnce } = await import("../../src/worker/handlers/outbox-forwarder.js");
+    const { getBoss } = await import("../../src/lib/server/queue-client.js");
+    const mockBoss = await getBoss();
 
     sentJobs.length = 0;
 
@@ -903,7 +911,7 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
 
     // Inject boss.send failure on the first drain.
     bossSendShouldThrow = true;
-    await drainOutboxOnce();
+    await drainOutboxOnce(mockBoss);
 
     const afterFail = await db.execute(sql`
       SELECT forwarded_at, forwarder_attempt, last_error
@@ -923,9 +931,17 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
     // boss.send was attempted but threw before sentJobs captured it.
     expect(sentJobs.filter((j) => j.queue === "youtube.backfill.channel")).toHaveLength(0);
 
+    // The claim-window (60s) blocks immediate retry to give natural
+    // back-off in production. For the test, advance the row's
+    // last_attempt_at past the window so the next drain claims it.
+    await db.execute(sql`
+      UPDATE outbox SET last_attempt_at = NULL
+      WHERE payload->>'channelKey' = ${channelKey}
+    `);
+
     // Disable the failure injection, drain again — second attempt succeeds.
     bossSendShouldThrow = false;
-    await drainOutboxOnce();
+    await drainOutboxOnce(mockBoss);
 
     const afterRetry = await db.execute(sql`
       SELECT forwarded_at, forwarder_attempt

--- a/tests/integration/refresh-content-quota.test.ts
+++ b/tests/integration/refresh-content-quota.test.ts
@@ -88,17 +88,15 @@ vi.mock("../../src/lib/sources/youtube/server/adapter.js", async (importOriginal
 
 const { db } = await import("../../src/lib/server/db/client.js");
 const { dataSources } = await import("../../src/lib/server/db/schema/data-sources.js");
-const { dataSourceChannelState } = await import(
-  "../../src/lib/server/db/schema/data-source-channel-state.js"
-);
+const { dataSourceChannelState } =
+  await import("../../src/lib/server/db/schema/data-source-channel-state.js");
 const { youtubeVideos } = await import("../../src/lib/sources/youtube/server/schema/index.js");
 const { events } = await import("../../src/lib/server/db/schema/events.js");
 const { auditLog } = await import("../../src/lib/server/db/schema/audit-log.js");
 const { createApp } = await import("../../src/lib/server/http/app.js");
 const { createSource } = await import("../../src/lib/server/services/data-sources.js");
-const { handleBackfillChannel } = await import(
-  "../../src/lib/sources/youtube/server/handlers/backfill-channel.js"
-);
+const { handleBackfillChannel } =
+  await import("../../src/lib/sources/youtube/server/handlers/backfill-channel.js");
 const { getChannelState } = await import("../../src/lib/server/services/channel-state.js");
 const { seedUserDirectly } = await import("./helpers.js");
 
@@ -197,19 +195,14 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
     expect(pollContentCalls).toHaveLength(1);
     // since arg lifted to newestKnown floor (branch="exhausted" with
     // newestKnown > target=epoch).
-    expect(pollContentCalls[0]!.since.getTime()).toBeGreaterThanOrEqual(
-      seededNewest.getTime(),
-    );
+    expect(pollContentCalls[0]!.since.getTime()).toBeGreaterThanOrEqual(seededNewest.getTime());
 
     // Audit row carries since_branch="exhausted" + requests_used <= 1.
     const auditRows = await db
       .select()
       .from(auditLog)
       .where(
-        and(
-          eq(auditLog.userId, u.id),
-          eq(auditLog.action, "source.refresh_content_requested"),
-        ),
+        and(eq(auditLog.userId, u.id), eq(auditLog.action, "source.refresh_content_requested")),
       );
     const completion = auditRows.find(
       (r) => (r.metadata as Record<string, unknown>)?.events_inserted !== undefined,
@@ -343,10 +336,7 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
       .select()
       .from(auditLog)
       .where(
-        and(
-          eq(auditLog.userId, u.id),
-          eq(auditLog.action, "source.refresh_content_requested"),
-        ),
+        and(eq(auditLog.userId, u.id), eq(auditLog.action, "source.refresh_content_requested")),
       );
     const completion = auditRows.find(
       (r) => (r.metadata as Record<string, unknown>)?.events_inserted !== undefined,
@@ -509,10 +499,7 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
       .select()
       .from(auditLog)
       .where(
-        and(
-          eq(auditLog.userId, u.id),
-          eq(auditLog.action, "source.refresh_content_requested"),
-        ),
+        and(eq(auditLog.userId, u.id), eq(auditLog.action, "source.refresh_content_requested")),
       );
     const completion = auditRows
       .filter((r) => (r.metadata as Record<string, unknown>)?.events_inserted !== undefined)
@@ -639,9 +626,9 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
     const state = await getChannelState("youtube_channel", channelKey);
     expect(state).toBeDefined();
     expect(state!.backfillComplete).toBe(true);
-    expect((state!.metadata as { lastBackfillPageToken?: string } | null)?.lastBackfillPageToken ?? null).toBe(
-      null,
-    );
+    expect(
+      (state!.metadata as { lastBackfillPageToken?: string } | null)?.lastBackfillPageToken ?? null,
+    ).toBe(null);
   });
 
   it("(e) empty + walkedPastSince (endOfPlaylist=false, no nextPageToken) → backfill_complete UNCHANGED, token cleared", async () => {
@@ -693,9 +680,9 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
     // Critical: NOT marked complete. Channel may have older history past
     // the 30d window; next widen-target click must be able to deep-walk.
     expect(state!.backfillComplete).toBe(false);
-    expect((state!.metadata as { lastBackfillPageToken?: string } | null)?.lastBackfillPageToken ?? null).toBe(
-      null,
-    );
+    expect(
+      (state!.metadata as { lastBackfillPageToken?: string } | null)?.lastBackfillPageToken ?? null,
+    ).toBe(null);
   });
 
   it("(g) PATCH widen + boss.send fails → UPDATE rolled back, backfillTargetSince stays at OLD value (atomicity-of-intent, PR #31 P2)", async () => {
@@ -851,8 +838,8 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
     expect(state).toBeDefined();
     expect(state!.backfillComplete).toBe(false);
     // Resume cursor survives so the next click continues the walk.
-    expect((state!.metadata as { lastBackfillPageToken?: string } | null)?.lastBackfillPageToken).toBe(
-      "RESUME_AT_PAGE_21",
-    );
+    expect(
+      (state!.metadata as { lastBackfillPageToken?: string } | null)?.lastBackfillPageToken,
+    ).toBe("RESUME_AT_PAGE_21");
   });
 });

--- a/tests/integration/refresh-content-quota.test.ts
+++ b/tests/integration/refresh-content-quota.test.ts
@@ -13,7 +13,7 @@
 // end-to-end-catch-up.test.ts.
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 interface CapturedJob {
   queue: string;
@@ -452,11 +452,26 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
     expect(stateAfterPatch!.backfillComplete).toBe(true);
 
     // The PATCH path detected widening past deepestWalked + complete=true
-    // → enqueued a force-deep job for THIS user.
-    const enqueues = sentJobs.filter((j) => j.queue === "youtube.backfill.channel");
-    expect(enqueues).toHaveLength(1);
-    const job = enqueues[0]!;
-    expect(job.data).toMatchObject({
+    // → wrote a force-deep intent to the outbox table (PR #31 Codex P2
+    // refactor — atomic with the data_sources UPDATE). The forwarder
+    // would translate this into boss.send asynchronously, but that
+    // half is exercised in test (h). Here we only assert the intent
+    // landed correctly.
+    const outboxRows = await db.execute(sql`
+      SELECT queue, payload, options
+      FROM outbox
+      WHERE queue = 'youtube.backfill.channel'
+        AND payload->>'channelKey' = ${channelKey}
+        AND payload->>'triggerUserId' = ${u.id}
+      ORDER BY created_at DESC
+      LIMIT 1
+    `);
+    expect(outboxRows.rows.length).toBe(1);
+    const outboxRow = outboxRows.rows[0] as {
+      payload: Record<string, unknown>;
+      options: Record<string, unknown>;
+    };
+    expect(outboxRow.payload).toMatchObject({
       kind: "youtube_channel",
       channelKey,
       triggerUserId: u.id,
@@ -464,9 +479,14 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
       flow: "historical",
       forceDeep: true,
     });
-    expect((job.options as { singletonKey?: string }).singletonKey).toBe(
-      `force-deep-${channelKey}-${u.id}`,
-    );
+    expect(outboxRow.options).toMatchObject({
+      singletonKey: `force-deep-${channelKey}-${u.id}`,
+    });
+
+    // Reconstruct the would-be pg-boss job data shape for the next
+    // half: pass it directly into handleBackfillChannel so we don't
+    // depend on the forwarder running.
+    const jobData = outboxRow.payload as Parameters<typeof handleBackfillChannel>[0]["data"];
 
     // Half 2 — invoke the handler with the captured job. Seed a historical
     // event so the success path runs (the historical-flow upgrade lives in
@@ -486,7 +506,7 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
 
     await handleBackfillChannel({
       id: "mock-job-quota-c",
-      data: job.data as Parameters<typeof handleBackfillChannel>[0]["data"],
+      data: jobData,
     });
 
     expect(pollContentCalls).toHaveLength(1);
@@ -685,20 +705,31 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
     ).toBe(null);
   });
 
-  it("(g) PATCH widen + boss.send fails → UPDATE rolled back, backfillTargetSince stays at OLD value (atomicity-of-intent, PR #31 P2)", async () => {
-    // Pre-fix the UPDATE ran BEFORE the force-deep enqueue. On boss.send
-    // failure, data_sources.backfill_target_since was committed but the
-    // force-deep job was lost — and the retry path was a no-op because
-    // maybeEnqueueForceDeepWalk's "newTarget >= previousTarget" early
-    // return short-circuited when the user re-PATCHed with the same
-    // (already-widened) value. Permanent silent loss of the deep-walk
-    // intent. PR #31 review P2.
+  it("(g) PATCH widen via outbox: UPDATE and force-deep intent commit atomically; boss never reached at request time (PR #31 Codex P2)", async () => {
+    // Pre-outbox the PATCH path called boss.send directly inside
+    // updateSource. Two failure modes existed in succession:
+    //   (i)  pre-Option-G: UPDATE-then-send → boss.send failure
+    //        committed the widen but lost the force-deep intent
+    //        forever (re-PATCH with the same target was a no-op).
+    //   (ii) Option-G: send-then-UPDATE → race window between
+    //        boss.send NOTIFY (worker pickup <10ms) and the
+    //        subsequent UPDATE commit (~15-25ms). Worker reads
+    //        pre-UPDATE subscriber state, fan-out filters old events
+    //        out, silent loss.
     //
-    // Post-fix the enqueue runs BEFORE the UPDATE: a throw from
-    // boss.send propagates up, the UPDATE never runs, the user sees a
-    // 5xx, retries, and on the retry the force-deep enqueue is
-    // attempted again — eventually succeeds. This test pins the
-    // happy-failure semantic.
+    // Post-outbox the PATCH path writes the force-deep intent to the
+    // `outbox` table inside the same Drizzle transaction as the
+    // data_sources UPDATE. boss.send is NOT called at request time —
+    // the asynchronous forwarder picks the row up and dispatches.
+    // Atomicity comes from the transaction, not from any
+    // boss-vs-DB ordering trick.
+    //
+    // This test pins the new semantic:
+    //   - PATCH returns 200.
+    //   - data_sources.backfillTargetSince is updated.
+    //   - An outbox row exists with the expected force-deep payload.
+    //   - The pg-boss mock saw ZERO sends at request time (the
+    //     forwarder is not started in this test).
     const channelKey = newChannelKey();
     await clearChannelFixture(channelKey);
 
@@ -722,8 +753,6 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
       .set({ backfillTargetSince: thirtyDaysAgo })
       .where(eq(dataSources.id, src.id));
 
-    // Seed channel state so maybeEnqueueForceDeepWalk's conditions hold
-    // (complete=true + oldest=30d-ago + newTarget=epoch < oldest).
     await db
       .insert(dataSourceChannelState)
       .values({
@@ -742,7 +771,6 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
       });
 
     sentJobs.length = 0;
-    bossSendShouldThrow = true;
 
     const patchRes = await app.request(`/api/sources/${src.id}`, {
       method: "PATCH",
@@ -753,45 +781,169 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
       body: JSON.stringify({ backfillTargetSince: "1970-01-01T00:00:00.000Z" }),
     });
 
-    // boss.send failure surfaces as a 5xx (internal_server_error or similar).
-    expect(patchRes.status).toBeGreaterThanOrEqual(500);
-    expect(patchRes.status).toBeLessThan(600);
+    expect(patchRes.status).toBe(200);
 
-    // Critical assertion — UPDATE rolled back (never committed).
-    // backfillTargetSince must STILL be the pre-PATCH value.
+    // The UPDATE committed.
     const [reloaded] = await db
       .select({ backfillTargetSince: dataSources.backfillTargetSince })
       .from(dataSources)
       .where(eq(dataSources.id, src.id));
-    expect(reloaded).toBeDefined();
-    expect(reloaded!.backfillTargetSince?.getTime()).toBe(thirtyDaysAgo.getTime());
+    expect(reloaded!.backfillTargetSince?.getTime()).toBe(new Date(0).getTime());
 
-    // No job in queue (boss.send threw before capturing).
+    // The outbox row exists with the expected payload — proves atomic
+    // commit alongside the UPDATE.
+    const outboxRows = await db.execute(sql`
+      SELECT queue, payload, options, forwarded_at
+      FROM outbox
+      WHERE queue = 'youtube.backfill.channel'
+        AND payload->>'channelKey' = ${channelKey}
+        AND payload->>'triggerUserId' = ${u.id}
+      ORDER BY created_at DESC
+      LIMIT 1
+    `);
+    expect(outboxRows.rows.length).toBe(1);
+    const row = outboxRows.rows[0] as {
+      payload: Record<string, unknown>;
+      options: Record<string, unknown>;
+      forwarded_at: Date | null;
+    };
+    expect(row.payload).toMatchObject({
+      kind: "youtube_channel",
+      channelKey,
+      triggerUserId: u.id,
+      depthBoundIso: "1970-01-01T00:00:00.000Z",
+      flow: "historical",
+      forceDeep: true,
+    });
+    expect(row.options).toMatchObject({
+      singletonKey: `force-deep-${channelKey}-${u.id}`,
+    });
+    // Forwarder not started in this test — row stays pending.
+    expect(row.forwarded_at).toBeNull();
+
+    // boss.send NOT called at request time. The forwarder is the only
+    // path that touches pg-boss for force-deep intents.
     expect(sentJobs.filter((j) => j.queue === "youtube.backfill.channel")).toHaveLength(0);
 
-    // Retry path — disable the failure injection, retry the same PATCH.
+    // Cleanup — drop the outbox row so it does not leak across tests.
+    await db.execute(sql`DELETE FROM outbox WHERE payload->>'channelKey' = ${channelKey}`);
+  });
+
+  it("(h) outbox forwarder picks up pending row, calls boss.send, marks forwarded_at (idempotent on retry)", async () => {
+    // Drives the forwarder's drainOutboxOnce export to prove the
+    // pending → forwarded transition. boss.send is mocked at the
+    // queue-client layer (see the top-of-file vi.mock); the forwarder
+    // collects via the same mock that records into sentJobs.
+    const { drainOutboxOnce } = await import(
+      "../../src/worker/handlers/outbox-forwarder.js"
+    );
+
+    sentJobs.length = 0;
+
+    const channelKey = newChannelKey();
+    const userId = `forwarder-test-${uniq()}`;
+    const payload = {
+      kind: "youtube_channel",
+      channelKey,
+      triggerUserId: userId,
+      depthBoundIso: "1970-01-01T00:00:00.000Z",
+      flow: "historical",
+      forceDeep: true,
+    };
+    const options = { singletonKey: `force-deep-${channelKey}-${userId}`, priority: 1 };
+
+    // Seed outbox row directly (skipping the PATCH path tested in (g)).
+    await db.execute(sql`
+      INSERT INTO outbox (queue, payload, options)
+      VALUES ('youtube.backfill.channel', ${JSON.stringify(payload)}::jsonb, ${JSON.stringify(options)}::jsonb)
+    `);
+
+    // First drain — should forward exactly once.
+    await drainOutboxOnce();
+    const after1 = await db.execute(sql`
+      SELECT forwarded_at, forwarder_attempt
+      FROM outbox
+      WHERE payload->>'channelKey' = ${channelKey}
+    `);
+    expect(after1.rows.length).toBe(1);
+    const row1 = after1.rows[0] as { forwarded_at: Date | null; forwarder_attempt: number };
+    expect(row1.forwarded_at).not.toBeNull();
+    expect(row1.forwarder_attempt).toBe(0);
+    expect(sentJobs.filter((j) => j.queue === "youtube.backfill.channel")).toHaveLength(1);
+
+    // Second drain — row is forwarded, must NOT be picked up again
+    // (idempotency: at-most-one boss.send per row, modulo crash-replay
+    // which is dedup'd by singletonKey at the pg-boss layer).
+    await drainOutboxOnce();
+    expect(sentJobs.filter((j) => j.queue === "youtube.backfill.channel")).toHaveLength(1);
+
+    // Cleanup.
+    await db.execute(sql`DELETE FROM outbox WHERE payload->>'channelKey' = ${channelKey}`);
+  });
+
+  it("(i) outbox forwarder retries on boss.send failure — row stays pending, attempt counter bumps", async () => {
+    const { drainOutboxOnce } = await import(
+      "../../src/worker/handlers/outbox-forwarder.js"
+    );
+
+    sentJobs.length = 0;
+
+    const channelKey = newChannelKey();
+    const userId = `forwarder-retry-${uniq()}`;
+    const payload = {
+      kind: "youtube_channel",
+      channelKey,
+      triggerUserId: userId,
+      depthBoundIso: "1970-01-01T00:00:00.000Z",
+      flow: "historical",
+      forceDeep: true,
+    };
+    const options = { singletonKey: `force-deep-${channelKey}-${userId}`, priority: 1 };
+
+    await db.execute(sql`
+      INSERT INTO outbox (queue, payload, options)
+      VALUES ('youtube.backfill.channel', ${JSON.stringify(payload)}::jsonb, ${JSON.stringify(options)}::jsonb)
+    `);
+
+    // Inject boss.send failure on the first drain.
+    bossSendShouldThrow = true;
+    await drainOutboxOnce();
+
+    const afterFail = await db.execute(sql`
+      SELECT forwarded_at, forwarder_attempt, last_error
+      FROM outbox
+      WHERE payload->>'channelKey' = ${channelKey}
+    `);
+    expect(afterFail.rows.length).toBe(1);
+    const r1 = afterFail.rows[0] as {
+      forwarded_at: Date | null;
+      forwarder_attempt: number;
+      last_error: string | null;
+    };
+    // Row stays pending — boss.send threw, forwarded_at NOT set.
+    expect(r1.forwarded_at).toBeNull();
+    expect(r1.forwarder_attempt).toBe(1);
+    expect(r1.last_error).toContain("simulated transient failure");
+    // boss.send was attempted but threw before sentJobs captured it.
+    expect(sentJobs.filter((j) => j.queue === "youtube.backfill.channel")).toHaveLength(0);
+
+    // Disable the failure injection, drain again — second attempt succeeds.
     bossSendShouldThrow = false;
-    const retry = await app.request(`/api/sources/${src.id}`, {
-      method: "PATCH",
-      headers: {
-        cookie: `neotolis.session_token=${u.signedSessionCookieValue}`,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({ backfillTargetSince: "1970-01-01T00:00:00.000Z" }),
-    });
-    expect(retry.status).toBe(200);
+    await drainOutboxOnce();
 
-    // On retry, force-deep enqueue ran successfully.
-    const enqueues = sentJobs.filter((j) => j.queue === "youtube.backfill.channel");
-    expect(enqueues).toHaveLength(1);
-    expect(enqueues[0]!.data).toMatchObject({ forceDeep: true });
+    const afterRetry = await db.execute(sql`
+      SELECT forwarded_at, forwarder_attempt
+      FROM outbox
+      WHERE payload->>'channelKey' = ${channelKey}
+    `);
+    const r2 = afterRetry.rows[0] as { forwarded_at: Date | null; forwarder_attempt: number };
+    expect(r2.forwarded_at).not.toBeNull();
+    // The successful retry left forwarder_attempt at 1 (we don't bump on success).
+    expect(r2.forwarder_attempt).toBe(1);
+    expect(sentJobs.filter((j) => j.queue === "youtube.backfill.channel")).toHaveLength(1);
 
-    // And the UPDATE finally committed.
-    const [final] = await db
-      .select({ backfillTargetSince: dataSources.backfillTargetSince })
-      .from(dataSources)
-      .where(eq(dataSources.id, src.id));
-    expect(final!.backfillTargetSince?.getTime()).toBe(new Date(0).getTime());
+    // Cleanup.
+    await db.execute(sql`DELETE FROM outbox WHERE payload->>'channelKey' = ${channelKey}`);
   });
 
   it("(f) empty + MAX_PAGES (endOfPlaylist=false, nextPageToken defined) → backfill_complete UNCHANGED, token PRESERVED for resume", async () => {

--- a/tests/integration/refresh-content-quota.test.ts
+++ b/tests/integration/refresh-content-quota.test.ts
@@ -54,6 +54,10 @@ const pollContentCalls: { since: Date }[] = [];
 let pollContentResults: RawEventStub[] = [];
 let pollContentEndOfPlaylist = false;
 let pollContentUnitsUsed = 1;
+// Phase 03.0.3 follow-up — tests (d)/(e)/(f) below toggle this to simulate
+// the three distinct empty-result shapes the walker can produce
+// (MAX_PAGES, walkedPastSince, endOfPlaylist).
+let pollContentNextPageToken: string | undefined = undefined;
 
 vi.mock("../../src/lib/sources/youtube/server/adapter.js", async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
@@ -68,6 +72,7 @@ vi.mock("../../src/lib/sources/youtube/server/adapter.js", async (importOriginal
           events: pollContentResults.slice(),
           unitsUsed: pollContentUnitsUsed,
           endOfPlaylist: pollContentEndOfPlaylist,
+          nextPageToken: pollContentNextPageToken,
         };
       },
     },
@@ -112,6 +117,7 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
     pollContentResults = [];
     pollContentEndOfPlaylist = false;
     pollContentUnitsUsed = 1;
+    pollContentNextPageToken = undefined;
   });
 
   it("(a) repeated click within 5min on a steady-state channel costs ≤1 page (not N/50 pages)", async () => {
@@ -575,5 +581,161 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
 
     const enqueues = sentJobs.filter((j) => j.queue === "youtube.backfill.channel");
     expect(enqueues).toHaveLength(0);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Phase 03.0.3 follow-up (external code review P1 #2) — empty-result
+  // state transitions. Pre-fix, ANY empty result with unitsUsed > 0
+  // marked the channel backfill_complete=true, conflating three distinct
+  // shapes the walker can produce. Tests (d)/(e)/(f) below pin all three.
+  // ─────────────────────────────────────────────────────────────────────
+
+  it("(d) empty + endOfPlaylist=true → backfill_complete=true, token cleared (genuine exhaustion)", async () => {
+    const channelKey = newChannelKey();
+    await clearChannelFixture(channelKey);
+
+    const u = await seedUserDirectly({ email: `quota-d-${uniq()}@test.local` });
+    const src = await createSource(
+      u.id,
+      {
+        kind: "youtube_channel",
+        handleUrl: `https://www.youtube.com/channel/${channelKey}`,
+        isOwnedByMe: true,
+        autoImport: true,
+      },
+      "127.0.0.1",
+    );
+    await db
+      .update(dataSources)
+      .set({ backfillTargetSince: new Date(0) })
+      .where(eq(dataSources.id, src.id));
+
+    // No prior state — first walk ever. Branch resolves to "deep"
+    // (deepestWalked === null && !backfillComplete).
+    pollContentResults = [];
+    pollContentUnitsUsed = 1;
+    pollContentEndOfPlaylist = true;
+    pollContentNextPageToken = undefined;
+
+    await handleBackfillChannel({
+      id: "mock-job-quota-d",
+      data: {
+        kind: "youtube_channel",
+        channelKey,
+        triggerUserId: u.id,
+        depthBoundIso: new Date(0).toISOString(),
+        flow: "incremental",
+      },
+    });
+
+    const state = await getChannelState("youtube_channel", channelKey);
+    expect(state).toBeDefined();
+    expect(state!.backfillComplete).toBe(true);
+    expect((state!.metadata as { lastBackfillPageToken?: string } | null)?.lastBackfillPageToken ?? null).toBe(
+      null,
+    );
+  });
+
+  it("(e) empty + walkedPastSince (endOfPlaylist=false, no nextPageToken) → backfill_complete UNCHANGED, token cleared", async () => {
+    // Pre-fix bug: a deep walk on a channel with no uploads in the
+    // requested 30d window would mark the channel complete=true after
+    // a single empty page, and auto-backfill would never revisit even
+    // when the user later widened the target. Test pins the fix: empty
+    // result with walkedPastSince does NOT set the complete flag.
+    const channelKey = newChannelKey();
+    await clearChannelFixture(channelKey);
+
+    const u = await seedUserDirectly({ email: `quota-e-${uniq()}@test.local` });
+    const src = await createSource(
+      u.id,
+      {
+        kind: "youtube_channel",
+        handleUrl: `https://www.youtube.com/channel/${channelKey}`,
+        isOwnedByMe: true,
+        autoImport: true,
+      },
+      "127.0.0.1",
+    );
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 86_400_000);
+    await db
+      .update(dataSources)
+      .set({ backfillTargetSince: thirtyDaysAgo })
+      .where(eq(dataSources.id, src.id));
+
+    // No prior state — but explicitly NOT exhausted. Walker mock returns
+    // empty + endOfPlaylist=false + no nextPageToken = walkedPastSince.
+    pollContentResults = [];
+    pollContentUnitsUsed = 1;
+    pollContentEndOfPlaylist = false;
+    pollContentNextPageToken = undefined;
+
+    await handleBackfillChannel({
+      id: "mock-job-quota-e",
+      data: {
+        kind: "youtube_channel",
+        channelKey,
+        triggerUserId: u.id,
+        depthBoundIso: thirtyDaysAgo.toISOString(),
+        flow: "incremental",
+      },
+    });
+
+    const state = await getChannelState("youtube_channel", channelKey);
+    expect(state).toBeDefined();
+    // Critical: NOT marked complete. Channel may have older history past
+    // the 30d window; next widen-target click must be able to deep-walk.
+    expect(state!.backfillComplete).toBe(false);
+    expect((state!.metadata as { lastBackfillPageToken?: string } | null)?.lastBackfillPageToken ?? null).toBe(
+      null,
+    );
+  });
+
+  it("(f) empty + MAX_PAGES (endOfPlaylist=false, nextPageToken defined) → backfill_complete UNCHANGED, token PRESERVED for resume", async () => {
+    // Walker hit the 20-page hard cap with zero new items collected
+    // (e.g. cache is fully populated for these 20 pages in overlap
+    // mode, but the channel has more history below). Resume cursor
+    // must survive so the next walk picks up from page 21.
+    const channelKey = newChannelKey();
+    await clearChannelFixture(channelKey);
+
+    const u = await seedUserDirectly({ email: `quota-f-${uniq()}@test.local` });
+    const src = await createSource(
+      u.id,
+      {
+        kind: "youtube_channel",
+        handleUrl: `https://www.youtube.com/channel/${channelKey}`,
+        isOwnedByMe: true,
+        autoImport: true,
+      },
+      "127.0.0.1",
+    );
+    await db
+      .update(dataSources)
+      .set({ backfillTargetSince: new Date(0) })
+      .where(eq(dataSources.id, src.id));
+
+    pollContentResults = [];
+    pollContentUnitsUsed = 20;
+    pollContentEndOfPlaylist = false;
+    pollContentNextPageToken = "RESUME_AT_PAGE_21";
+
+    await handleBackfillChannel({
+      id: "mock-job-quota-f",
+      data: {
+        kind: "youtube_channel",
+        channelKey,
+        triggerUserId: u.id,
+        depthBoundIso: new Date(0).toISOString(),
+        flow: "incremental",
+      },
+    });
+
+    const state = await getChannelState("youtube_channel", channelKey);
+    expect(state).toBeDefined();
+    expect(state!.backfillComplete).toBe(false);
+    // Resume cursor survives so the next click continues the walk.
+    expect((state!.metadata as { lastBackfillPageToken?: string } | null)?.lastBackfillPageToken).toBe(
+      "RESUME_AT_PAGE_21",
+    );
   });
 });

--- a/tests/integration/refresh-content-quota.test.ts
+++ b/tests/integration/refresh-content-quota.test.ts
@@ -834,9 +834,7 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
     // pending → forwarded transition. boss.send is mocked at the
     // queue-client layer (see the top-of-file vi.mock); the forwarder
     // collects via the same mock that records into sentJobs.
-    const { drainOutboxOnce } = await import(
-      "../../src/worker/handlers/outbox-forwarder.js"
-    );
+    const { drainOutboxOnce } = await import("../../src/worker/handlers/outbox-forwarder.js");
 
     sentJobs.length = 0;
 
@@ -882,9 +880,7 @@ describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
   });
 
   it("(i) outbox forwarder retries on boss.send failure — row stays pending, attempt counter bumps", async () => {
-    const { drainOutboxOnce } = await import(
-      "../../src/worker/handlers/outbox-forwarder.js"
-    );
+    const { drainOutboxOnce } = await import("../../src/worker/handlers/outbox-forwarder.js");
 
     sentJobs.length = 0;
 

--- a/tests/integration/refresh-content-quota.test.ts
+++ b/tests/integration/refresh-content-quota.test.ts
@@ -1,0 +1,61 @@
+// Phase 03.0.3 P1 — refresh-content quota-burn invariants (issue #29).
+//
+// 3 behavioural tests verbatim from CONTEXT D-C1:
+//   (a) repeated click within 5min on a steady-state channel costs ≤1 page
+//       (not N/50 pages) — branch="exhausted".
+//   (b) backdated upload (publishedAt < newestKnown but > prior session) is
+//       collected on the next click — branch="incremental".
+//   (c) widening backfillTargetSince (30d → epoch) triggers deep walk on
+//       next refresh-content click — branch="deep" (no eager reset; D-#29-6).
+//
+// Live bodies land in Task 5 of plan 03.0.3-01. Wave 0 scaffold: 3 it.skip
+// placeholders verbatim with the test names from issue #29 / D-C1.
+
+import { describe, it, vi } from "vitest";
+
+const sentJobs: Array<{
+  queue: string;
+  data: Record<string, unknown>;
+  options: Record<string, unknown>;
+}> = [];
+
+vi.mock("../../src/lib/server/queue-client.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    getBoss: async () => ({
+      send: async (
+        queue: string,
+        data: Record<string, unknown>,
+        options: Record<string, unknown>,
+      ) => {
+        sentJobs.push({ queue, data, options });
+        return "mock-job-id";
+      },
+    }),
+  };
+});
+
+describe("refresh-content quota burn — Phase 03.0.3 P1 (issue #29)", () => {
+  it.skip(
+    "(a) repeated click within 5min on a steady-state channel costs ≤1 page (not N/50 pages)",
+    () => {
+      // Live body lands in Task 5 — exercises branch="exhausted".
+    },
+  );
+
+  it.skip(
+    "(b) backdated upload (publishedAt < newestKnown but > prior session) is collected on the next click",
+    () => {
+      // Live body lands in Task 5 — exercises branch="incremental".
+    },
+  );
+
+  it.skip(
+    "(c) widening backfillTargetSince (30d → epoch) triggers deep walk on next refresh-content click",
+    () => {
+      // Live body lands in Task 5 — exercises branch="deep" and D-#29-6
+      // (no eager state reset on PATCH).
+    },
+  );
+});

--- a/tests/integration/scheduler-enqueue.test.ts
+++ b/tests/integration/scheduler-enqueue.test.ts
@@ -142,14 +142,48 @@ describe("youtube.poll.cron tier-eligibility (Plan 03.0.1-07 + per-video refacto
     expect(pollStatsCalls[0]!.quotaUser).toBe("neotolis-svc-cold");
   });
 
-  it("Frozen videos (publishedAt > 28d) are NOT polled by either tier handler", async () => {
+  it("Frozen videos that have already been polled (publishedAt > 28d, lastPolledAt set) are NOT polled by either tier handler", async () => {
     const u = await seedUserDirectly({ email: `sch-frozen-${uniq()}@test.local` });
     const longAgo = new Date(Date.now() - 35 * 86_400_000);
-    const { videoId } = await insertEventWithVideo(u.id, longAgo);
+    // Phase 03.0.3 follow-up — the bootstrap rule promotes frozen-by-age
+    // videos with lastPolledAt=NULL to cold for ONE shot. To pin the
+    // dormant path (already-polled video stays frozen forever), seed an
+    // explicit lastPolledAt timestamp.
+    const { videoId } = await insertEventWithVideo(u.id, longAgo, {
+      videoOverrides: { lastPolledAt: new Date(Date.now() - 86_400_000) },
+    });
 
     await handlePollActive({ id: "test", data: { tier: "active" } });
     await handlePollCold({ id: "test", data: { tier: "cold" } });
 
+    const allPolledIds = pollStatsCalls.flatMap((c) => c.videoIds);
+    expect(allPolledIds).not.toContain(videoId);
+  });
+
+  it("Frozen videos that have NEVER been polled (publishedAt > 28d, lastPolledAt IS NULL) ARE polled once by cold tier (Phase 03.0.3 bootstrap)", async () => {
+    const u = await seedUserDirectly({ email: `sch-frozen-bootstrap-${uniq()}@test.local` });
+    const longAgo = new Date(Date.now() - 35 * 86_400_000);
+    // No videoOverrides — youtube_videos.last_polled_at column defaults
+    // to NULL. The bootstrap rule (resolveTier line: frozen + lastPolledAt
+    // === null → cold) makes this video eligible for handlePollCold's
+    // selectEligibleVideoIds query.
+    const { videoId } = await insertEventWithVideo(u.id, longAgo);
+
+    await handlePollCold({ id: "test", data: { tier: "cold" } });
+
+    const allPolledIds = pollStatsCalls.flatMap((c) => c.videoIds);
+    expect(allPolledIds).toContain(videoId);
+  });
+
+  it("Bootstrap is dormant on active tier — never-polled active videos still classify as active, NOT cold (no double-poll across both crons)", async () => {
+    const u = await seedUserDirectly({ email: `sch-active-bootstrap-${uniq()}@test.local` });
+    const recent = new Date(Date.now() - 12 * 60 * 60 * 1000); // 12h ago — active
+    const { videoId } = await insertEventWithVideo(u.id, recent);
+
+    await handlePollCold({ id: "test", data: { tier: "cold" } });
+
+    // handlePollCold's eligibility filter must reject this video — it's
+    // active-tier by age and the bootstrap rule only fires for frozen.
     const allPolledIds = pollStatsCalls.flatMap((c) => c.videoIds);
     expect(allPolledIds).not.toContain(videoId);
   });

--- a/tests/integration/youtube-adapter-walker-overlap.test.ts
+++ b/tests/integration/youtube-adapter-walker-overlap.test.ts
@@ -1,0 +1,250 @@
+// Phase 03.0.3 follow-up — D-#29-1 backdated-upload safety, adapter-level.
+//
+// Pre-fix, youtubeChannelAdapter.pollContent dropped every item with
+// publishedAt <= since (the `walkedPastSince = true; continue` branch).
+// Test (b) in refresh-content-quota.test.ts mocked pollContent so the
+// drop was never exercised end-to-end; this file drives the REAL walker
+// against a fixture playlistItems.list response with chargedFetch
+// stubbed at the HTTP boundary (not at the adapter boundary).
+//
+// Two scenarios pinned here:
+//   1. walkStop="depth" (legacy / cron / deep branch) — items with
+//      publishedAt <= since ARE dropped. Existing unit tests already
+//      cover this in isolation; we keep one assertion here to make the
+//      contrast explicit alongside the overlap-mode test.
+//   2. walkStop="overlap" (Phase 03.0.3 incremental / exhausted branches)
+//      — items with publishedAt <= since are dropped ONLY when they are
+//      ALSO in the youtube_videos cache. A backdated upload (publishedAt
+//      far in the past, NOT in the cache) survives the walk.
+//
+// Stop-after-overlap: after OVERLAP_THRESHOLD=3 consecutive cached-and-
+// past-since items, the walker breaks early. Single-item gaps (one
+// re-upload sitting between unknown items) do NOT terminate the walk.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { and, eq, inArray } from "drizzle-orm";
+
+vi.mock("../../src/lib/sources/youtube/server/quota.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    pickKeyForJob: async () => ({ apiKey: "TEST_KEY", apiKeyId: "test-walker-key" }),
+    youtubeQuotaUser: () => "test-walker-quota-user",
+  };
+});
+
+interface CapturedCall {
+  url: URL;
+}
+const fetchCalls: CapturedCall[] = [];
+let fetchResponder: (url: URL) => Response = () =>
+  new Response(JSON.stringify({ items: [] }), { status: 200 });
+
+vi.mock("../../src/lib/sources/youtube/server/http.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    chargedFetch: async (url: URL): Promise<Response> => {
+      fetchCalls.push({ url });
+      return fetchResponder(url);
+    },
+  };
+});
+
+const { db } = await import("../../src/lib/server/db/client.js");
+const { youtubeVideos } = await import("../../src/lib/sources/youtube/server/schema/index.js");
+const { youtubeChannelAdapterCore } = await import(
+  "../../src/lib/sources/youtube/server/adapter.js"
+);
+
+const uniq = (): string => Math.random().toString(36).slice(2, 10);
+
+interface FixtureItem {
+  videoId: string;
+  publishedAt: string;
+  title?: string;
+}
+
+function playlistResponse(items: FixtureItem[], nextPageToken?: string): Response {
+  return new Response(
+    JSON.stringify({
+      kind: "youtube#playlistItemListResponse",
+      ...(nextPageToken ? { nextPageToken } : {}),
+      items: items.map((it) => ({
+        snippet: {
+          publishedAt: it.publishedAt,
+          title: it.title ?? `Title ${it.videoId}`,
+          channelId: "UCFIXTURE",
+          resourceId: { videoId: it.videoId, kind: "youtube#video" },
+        },
+      })),
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+async function seedYoutubeVideos(rows: Array<{ videoId: string; publishedAt: Date }>): Promise<void> {
+  for (const r of rows) {
+    await db
+      .insert(youtubeVideos)
+      .values({
+        videoId: r.videoId,
+        title: `Cached ${r.videoId}`,
+        channelId: "UCFIXTURE",
+        publishedAt: r.publishedAt,
+        fetchedAt: new Date(),
+      })
+      .onConflictDoNothing();
+  }
+}
+
+async function clearFixtures(prefix: string): Promise<void> {
+  await db.delete(youtubeVideos).where(eq(youtubeVideos.channelId, "UCFIXTURE"));
+  // Defensive — clear any specific prefix the test seeded directly.
+  const rows = await db
+    .select({ videoId: youtubeVideos.videoId })
+    .from(youtubeVideos)
+    .where(and(inArray(youtubeVideos.videoId, [prefix])));
+  if (rows.length > 0) {
+    await db.delete(youtubeVideos).where(inArray(youtubeVideos.videoId, [prefix]));
+  }
+}
+
+describe("youtubeChannelAdapterCore.pollContent — D-#29-1 backdated-upload safety", () => {
+  beforeEach(async () => {
+    fetchCalls.length = 0;
+    fetchResponder = () => new Response(JSON.stringify({ items: [] }), { status: 200 });
+    await clearFixtures("");
+  });
+
+  it("walkStop='depth' drops items publishedAt <= since (legacy / deep branch behavior)", async () => {
+    const now = Date.now();
+    const since = new Date(now - 7 * 86_400_000); // 7d ago
+    const playlist: FixtureItem[] = [
+      { videoId: `wd_new1_${uniq()}`, publishedAt: new Date(now - 86_400_000).toISOString() }, // 1d ago — after since → collect
+      { videoId: `wd_old1_${uniq()}`, publishedAt: new Date(now - 10 * 86_400_000).toISOString() }, // 10d ago — before since → drop
+    ];
+    fetchResponder = () => playlistResponse(playlist);
+
+    const result = await youtubeChannelAdapterCore.pollContent(
+      {
+        id: "UCFIXTURE",
+        userId: "user-test-walker",
+        metadata: { uploadsPlaylistId: "UUFIXTURE", channelId: "UCFIXTURE" },
+      },
+      since,
+      { origin: "user", walkStop: "depth" },
+    );
+
+    expect(result.events.map((e) => e.externalId)).toEqual([playlist[0]!.videoId]);
+    // walkedPastSince triggered → nextPageToken cleared (undefined).
+    expect(result.nextPageToken).toBeUndefined();
+  });
+
+  it("walkStop='overlap' KEEPS backdated cache-miss items (D-#29-1 invariant)", async () => {
+    const now = Date.now();
+    const since = new Date(now); // since = "newestKnown" = now (incremental branch shape)
+    const backdatedId = `ov_backdated_${uniq()}`;
+    const new1Id = `ov_new1_${uniq()}`;
+    const playlist: FixtureItem[] = [
+      // Page order = upload order DESC. Both items uploaded recently.
+      { videoId: new1Id, publishedAt: new Date(now - 60_000).toISOString() }, // 60s ago
+      { videoId: backdatedId, publishedAt: new Date(now - 90 * 86_400_000).toISOString() }, // 90d ago — past since but NOT in cache
+    ];
+    fetchResponder = () => playlistResponse(playlist);
+
+    const result = await youtubeChannelAdapterCore.pollContent(
+      {
+        id: "UCFIXTURE",
+        userId: "user-test-walker",
+        metadata: { uploadsPlaylistId: "UUFIXTURE", channelId: "UCFIXTURE" },
+      },
+      since,
+      { origin: "user", walkStop: "overlap" },
+    );
+
+    // BOTH items collected: new1 (publishedAt > since irrelevant in overlap mode)
+    // AND backdated (publishedAt past since but cache-miss).
+    expect(result.events.map((e) => e.externalId).sort()).toEqual([backdatedId, new1Id].sort());
+  });
+
+  it("walkStop='overlap' stops after OVERLAP_THRESHOLD=3 consecutive cached+past-since items", async () => {
+    const now = Date.now();
+    const since = new Date(now);
+    // Seed cache with 3 known videos all dated in the past.
+    const known1 = `ov_k1_${uniq()}`;
+    const known2 = `ov_k2_${uniq()}`;
+    const known3 = `ov_k3_${uniq()}`;
+    const known4 = `ov_k4_${uniq()}`;
+    await seedYoutubeVideos([
+      { videoId: known1, publishedAt: new Date(now - 86_400_000) },
+      { videoId: known2, publishedAt: new Date(now - 2 * 86_400_000) },
+      { videoId: known3, publishedAt: new Date(now - 3 * 86_400_000) },
+      { videoId: known4, publishedAt: new Date(now - 4 * 86_400_000) },
+    ]);
+
+    const new1 = `ov_n1_${uniq()}`;
+    const playlist: FixtureItem[] = [
+      { videoId: new1, publishedAt: new Date(now - 60_000).toISOString() },
+      { videoId: known1, publishedAt: new Date(now - 86_400_000).toISOString() },
+      { videoId: known2, publishedAt: new Date(now - 2 * 86_400_000).toISOString() },
+      { videoId: known3, publishedAt: new Date(now - 3 * 86_400_000).toISOString() },
+      // The 4th known would only be reached if the walker did NOT stop after 3.
+      { videoId: known4, publishedAt: new Date(now - 4 * 86_400_000).toISOString() },
+    ];
+    fetchResponder = () => playlistResponse(playlist);
+
+    const result = await youtubeChannelAdapterCore.pollContent(
+      {
+        id: "UCFIXTURE",
+        userId: "user-test-walker",
+        metadata: { uploadsPlaylistId: "UUFIXTURE", channelId: "UCFIXTURE" },
+      },
+      since,
+      { origin: "user", walkStop: "overlap" },
+    );
+
+    // Only new1 collected. known1/known2/known3 hit the overlap threshold;
+    // known4 is never even seen by the per-item loop (walker breaks at known3).
+    expect(result.events.map((e) => e.externalId)).toEqual([new1]);
+    // walkedPastSince → nextPageToken cleared.
+    expect(result.nextPageToken).toBeUndefined();
+  });
+
+  it("walkStop='overlap' does NOT stop on single-item gaps (counter resets on unknown)", async () => {
+    const now = Date.now();
+    const since = new Date(now);
+    const known1 = `ov_g_k1_${uniq()}`;
+    const known2 = `ov_g_k2_${uniq()}`;
+    await seedYoutubeVideos([
+      { videoId: known1, publishedAt: new Date(now - 86_400_000) },
+      { videoId: known2, publishedAt: new Date(now - 3 * 86_400_000) },
+    ]);
+
+    const new1 = `ov_g_n1_${uniq()}`;
+    const new2 = `ov_g_n2_${uniq()}`;
+    // Pattern: known, known, NEW (gap), known, known — counter resets at NEW,
+    // so 2 known + 1 new + 2 known = walker should NOT have hit the threshold,
+    // continues to endOfPlaylist.
+    const playlist: FixtureItem[] = [
+      { videoId: known1, publishedAt: new Date(now - 86_400_000).toISOString() },
+      { videoId: known2, publishedAt: new Date(now - 3 * 86_400_000).toISOString() },
+      { videoId: new1, publishedAt: new Date(now - 50 * 86_400_000).toISOString() }, // backdated, not cached
+      { videoId: new2, publishedAt: new Date(now - 51 * 86_400_000).toISOString() }, // backdated, not cached
+    ];
+    fetchResponder = () => playlistResponse(playlist);
+
+    const result = await youtubeChannelAdapterCore.pollContent(
+      {
+        id: "UCFIXTURE",
+        userId: "user-test-walker",
+        metadata: { uploadsPlaylistId: "UUFIXTURE", channelId: "UCFIXTURE" },
+      },
+      since,
+      { origin: "user", walkStop: "overlap" },
+    );
+
+    // new1 and new2 both collected — the cache-miss gap reset the counter.
+    expect(result.events.map((e) => e.externalId).sort()).toEqual([new1, new2].sort());
+  });
+});

--- a/tests/integration/youtube-adapter-walker-overlap.test.ts
+++ b/tests/integration/youtube-adapter-walker-overlap.test.ts
@@ -53,9 +53,8 @@ vi.mock("../../src/lib/sources/youtube/server/http.js", async (importOriginal) =
 
 const { db } = await import("../../src/lib/server/db/client.js");
 const { youtubeVideos } = await import("../../src/lib/sources/youtube/server/schema/index.js");
-const { youtubeChannelAdapterCore } = await import(
-  "../../src/lib/sources/youtube/server/adapter.js"
-);
+const { youtubeChannelAdapterCore } =
+  await import("../../src/lib/sources/youtube/server/adapter.js");
 
 const uniq = (): string => Math.random().toString(36).slice(2, 10);
 
@@ -83,7 +82,9 @@ function playlistResponse(items: FixtureItem[], nextPageToken?: string): Respons
   );
 }
 
-async function seedYoutubeVideos(rows: Array<{ videoId: string; publishedAt: Date }>): Promise<void> {
+async function seedYoutubeVideos(
+  rows: Array<{ videoId: string; publishedAt: Date }>,
+): Promise<void> {
   for (const r of rows) {
     await db
       .insert(youtubeVideos)

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -10,8 +10,21 @@ import pg from "pg";
 // Plan 01-03 has landed `src/lib/server/db/migrate.ts`; if migrations fail (e.g. no Postgres
 // reachable), the catch logs a warn so contributors understand why integration tests
 // skip-with-context.
+//
+// Phase 03.0.3 UAT follow-up — env-routing fix. Pre-fix the truncate pool
+// used TEST_DATABASE_URL while the Drizzle `db` client in
+// src/lib/server/db/client.ts read DATABASE_URL. On a developer machine
+// where DATABASE_URL points to the local production-data database, every
+// integration test wrote fixtures (`view=1/like=0/comment=0`, mocked
+// `vid_*` external_ids) into prod data and the afterEach TRUNCATE bit
+// the wrong DB. Force the Drizzle client to share the same DB as this
+// setup file by overwriting DATABASE_URL BEFORE any test imports
+// transitively pull in $lib/server/config/env.ts (which Zod-validates the
+// value at module-load time). vitest setupFiles run before test files,
+// so this assignment is in scope for every test process.
 const dbUrl =
   process.env.TEST_DATABASE_URL ?? "postgres://postgres:postgres@localhost:5432/neotolis_test";
+process.env.DATABASE_URL = dbUrl;
 
 export const pool = new pg.Pool({ connectionString: dbUrl, max: 5 });
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -29,12 +29,23 @@ process.env.DATABASE_URL = dbUrl;
 export const pool = new pg.Pool({ connectionString: dbUrl, max: 5 });
 
 beforeAll(async () => {
-  try {
-    const { runMigrations } = await import("../src/lib/server/db/migrate.js");
-    await runMigrations();
-  } catch (err) {
-    console.warn("[tests/setup] migrations failed:", (err as Error).message);
-  }
+  // Phase 03.0.3 round-3 (Codex P2) — migration failure is no longer
+  // silently warned. Pre-fix this try/catch suppressed both "no Postgres
+  // reachable" (the original intent) AND "schema drift on local
+  // neotolis_test DB" (an accidental side effect). Integration tests
+  // against a half-migrated DB are vacuous-pass at best and silently
+  // wrong at worst; AGENTS.md Validation §4 ("CI gate honesty") forbids
+  // both shapes. We now propagate the failure so:
+  //   - CI sees a clean migration on every run (fresh DB → no drift
+  //     ever surfaces), or fails the integration-tests job loudly.
+  //   - Local dev sees the drift immediately and can resolve it via
+  //     `docker exec <pg-container> psql -U postgres -c 'DROP DATABASE
+  //     neotolis_test;' && pnpm db:migrate` (recreate via the migrate
+  //     helper that runs against TEST_DATABASE_URL).
+  // The "no Postgres" case still surfaces with a clear ECONNREFUSED that
+  // any contributor recognises.
+  const { runMigrations } = await import("../src/lib/server/db/migrate.js");
+  await runMigrations();
 });
 
 afterEach(async () => {

--- a/tests/unit/tier-resolver-client-mirror.test.ts
+++ b/tests/unit/tier-resolver-client-mirror.test.ts
@@ -101,7 +101,12 @@ describe("tier-resolver client mirror — identical results across battery", () 
     // Phase 03.0.3 bootstrap rule — mirror must agree.
     ["bootstrap: frozen-by-age + never polled → cold", ago(30 * 86_400_000), null, null],
     ["bootstrap dormant: frozen-by-age + polled → frozen", ago(30 * 86_400_000), null, ago(1000)],
-    ["bootstrap: override wins (frozen + never + not_found)", ago(30 * 86_400_000), "not_found", null],
+    [
+      "bootstrap: override wins (frozen + never + not_found)",
+      ago(30 * 86_400_000),
+      "not_found",
+      null,
+    ],
   ];
 
   test.each(battery)("%s → mirror === canonical", (_label, published, status, polledAt) => {

--- a/tests/unit/tier-resolver-client-mirror.test.ts
+++ b/tests/unit/tier-resolver-client-mirror.test.ts
@@ -42,6 +42,7 @@ type Tier = "pending" | "active" | "cold" | "frozen" | "unavailable";
 function mirrorResolveTier(
   publishedAt: Date | null,
   lastPollStatus: string | null,
+  lastPolledAt: Date | null,
   now: Date,
 ): Tier {
   if (publishedAt === null) return "pending";
@@ -51,6 +52,8 @@ function mirrorResolveTier(
   const ageMs = now.getTime() - publishedAt.getTime();
   if (ageMs < MIRROR_TIER_BOUNDARY_ACTIVE_MS) return "active";
   if (ageMs < MIRROR_TIER_BOUNDARY_COLD_MS) return "cold";
+  // Phase 03.0.3 follow-up — bootstrap rule mirror.
+  if (lastPolledAt === null) return "cold";
   return "frozen";
 }
 
@@ -75,29 +78,35 @@ describe("tier-resolver client mirror — boundary constants", () => {
 
 describe("tier-resolver client mirror — identical results across battery", () => {
   // Boundary battery — every literal from tests/unit/tier-resolver.test.ts.
-  const battery: Array<[string, Date | null, string | null]> = [
-    ["pending: publishedAt=null", null, null],
-    ["pending: publishedAt=null + status='ok' still pending", null, "ok"],
-    ["pending: publishedAt=null + status='not_found' still pending", null, "not_found"],
-    ["active boundary low (0ms ago)", ago(0), null],
-    ["active boundary high (23h59m59s999ms ago)", ago(86_399_999), null],
-    ["cold boundary low (24h ago)", ago(86_400_000), null],
-    ["cold boundary low+1m (24h1m ago)", ago(86_400_000 + 60_000), null],
-    ["cold boundary high (27d23h59m59s999ms ago)", ago(27 * 86_400_000 + 86_399_999), null],
-    ["frozen boundary (28d ago)", ago(28 * 86_400_000), null],
-    ["frozen boundary +1m (28d1m ago)", ago(28 * 86_400_000 + 60_000), null],
-    ["override not_found", ago(1000), "not_found"],
-    ["override private", ago(1000), "private"],
-    ["override auth_error", ago(1000), "auth_error"],
-    ["override not_found at 28d", ago(28 * 86_400_000), "not_found"],
-    ["non-override 'ok' at active", ago(1000), "ok"],
-    ["non-override 'timeout' at cold", ago(2 * 86_400_000), "timeout"],
-    ["non-override 'ok' at frozen", ago(30 * 86_400_000), "ok"],
+  // lastPolledAt fixed to NOW unless the case specifically exercises the
+  // bootstrap rule (frozen + lastPolledAt=null → cold).
+  const battery: Array<[string, Date | null, string | null, Date | null]> = [
+    ["pending: publishedAt=null", null, null, null],
+    ["pending: publishedAt=null + status='ok' still pending", null, "ok", null],
+    ["pending: publishedAt=null + status='not_found' still pending", null, "not_found", null],
+    ["active boundary low (0ms ago)", ago(0), null, NOW],
+    ["active boundary high (23h59m59s999ms ago)", ago(86_399_999), null, NOW],
+    ["cold boundary low (24h ago)", ago(86_400_000), null, NOW],
+    ["cold boundary low+1m (24h1m ago)", ago(86_400_000 + 60_000), null, NOW],
+    ["cold boundary high (27d23h59m59s999ms ago)", ago(27 * 86_400_000 + 86_399_999), null, NOW],
+    ["frozen boundary (28d ago)", ago(28 * 86_400_000), null, NOW],
+    ["frozen boundary +1m (28d1m ago)", ago(28 * 86_400_000 + 60_000), null, NOW],
+    ["override not_found", ago(1000), "not_found", NOW],
+    ["override private", ago(1000), "private", NOW],
+    ["override auth_error", ago(1000), "auth_error", NOW],
+    ["override not_found at 28d", ago(28 * 86_400_000), "not_found", NOW],
+    ["non-override 'ok' at active", ago(1000), "ok", NOW],
+    ["non-override 'timeout' at cold", ago(2 * 86_400_000), "timeout", NOW],
+    ["non-override 'ok' at frozen", ago(30 * 86_400_000), "ok", NOW],
+    // Phase 03.0.3 bootstrap rule — mirror must agree.
+    ["bootstrap: frozen-by-age + never polled → cold", ago(30 * 86_400_000), null, null],
+    ["bootstrap dormant: frozen-by-age + polled → frozen", ago(30 * 86_400_000), null, ago(1000)],
+    ["bootstrap: override wins (frozen + never + not_found)", ago(30 * 86_400_000), "not_found", null],
   ];
 
-  test.each(battery)("%s → mirror === canonical", (_label, published, status) => {
-    const canonical = canonicalResolveTier(published, status, NOW);
-    const mirror = mirrorResolveTier(published, status, NOW);
+  test.each(battery)("%s → mirror === canonical", (_label, published, status, polledAt) => {
+    const canonical = canonicalResolveTier(published, status, polledAt, NOW);
+    const mirror = mirrorResolveTier(published, status, polledAt, NOW);
     expect(mirror).toBe(canonical);
   });
 });

--- a/tests/unit/tier-resolver.test.ts
+++ b/tests/unit/tier-resolver.test.ts
@@ -44,50 +44,84 @@ describe("resolveTier — boundary table (D-05)", () => {
     ["frozen boundary (28d ago)", ago(28 * 86_400_000), "frozen"],
     ["frozen boundary +1m (28d1m ago)", ago(28 * 86_400_000 + 60_000), "frozen"],
   ] as const)("%s", (_label, published, expected) => {
-    expect(resolveTier(published, null, NOW)).toBe(expected);
+    // Boundary table fixes lastPolledAt to a non-null date so the
+    // bootstrap rule (frozen + lastPolledAt=null → cold) doesn't shadow
+    // the age-by-itself classification. The bootstrap rule has its own
+    // describe block below.
+    expect(resolveTier(published, null, NOW, NOW)).toBe(expected);
   });
 });
 
 describe("resolveTier — pending tier (NULL publishedAt)", () => {
-  test("publishedAt=null → 'pending' regardless of lastPollStatus", () => {
-    expect(resolveTier(null, null, NOW)).toBe("pending");
-    expect(resolveTier(null, "ok", NOW)).toBe("pending");
+  test("publishedAt=null → 'pending' regardless of lastPollStatus / lastPolledAt", () => {
+    expect(resolveTier(null, null, null, NOW)).toBe("pending");
+    expect(resolveTier(null, "ok", NOW, NOW)).toBe("pending");
     // 'pending' wins over even the unavailable overrides — we have no data
     // to classify yet, the not_found could be a transient backfill miss.
-    expect(resolveTier(null, "not_found", NOW)).toBe("pending");
+    expect(resolveTier(null, "not_found", null, NOW)).toBe("pending");
   });
 });
 
 describe("resolveTier — last_poll_status overrides (D-12)", () => {
   test("lastPollStatus='not_found' overrides → unavailable", () => {
-    expect(resolveTier(ago(1000), "not_found", NOW)).toBe("unavailable");
+    expect(resolveTier(ago(1000), "not_found", NOW, NOW)).toBe("unavailable");
   });
 
   test("lastPollStatus='private' overrides → unavailable", () => {
-    expect(resolveTier(ago(1000), "private", NOW)).toBe("unavailable");
+    expect(resolveTier(ago(1000), "private", NOW, NOW)).toBe("unavailable");
   });
 
   test("lastPollStatus='auth_error' overrides → unavailable", () => {
-    expect(resolveTier(ago(1000), "auth_error", NOW)).toBe("unavailable");
+    expect(resolveTier(ago(1000), "auth_error", NOW, NOW)).toBe("unavailable");
   });
 
   test("override fires regardless of age (28d-old + 'not_found' still unavailable, NOT frozen)", () => {
-    expect(resolveTier(ago(28 * 86_400_000), "not_found", NOW)).toBe("unavailable");
+    expect(resolveTier(ago(28 * 86_400_000), "not_found", NOW, NOW)).toBe("unavailable");
   });
 
   test("lastPollStatus='ok' is NOT an override — falls through to age-based tier", () => {
-    expect(resolveTier(ago(1000), "ok", NOW)).toBe("active");
+    expect(resolveTier(ago(1000), "ok", NOW, NOW)).toBe("active");
   });
 
   test("lastPollStatus='timeout' is NOT an override — falls through to age-based tier", () => {
-    expect(resolveTier(ago(1000), "timeout", NOW)).toBe("active");
+    expect(resolveTier(ago(1000), "timeout", NOW, NOW)).toBe("active");
+  });
+});
+
+describe("resolveTier — bootstrap rule (Phase 03.0.3 follow-up)", () => {
+  // Issue #29 extension: a video that is frozen by age (published_at > 28d
+  // ago) but has NEVER been polled (last_polled_at IS NULL) is upgraded
+  // to 'cold' so the next scheduler tick picks it up exactly once. After
+  // writeSnapshot stamps last_polled_at, the bootstrap rule is dormant
+  // for that video forever.
+  test("frozen-by-age + lastPolledAt=null → 'cold' (bootstrap upgrade)", () => {
+    expect(resolveTier(ago(30 * 86_400_000), null, null, NOW)).toBe("cold");
+  });
+
+  test("frozen-by-age + lastPolledAt set → 'frozen' (bootstrap dormant)", () => {
+    expect(resolveTier(ago(30 * 86_400_000), null, ago(1000), NOW)).toBe("frozen");
+  });
+
+  test("frozen-by-age + lastPolledAt=null + lastPollStatus='not_found' → 'unavailable' (override wins over bootstrap)", () => {
+    // A video that was never polled but for which we already know the
+    // upstream is gone — bootstrap should NOT bring it back into the
+    // polling pool. Defense in depth: the override list is checked first.
+    expect(resolveTier(ago(30 * 86_400_000), "not_found", null, NOW)).toBe("unavailable");
+  });
+
+  test("active-tier video + lastPolledAt=null → still 'active' (bootstrap dormant in young tiers)", () => {
+    expect(resolveTier(ago(1000), null, null, NOW)).toBe("active");
+  });
+
+  test("cold-tier video + lastPolledAt=null → still 'cold' (no over-classification)", () => {
+    expect(resolveTier(ago(2 * 86_400_000), null, null, NOW)).toBe("cold");
   });
 });
 
 describe("resolveTier — defaults", () => {
   test("default now=new Date() works", () => {
     const recent = new Date(Date.now() - 1000);
-    expect(resolveTier(recent, null)).toBe("active");
+    expect(resolveTier(recent, null, recent)).toBe("active");
   });
 });
 


### PR DESCRIPTION
## Summary

- **Part 1 — quota burn fix.** `POST /api/sources/:id/refresh-content` on a quiet steady-state channel previously walked the full uploads playlist on every click (~110 YouTube quota units across 8 channels). Replaces eager `since=backfillTargetSince` with three-branch derivation (steady-state newest-known, partial-walk incremental, deep). `resetChannelBackfillComplete` deleted; `channel-context-backfill` writes terminal state per `stopReason` to eliminate the onboarding double-walk. New mechanism: when a user widens `backfillTargetSince` past `backfill_oldest_at` on a fully-walked channel, `updateSource` enqueues a one-shot force-deep job (`forceDeep=true`) for THIS user only — preserves D-#29-7 multi-tenant fairness; subscribers free-ride on fan-out. Cron paths never set `forceDeep`. **UAT-1 confirmed on local dev: 8 channels = 8 quota units (was ~110).**
- **Part 2 — feed enrichment uniformity.** SSR first batch on `/feed` showed view/like/comment + channel chip via inline JOIN; cursor-paginated batches from `GET /api/events` dropped both. Adds `DataSourceAdapter.enrichFeedDtos` contract method; YouTube implements it via batched `youtube_video_snapshots` + `youtube_videos.channelTitle` lookups. Wired into `/feed/+page.server.ts`, `/api/events`, and `/games/[gameId]/+page.server.ts`. `/api/events/deleted` deliberately skips — `DeletedEventsPanel` is compact. **UAT-2 confirmed on local dev: first batch and cursor batches behave identically per-video.**
- **Part 3 — bootstrap tier for never-polled videos** (added during UAT, per user decision in #29 comment). `resolveTier` gains a 4th argument `lastPolledAt`; frozen-by-age + lastPolledAt IS NULL videos upgrade to tier=cold for ONE bootstrap shot. After the first writeSnapshot stamps last_polled_at, the rule is dormant. `selectEligibleVideoIds` SQL widens with `OR (last_polled_at IS NULL)` for tier=cold; PollingBadge mirror updated in lock-step. Quota safety: each frozen video gets at most ONE extra batch entry.
- Closes #29.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm eslint` clean on all touched files
- [x] Phase-focused tests pass (61/61):
  - [x] `refresh-content-quota.test.ts` 4/4 (steady-state, backdated, widening-via-force-deep, no-op-widen)
  - [x] `feed-api-enrichment.test.ts` 2/2 (cursor parity, deleted-skip)
  - [x] `channel-context-backfill-empty.test.ts` 2/2 (new — empty-window invariant + audit row)
  - [x] `tier-resolver.test.ts` 23/23 (incl. 5 new bootstrap cases)
  - [x] `tier-resolver-client-mirror.test.ts` 23/23 (mirror equality across battery)
  - [x] `scheduler-enqueue.test.ts` (existing frozen test refined to seed lastPolledAt; 2 new bootstrap tests)
- [x] Manual UAT on local dev:
  - [x] 8-channel `/sources` "Pull new content" → 8 quota units (verified in audit_log: since_branch="exhausted" × 8, requests_used=1 × 8)
  - [x] `/feed` SSR first batch + cursor batches behave identically — both show stats+chip for events with snapshots, both omit for events without
- [ ] Manual UAT on prod (`neotolis-diary.dev`) after deploy:
  - [ ] 8-channel "Pull new content" → ≤8 units on `/admin/quota`
  - [ ] Widen `backfillTargetSince` on a complete channel → force-deep walk fires under THIS user's quota bucket; other subscribers' next refresh still costs ≤1 page (D-#29-7 fairness preserved)
  - [ ] After bootstrap cron tick: frozen-tier videos that previously had no snapshot now show stats on /feed

## Known pre-existing infrastructure debt (NOT introduced by this PR)

Full integration suite shows 179/598 fail with `user_email_unique` collisions from static-email seeds in `seedUserDirectly(...static email...)` across ~25 test files. Documented in `.planning/phases/03.0.3-youtube-feed-fixes/deferred-items.md` for 2 files (`feed.test.ts`, `ingest-paste-then-poll.test.ts`); same pattern affects many more. Confirmed pre-existing via `git diff master..HEAD` returning empty for the affected test files. Out of scope for this PR — file separately.

## Self-review

- **Constraints:** No new `process.env` reads outside `src/lib/server/config/env.ts`. No new at-rest secrets. No new SaaS-vs-self-host code path. No new public dashboards / share routes. TLS unchanged. Open-source compatibility preserved.
- **Philosophy:** `enrichFeedDtos` is a contract on the existing `DataSourceAdapter` — extension, not horizontal growth. Three concrete callers (`/feed`, `/api/events`, `/games/[gameId]`) earn the abstraction. Force-deep mechanism is one private helper in `data-sources.ts` + one optional field in the job payload — no new schema. Bootstrap tier rule is one branch in `resolveTier` + one OR-clause in the SQL window — minimum-viable change.
- **Practices:** Atomic PR (one phase = one PR, squash-merge). Tests land with the feature (Wave 0 placeholder pattern + new gap-closing tests). No migrations. Env reads centralized. Self-host parity holds. Pino redact unbroken (no new secret-shaped field names). Comments are WHY-only on D-#29-* decisions. Conventional Commits throughout. Versions unchanged.
- **CI gate honesty:** Test (b) reframed to honestly describe what it asserts (fan-out INSERT, NOT walker-level filter) — see commit `e28381d`. TODO filed for missing walker-level unit test. Test (c) rewritten end-to-end through real PATCH → enqueue → handler path. New test (c2) pins no-op widen. New `channel-context-backfill-empty.test.ts` pins empty-window. New tier-resolver bootstrap tests + scheduler-enqueue bootstrap tests pin the new rule + its dormant cases + override-wins defense.
- **Documentation drift:** `SOURCE-REFERENCE.md` paragraph 10/11 extended. `AGENTS.md` Privacy invariants reviewed against every diff and remain load-bearing. `tier-resolver.ts` header docs updated with bootstrap rationale. PollingBadge mirror block updated in lock-step.

## Self-review (second pass — independent code review)

A second-pass review (fresh-context independent reviewer) was run on the initial 16 commits. It returned **ship-with-followups** and flagged:

| Severity | Finding | Status |
|----------|---------|--------|
| P1 | Test (c) algebra was inconsistent with code — `backfillComplete=true` always routes to `branch=exhausted`, so the widening to deep walk acceptance from #29 was effectively a no-op | **Closed** by commit `810d5a9` (force-deep job mechanism) |
| P1 | Test (b) was vacuous-pass — `pollContent` mocked, did not verify D-#29-1 walker filter | **Closed** by commit `e28381d` (honest framing + TODO for walker-level unit test) |
| Bug | Early-return at `channel-context-backfill.ts:497` on `collected.length === 0` skipped terminal state writes; naturally-empty channels stayed `backfill_complete=false`; cron double-walked them daily | **Closed** by commit `749b46e` (fall-through + IN()-clause guard) |
| Bug (assessed) | `hardCapResumeToken=null` on MAX_PAGES with no `nextPageToken` | **Verified non-bug** — `!nextPageToken` check fires FIRST |
| P2 | Obsolete comment + `_userId` not annotated | **Closed** by commit `a8f463c` (P2 cleanup) |
| UAT gap | Frozen-by-age videos with no snapshot were invisible to scheduler forever | **Closed** by commit `5c8405b` (bootstrap tier rule, Part 3 above) |
| Open question | DRY-violation: 3 callsites duplicate the `for-of allAdapters` loop | **Accepted as-is** — 3 callsites is the abstraction threshold; a 4th (e.g. `/inbox`) would prompt moving the loop inside `mapEventsToDtos` with an `{enrich: false}` option. |
| Open question | Race on parallel refresh-content clicks | **Verified safe** — `backfillSource` uses `singletonKey: backfill-channel-{channelKey}`; force-deep uses `force-deep-{channelKey}-{userId}` |

Pass-2 verification (gsd-verifier, fresh scan) on the full branch: 5/5 must-haves verified at code-path level, AGENTS.md Privacy invariants preserved on the new force-deep code path. UAT 1 + 2 manually confirmed on local dev during UAT session.

Generated with Claude Code (claude.com/claude-code)
