### PR TITLE
feat(phase-03.2): outbound Reddit proxy support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -187,5 +187,23 @@ REDDIT_USER_AGENT=
 # fast at boot.
 #REDDIT_BASE_URL_OVERRIDE=http://localhost:18080
 
+# Optional outbound HTTP proxy for Reddit fetches. When set, every
+# redditFetch routes through this proxy via undici's ProxyAgent.
+# Empty/unset = direct fetch (the right choice for self-host operators
+# on residential IPs — Reddit doesn't fence consumer ISPs).
+#
+# When to set: your deployment lives on a cloud VPS (Hetzner, DO,
+# Linode, AWS, etc.). Reddit aggressively 403's every datacenter IP
+# range. A residential proxy makes Reddit see a consumer-ISP IP and
+# respond normally. Tested working: Webshare static-residential
+# ($6/mo, 20 IPs, 250GB bandwidth). Other residential providers
+# (Bright Data, Smartproxy, Decodo) should work the same shape.
+#
+# Format: http://user:pass@host:port  (Webshare emits this shape).
+# Diagnose your VPS first — if a direct curl to /r/X/new.json returns
+# 200, you don't need a proxy. See docs/deploy/MANUAL-DEPLOY.md
+# "Reddit + cloud-hosted VPS reality check" for the curl one-liner.
+#REDDIT_PROXY_URL=http://user:pass@host:port
+
 # (POSTGRES_PASSWORD is defined at the top of this file — it must come
 # before any line that interpolates ${POSTGRES_PASSWORD}. See top of file.)

--- a/docs/deploy/MANUAL-DEPLOY.md
+++ b/docs/deploy/MANUAL-DEPLOY.md
@@ -100,29 +100,39 @@ Add any new keys to `.env`. **Phase 03.1 (Reddit) added:**
 
 | Var | Required? | What to set |
 |---|---|---|
-| `REDDIT_USER_AGENT` | yes for Reddit features | `node:com.neotolis.gpd:0.1.0 (by /u/<your-handle>)` — see `.env.example` for the convention. **Leave empty to disable Reddit cleanly** — see warning below. |
+| `REDDIT_USER_AGENT` | yes for Reddit features | `node:com.neotolis.gpd:0.1.0 (by /u/<your-handle>)` — see `.env.example` for the convention. Leave empty to disable Reddit cleanly. |
+| `REDDIT_PROXY_URL` | conditional — see below | `http://user:pass@host:port`. Required only when your VPS IP is in Reddit's datacenter blocklist. |
 | `REDDIT_BASE_URL_OVERRIDE` | no | TEST-ONLY. Leave **unset** in production. |
 
 > **⚠️ Reddit + cloud-hosted VPS reality check.** Reddit's edge
 > (Fastly/Varnish) aggressively 403's traffic from datacenter IP ranges
-> — Hetzner, DigitalOcean, Linode, AWS. If your VPS is in one of those
-> blocklists, setting `REDDIT_USER_AGENT` to a valid value will NOT help
-> — Reddit returns `HTTP/2 403 server: snooserv` before any UA check.
-> The adapter then triggers an escalating pause (10m → 1h → 3h → 12h)
-> and dead-letters queue rows forever.
+> — Hetzner, DigitalOcean, Linode, AWS, even Cloudflare Workers. If
+> your VPS is in one of those blocklists, setting `REDDIT_USER_AGENT`
+> to a valid value will NOT help — Reddit returns `HTTP/2 403 server:
+> snooserv` before any UA check. The adapter then triggers an
+> escalating pause (10m → 1h → 3h → 12h) and dead-letters queue rows
+> forever.
 >
 > **Diagnose** with one curl from the VPS BEFORE setting the UA:
 > ```bash
 > curl -A "node:com.neotolis.gpd:0.1.0 (by /u/test)" -i \
 >   'https://www.reddit.com/r/IndieDev/new.json?limit=1' | head -1
 > ```
-> - `HTTP/2 200` → IP is clean, set the UA normally.
-> - `HTTP/2 403` → IP is fenced. **Leave `REDDIT_USER_AGENT` empty.**
->   Reddit features cleanly disable (paste returns 422
->   `reddit_not_configured`, /sources/new shows "not configured");
->   nothing degraded, nothing dead-lettered. Self-host operators on
->   residential IPs are unaffected. Long-term fix (proxy / OAuth) is
->   tracked separately.
+> - `HTTP/2 200` → IP is clean. Set `REDDIT_USER_AGENT` only; leave
+>   `REDDIT_PROXY_URL` unset. Typical for self-host operators on
+>   residential IPs.
+> - `HTTP/2 403` → IP is fenced. Two options:
+>   - **Disable cleanly:** leave `REDDIT_USER_AGENT` empty. Reddit
+>     features show as "not configured" in the UI; nothing degraded,
+>     nothing dead-lettered.
+>   - **Route through residential proxy:** set both
+>     `REDDIT_USER_AGENT` AND `REDDIT_PROXY_URL`. Tested working with
+>     Webshare static-residential ($6/mo, 20 IPs, 250GB bandwidth) —
+>     the cheapest path the author found. Other residential providers
+>     (Bright Data, Smartproxy, Decodo) work the same shape. Confirm
+>     by re-running the curl ABOVE with `--proxy
+>     http://user:pass@host:port` and `--ssl-no-revoke` before saving
+>     to `.env`; if THAT returns 200, you're set.
 
 Save and close.
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "pino": "^10.3.1",
     "rate-limiter-flexible": "^5.0.0",
     "svelte": "^5.55.5",
+    "undici": "^8.3.0",
     "uuidv7": "^1.0.2",
     "vite": "^8.0.10",
     "zod": "^4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       svelte:
         specifier: ^5.55.5
         version: 5.55.5(@typescript-eslint/types@8.59.0)
+      undici:
+        specifier: ^8.3.0
+        version: 8.3.0
       uuidv7:
         specifier: ^1.0.2
         version: 1.2.1
@@ -2985,6 +2988,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici@8.3.0:
+    resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
+    engines: {node: '>=22.19.0'}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -5701,6 +5708,8 @@ snapshots:
   ufo@1.6.3: {}
 
   undici-types@6.21.0: {}
+
+  undici@8.3.0: {}
 
   unpipe@1.0.0: {}
 

--- a/src/lib/server/config/env.ts
+++ b/src/lib/server/config/env.ts
@@ -188,6 +188,19 @@ const RawSchema = z.object({
   // only supported live behavior.
   REDDIT_BASE_URL_OVERRIDE: z.string().url().optional(),
 
+  // Optional outbound HTTP proxy for Reddit fetches. When set, every
+  // `redditFetch` routes through this proxy via undici's ProxyAgent.
+  // Format: `http://user:pass@host:port` (Webshare static-residential
+  // shape). Empty/unset = direct fetch (self-host operators on residential
+  // IPs need nothing).
+  //
+  // Why this exists: Reddit aggressively 403's outbound traffic from
+  // datacenter IP ranges (Hetzner, DO, Linode, AWS, Cloudflare Workers).
+  // The author's prod VPS hits this fence. Routing through a residential
+  // proxy makes Reddit see a consumer-ISP IP and respond normally.
+  // See docs/deploy/MANUAL-DEPLOY.md for the operator decision tree.
+  REDDIT_PROXY_URL: z.string().url().optional(),
+
   // Deployment hint for operators. Adapter-owned workers are protected by
   // per-adapter singleton locks or DB-backed claim gates; this value is no
   // longer a global quota safety guard.
@@ -296,6 +309,7 @@ export const env = {
   ADMIN_EMAIL_ALLOWLIST: raw.ADMIN_EMAIL_ALLOWLIST,
   YOUTUBE_API_BASE_URL: raw.YOUTUBE_API_BASE_URL,
   REDDIT_BASE_URL_OVERRIDE: raw.REDDIT_BASE_URL_OVERRIDE,
+  REDDIT_PROXY_URL: raw.REDDIT_PROXY_URL,
   WORKER_REPLICA_COUNT: raw.WORKER_REPLICA_COUNT,
 } as const;
 

--- a/src/lib/sources/reddit/server/http.ts
+++ b/src/lib/sources/reddit/server/http.ts
@@ -153,19 +153,29 @@ export async function redditFetch<T = unknown>(
   const dispatcher = getProxyDispatcher();
   let res: Response;
   try {
-    // undiciFetch is API-compatible with global fetch but accepts the
-    // `dispatcher` option that routes the request through ProxyAgent.
-    // When env.REDDIT_PROXY_URL is empty, dispatcher is null and undici
-    // uses its default agent — behaviour identical to a direct
-    // global fetch call.
-    res = (await undiciFetch(url, {
-      method: opts.method ?? "GET",
-      headers: {
-        "User-Agent": creds.userAgent,
-        Accept: "application/json",
-      },
-      ...(dispatcher ? { dispatcher } : {}),
-    })) as unknown as Response;
+    if (dispatcher !== null) {
+      // Proxy path. undiciFetch is API-compatible with global fetch but
+      // accepts the `dispatcher` option that routes through ProxyAgent.
+      res = (await undiciFetch(url, {
+        method: opts.method ?? "GET",
+        headers: {
+          "User-Agent": creds.userAgent,
+          Accept: "application/json",
+        },
+        dispatcher,
+      })) as unknown as Response;
+    } else {
+      // No proxy → use global fetch so tests can mock via vi.stubGlobal.
+      // Behaviour identical (Node 18+ global fetch is undici under the
+      // hood); only the test surface differs.
+      res = await fetch(url, {
+        method: opts.method ?? "GET",
+        headers: {
+          "User-Agent": creds.userAgent,
+          Accept: "application/json",
+        },
+      });
+    }
   } catch (cause) {
     throw new AdapterError(`Reddit fetch network error: ${String(cause)}`, {
       category: "transient",

--- a/src/lib/sources/reddit/server/http.ts
+++ b/src/lib/sources/reddit/server/http.ts
@@ -44,6 +44,7 @@
 // always sees the rate-limit signal.
 
 import type { z } from "zod";
+import { fetch as undiciFetch, ProxyAgent } from "undici";
 import { AdapterError } from "$lib/sources/errors.js";
 import { pickRedditCredentials } from "./credentials.js";
 import { writeAudit } from "$lib/server/audit.js";
@@ -76,6 +77,30 @@ interface BurstState {
 let burstState: BurstState = { count: 0, windowStartMs: 0, auditEmittedThisBurst: false };
 const BURST_WINDOW_MS = 5 * 60_000;
 const BURST_THRESHOLD = 3;
+
+// Outbound HTTP proxy for Reddit. Lazily constructed on first use so the
+// undici ProxyAgent's connection pool is created once and reused across
+// every redditFetch (keep-alive is what makes residential-proxy latency
+// tolerable — TCP+TLS handshake per call would dominate).
+// Empty/unset env var → null → direct fetch (self-host parity).
+let cachedProxyAgent: ProxyAgent | null = null;
+function getProxyDispatcher(): ProxyAgent | null {
+  if (!env.REDDIT_PROXY_URL) return null;
+  if (cachedProxyAgent === null) {
+    cachedProxyAgent = new ProxyAgent(env.REDDIT_PROXY_URL);
+    logger.info(
+      { proxyHost: new URL(env.REDDIT_PROXY_URL).host },
+      "reddit outbound proxy configured",
+    );
+  }
+  return cachedProxyAgent;
+}
+
+/** Test-only helper — drop the cached ProxyAgent so tests can swap
+ *  REDDIT_PROXY_URL via vi.stubEnv and pick up the new value. */
+export function __resetProxyAgentForTest(): void {
+  cachedProxyAgent = null;
+}
 
 /**
  * Wraps native fetch with Reddit-specific behavior:
@@ -125,15 +150,22 @@ export async function redditFetch<T = unknown>(
   }
 
   const url = path.startsWith("http") ? path : REDDIT_BASE + path;
+  const dispatcher = getProxyDispatcher();
   let res: Response;
   try {
-    res = await fetch(url, {
+    // undiciFetch is API-compatible with global fetch but accepts the
+    // `dispatcher` option that routes the request through ProxyAgent.
+    // When env.REDDIT_PROXY_URL is empty, dispatcher is null and undici
+    // uses its default agent — behaviour identical to a direct
+    // global fetch call.
+    res = (await undiciFetch(url, {
       method: opts.method ?? "GET",
       headers: {
         "User-Agent": creds.userAgent,
         Accept: "application/json",
       },
-    });
+      ...(dispatcher ? { dispatcher } : {}),
+    })) as unknown as Response;
   } catch (cause) {
     throw new AdapterError(`Reddit fetch network error: ${String(cause)}`, {
       category: "transient",

--- a/tests/unit/scripts.test.ts
+++ b/tests/unit/scripts.test.ts
@@ -2,18 +2,14 @@ import { describe, it, expect } from "vitest";
 import { execSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
-// Tests for scripts/deploy.sh, scripts/deploy-rollback.sh, scripts/backup.sh,
-// nginx/refresh-cf-ips.sh.
+// Tests for scripts/backup.sh, nginx/refresh-cf-ips.sh, nginx config.
+//
+// scripts/deploy.sh and scripts/deploy-rollback.sh were removed in PR #35
+// — they assumed a `command="..."`-restricted SSH key on the VPS that was
+// never set up. Manual deploy via docs/deploy/MANUAL-DEPLOY.md is the
+// supported path. If automation comes back later, restore the assertions.
 
-describe("deploy + backup scripts syntax + invariants", () => {
-  it("scripts/deploy.sh syntax-validates via `bash -n`", () => {
-    expect(() => execSync("bash -n scripts/deploy.sh", { stdio: "pipe" })).not.toThrow();
-  });
-
-  it("scripts/deploy-rollback.sh syntax-validates via `bash -n`", () => {
-    expect(() => execSync("bash -n scripts/deploy-rollback.sh", { stdio: "pipe" })).not.toThrow();
-  });
-
+describe("backup script + nginx config syntax + invariants", () => {
   it("scripts/backup.sh syntax-validates via `bash -n`", () => {
     expect(() => execSync("bash -n scripts/backup.sh", { stdio: "pipe" })).not.toThrow();
   });


### PR DESCRIPTION
## Summary

- Reddit aggressively 403's all datacenter IPs (Hetzner, DO, AWS, CF Workers — verified end-to-end during research). Author's prod VPS hits the fence.
- Adds optional `REDDIT_PROXY_URL` env var. When set, every `redditFetch` routes through it via undici's `ProxyAgent`. When unset, behaviour is identical to before — self-host operators on residential IPs unaffected.
- Tested working against Webshare static-residential. Same 3 dead-letter rows that 403'd on prod yesterday now drain cleanly through the proxy on the local dev worker.

## Test plan

- [x] Lint + typecheck green locally.
- [x] Local dev worker drains previously-403'd queue rows successfully via proxy (signature: `reddit outbound proxy configured` + `sub_poll: complete` × 3).
- [ ] CI green on this branch.
- [ ] After merge: set `REDDIT_PROXY_URL` on prod `.env`, force-recreate worker, verify worker logs `sub_poll: complete` (not `Reddit 403`).

Closes #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)