### PR TITLE
fix(observability): reduce error-log noise — scanner 404s + pg shutdown

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -35,6 +35,16 @@ import type { Handle, HandleServerError } from "@sveltejs/kit";
 import { auth } from "./lib/auth.js";
 import { toUserDto, toSessionDto } from "./lib/server/dto.js";
 import { logger } from "./lib/server/logger.js";
+import { env } from "./lib/server/config/env.js";
+
+// Canonical PUBLIC origin, computed once. We compare a request's Referer
+// against THIS (a single, explicitly-configured source of truth) rather than
+// `event.url.origin` — the latter is derived by adapter-node from forwarded
+// headers and only happens to equal the public origin today (it defaults the
+// scheme to "https" and trusts the proxied Host). Pinning to BETTER_AUTH_URL
+// keeps the internal-vs-external Referer check correct regardless of proxy
+// header config or adapter-version changes.
+const CANONICAL_ORIGIN = new URL(env.BETTER_AUTH_URL).origin;
 
 const VALID_THEMES = new Set(["light", "dark", "system"]);
 
@@ -99,14 +109,15 @@ export const handleError: HandleServerError = ({ error, event, status }) => {
   return { message: "Internal Error" };
 };
 
-/** True when the request's Referer points at our own origin — i.e. a link
- *  inside the app led to this URL. Distinguishes our broken links from
- *  scanner probes without enumerating scanner paths. */
-function isInternalReferer(event: { request: Request; url: URL }): boolean {
+/** True when the request's Referer points at our own canonical origin — i.e.
+ *  a link inside the app led to this URL. Distinguishes our broken links from
+ *  scanner probes without enumerating scanner paths. Compares against
+ *  CANONICAL_ORIGIN (BETTER_AUTH_URL), not event.url.origin — see note above. */
+function isInternalReferer(event: { request: Request }): boolean {
   const referer = event.request.headers.get("referer");
   if (!referer) return false;
   try {
-    return new URL(referer).origin === event.url.origin;
+    return new URL(referer).origin === CANONICAL_ORIGIN;
   } catch {
     return false;
   }

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -68,17 +68,58 @@ export const themeHandle: Handle = async ({ event, resolve }) => {
 
 export const handle: Handle = sequence(authHandle, themeHandle);
 
-// SvelteKit invokes handleError for UNEXPECTED errors thrown during
-// load/render (5xx). Expected errors via the `error()` helper and plain
-// 404s do NOT reach here. Without this hook those server-render crashes go
-// to SvelteKit's default formatter (plain text), bypassing Pino and the
-// Grafana error panel. Logging via Pino (level 50) makes them visible;
-// the returned shape is the safe client-facing payload (never leak the
-// stack — Pino already captured it, redacted).
+// SvelteKit invokes handleError for two kinds of error during load/render:
+// genuine unexpected throws (status 500) AND unmatched-route 404s. Explicit
+// `throw error(...)` BYPASSES this hook (SvelteKit returns the response
+// directly), so every legitimate not-found in this app (event/game/source/
+// admin, cross-tenant) already renders its proper 404 page and never lands
+// here. That leaves two cases to triage:
+//
+//   - status >= 500 → a real unexpected crash. Log at error (level 50) so it
+//     surfaces in the Grafana error panel instead of @hono/node-server's raw
+//     stderr. Return a safe client payload (stack stays in Pino, redacted).
+//   - status === 404 → an unmatched route. Almost always a scanner probe
+//     (/wp-admin, /wp-json/*, robots.txt). We do NOT log those as errors —
+//     they'd flood the error panel (and nginx's JSON access log already
+//     records every 404 by path+status). The one exception worth seeing is a
+//     404 whose Referer is our OWN origin = a broken internal link (our bug),
+//     logged at warn. Path-allowlisting scanners is a losing game (infinite,
+//     ever-changing paths); the referer signal catches our 404s precisely.
 export const handleError: HandleServerError = ({ error, event, status }) => {
-  logger.error(
-    { err: error, status, path: event.url.pathname, method: event.request.method },
-    "sveltekit unhandled error",
-  );
+  const base = { path: event.url.pathname, method: event.request.method };
+
+  if (status >= 500) {
+    logger.error({ err: error, status, ...base }, "sveltekit unhandled error");
+  } else if (status === 404 && isInternalReferer(event)) {
+    logger.warn({ status, referer: refererPath(event), ...base }, "internal 404 (broken link)");
+  }
+  // status === 404 with no/external referer, and any other 4xx → not logged
+  // here; nginx JSON access log carries them if ever needed.
+
   return { message: "Internal Error" };
 };
+
+/** True when the request's Referer points at our own origin — i.e. a link
+ *  inside the app led to this URL. Distinguishes our broken links from
+ *  scanner probes without enumerating scanner paths. */
+function isInternalReferer(event: { request: Request; url: URL }): boolean {
+  const referer = event.request.headers.get("referer");
+  if (!referer) return false;
+  try {
+    return new URL(referer).origin === event.url.origin;
+  } catch {
+    return false;
+  }
+}
+
+/** The Referer's pathname only (never the query string — our own filter
+ *  state lives there and must not be logged). Empty string if unparseable. */
+function refererPath(event: { request: Request }): string {
+  const referer = event.request.headers.get("referer");
+  if (!referer) return "";
+  try {
+    return new URL(referer).pathname;
+  } catch {
+    return "";
+  }
+}

--- a/src/lib/server/queue-client.ts
+++ b/src/lib/server/queue-client.ts
@@ -39,7 +39,7 @@ const PG_CONNECTION_LIFECYCLE_CODES = new Set(["57P01", "57P03"]);
 export function logPgBossError(err: unknown): void {
   const code = (err as { code?: unknown })?.code;
   if (typeof code === "string" && PG_CONNECTION_LIFECYCLE_CODES.has(code)) {
-    logger.warn({ err, code }, "pg-boss connection terminated (shutdown/restart)");
+    logger.warn({ err, code }, "pg-boss backend connection terminated (likely deploy/restart)");
     return;
   }
   logger.error({ err }, "pg-boss error");

--- a/src/lib/server/queue-client.ts
+++ b/src/lib/server/queue-client.ts
@@ -26,6 +26,25 @@ import { env } from "./config/env.js";
 import { logger } from "./logger.js";
 import { declareAllQueues } from "./queues.js";
 
+// Postgres SQLSTATEs for "the connection was terminated by the server", which
+// is exactly what happens to pg-boss's pool on every deploy/restart when the
+// container gets SIGTERM and Postgres closes the backend. These are lifecycle
+// events, not application bugs — logging them at `error` (level 50) floods the
+// Grafana error panel on every single deploy. Downgrade to `warn`; a genuine
+// pg-boss fault (any other code) still logs at error.
+//   57P01 admin_shutdown      — "terminating connection due to administrator command"
+//   57P03 cannot_connect_now  — server still starting up / shutting down
+const PG_CONNECTION_LIFECYCLE_CODES = new Set(["57P01", "57P03"]);
+
+export function logPgBossError(err: unknown): void {
+  const code = (err as { code?: unknown })?.code;
+  if (typeof code === "string" && PG_CONNECTION_LIFECYCLE_CODES.has(code)) {
+    logger.warn({ err, code }, "pg-boss connection terminated (shutdown/restart)");
+    return;
+  }
+  logger.error({ err }, "pg-boss error");
+}
+
 /**
  * Create + start a pg-boss instance with all queues declared.
  *
@@ -53,9 +72,7 @@ export async function createBoss(): Promise<PgBoss> {
     // specific queue needs different behaviour.
   });
 
-  boss.on("error", (err) => {
-    logger.error({ err }, "pg-boss error");
-  });
+  boss.on("error", logPgBossError);
 
   await boss.start();
 

--- a/tests/unit/hooks-error.test.ts
+++ b/tests/unit/hooks-error.test.ts
@@ -1,9 +1,12 @@
 // SvelteKit handleError hook test.
 //
-// handleError fires for UNEXPECTED server-render/load errors (5xx). Verifies
-// it logs via Pino (level 50 → visible to the Grafana error panel) with
-// path/method/status context, and returns the safe client payload (no stack
-// leak — Pino captured it, redacted).
+// handleError fires for unexpected 5xx throws AND unmatched-route 404s.
+// Verifies the three branches:
+//   - status >= 500 → logged at error (level 50 → Grafana error panel) with
+//     the err object; returns the safe client payload (stack stays in Pino).
+//   - scanner/external-referer 404 → NOT logged (keeps the error panel clean).
+//   - internal-referer 404 → logged at warn (broken link), referer PATH only
+//     (query string stripped — no private filter state leaks).
 
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { randomBytes } from "node:crypto";

--- a/tests/unit/hooks-error.test.ts
+++ b/tests/unit/hooks-error.test.ts
@@ -23,19 +23,22 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-// handleError only reads event.url.pathname and event.request.method; the
-// rest of RequestEvent is irrelevant here, so cast a minimal synthetic event
-// rather than fabricate cookies/locals/fetch/etc. A typed cast (rather than a
-// suppression directive) keeps the typing robust against formatter reflows.
-function fakeEvent(pathname: string, method: string): RequestEvent {
+// handleError only reads event.url.{origin,pathname} and event.request
+// (method + Referer header); the rest of RequestEvent is irrelevant here, so
+// cast a minimal synthetic event rather than fabricate cookies/locals/fetch.
+// A typed cast (rather than a suppression directive) keeps the typing robust
+// against formatter reflows. `referer` simulates the incoming Referer header.
+function fakeEvent(pathname: string, method: string, referer?: string): RequestEvent {
+  const headers = new Headers();
+  if (referer) headers.set("referer", referer);
   return {
     url: new URL(`http://localhost${pathname}`),
-    request: new Request(`http://localhost${pathname}`, { method }),
+    request: new Request(`http://localhost${pathname}`, { method, headers }),
   } as unknown as RequestEvent;
 }
 
 describe("handleError (SvelteKit)", () => {
-  it("logs the render error with context and returns a safe message", () => {
+  it("logs a 500 unexpected crash at error level with context", () => {
     const errorLog = vi.spyOn(logger, "error").mockImplementation(() => {});
     const error = new Error("loader exploded");
 
@@ -53,5 +56,50 @@ describe("handleError (SvelteKit)", () => {
     expect(call[1]).toBe("sveltekit unhandled error");
     expect(payload).toMatchObject({ status: 500, path: "/feed", method: "GET" });
     expect(payload.err).toBe(error);
+  });
+
+  it("does NOT log a scanner 404 (no/external referer) — keeps the error panel clean", () => {
+    const errorLog = vi.spyOn(logger, "error").mockImplementation(() => {});
+    const warnLog = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+    // No referer (typical scanner probe).
+    handleError({
+      error: new Error("Not found: /wp-admin/install.php"),
+      event: fakeEvent("/wp-admin/install.php", "GET"),
+      status: 404,
+      message: "Not Found",
+    });
+    // External referer must also be treated as not-ours.
+    handleError({
+      error: new Error("Not found: /wp-login.php"),
+      event: fakeEvent("/wp-login.php", "GET", "https://evil.example.com/scan"),
+      status: 404,
+      message: "Not Found",
+    });
+
+    expect(errorLog).not.toHaveBeenCalled();
+    expect(warnLog).not.toHaveBeenCalled();
+  });
+
+  it("logs an internal-referer 404 at warn (broken link), with referer PATH only", () => {
+    const errorLog = vi.spyOn(logger, "error").mockImplementation(() => {});
+    const warnLog = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+    handleError({
+      error: new Error("Not found: /feeed"),
+      // Referer is our own origin, with a query string that must NOT be logged.
+      event: fakeEvent("/feeed", "GET", "http://localhost/feed?filter=secret"),
+      status: 404,
+      message: "Not Found",
+    });
+
+    expect(errorLog).not.toHaveBeenCalled();
+    expect(warnLog).toHaveBeenCalledTimes(1);
+    const call = warnLog.mock.calls[0]!;
+    const payload = call[0] as { status: number; path: string; referer: string };
+    expect(call[1]).toBe("internal 404 (broken link)");
+    expect(payload).toMatchObject({ status: 404, path: "/feeed", referer: "/feed" });
+    // The referer query string is dropped — no private filter state leaks.
+    expect(payload.referer).not.toContain("secret");
   });
 });

--- a/tests/unit/hooks-error.test.ts
+++ b/tests/unit/hooks-error.test.ts
@@ -76,6 +76,15 @@ describe("handleError (SvelteKit)", () => {
       status: 404,
       message: "Not Found",
     });
+    // Same host but DIFFERENT scheme/port than the canonical origin
+    // (BETTER_AUTH_URL=http://localhost:3000) is NOT internal — guards the
+    // scheme/port-sensitivity of the origin comparison.
+    handleError({
+      error: new Error("Not found: /x"),
+      event: fakeEvent("/x", "GET", "https://localhost:3000/feed"),
+      status: 404,
+      message: "Not Found",
+    });
 
     expect(errorLog).not.toHaveBeenCalled();
     expect(warnLog).not.toHaveBeenCalled();
@@ -87,8 +96,9 @@ describe("handleError (SvelteKit)", () => {
 
     handleError({
       error: new Error("Not found: /feeed"),
-      // Referer is our own origin, with a query string that must NOT be logged.
-      event: fakeEvent("/feeed", "GET", "http://localhost/feed?filter=secret"),
+      // Referer is our own canonical origin (BETTER_AUTH_URL=http://localhost:3000),
+      // with a query string that must NOT be logged.
+      event: fakeEvent("/feeed", "GET", "http://localhost:3000/feed?filter=secret"),
       status: 404,
       message: "Not Found",
     });

--- a/tests/unit/pgboss-error-log.test.ts
+++ b/tests/unit/pgboss-error-log.test.ts
@@ -36,7 +36,9 @@ describe("logPgBossError", () => {
 
     expect(errorLog).not.toHaveBeenCalled();
     expect(warnLog).toHaveBeenCalledTimes(1);
-    expect(warnLog.mock.calls[0]![1]).toBe("pg-boss connection terminated (shutdown/restart)");
+    expect(warnLog.mock.calls[0]![1]).toBe(
+      "pg-boss backend connection terminated (likely deploy/restart)",
+    );
   });
 
   it("downgrades 57P03 (cannot_connect_now) to warn", () => {
@@ -72,5 +74,16 @@ describe("logPgBossError", () => {
 
     expect(warnLog).not.toHaveBeenCalled();
     expect(errorLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("tolerates a null/non-object err without throwing (logs at error)", () => {
+    const errorLog = vi.spyOn(logger, "error").mockImplementation(() => {});
+    const warnLog = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+    expect(() => logPgBossError(null)).not.toThrow();
+    expect(() => logPgBossError("boom")).not.toThrow();
+
+    expect(warnLog).not.toHaveBeenCalled();
+    expect(errorLog).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/unit/pgboss-error-log.test.ts
+++ b/tests/unit/pgboss-error-log.test.ts
@@ -1,0 +1,76 @@
+// pg-boss error-handler log-level classification.
+//
+// Connection-lifecycle SQLSTATEs (57P01 admin_shutdown / 57P03
+// cannot_connect_now) happen on every deploy when the container gets SIGTERM
+// and Postgres closes pg-boss's backend. They are NOT application bugs, so
+// logPgBossError downgrades them to `warn`; any other pg-boss fault stays at
+// `error`. This keeps the Grafana level>=50 panel from flooding on each deploy.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { randomBytes } from "node:crypto";
+
+process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+process.env.BETTER_AUTH_URL ??= "http://localhost:3000";
+process.env.BETTER_AUTH_SECRET ??= "x".repeat(40);
+process.env.OAUTH_CLIENT_ID ??= "test";
+process.env.OAUTH_CLIENT_SECRET ??= "test";
+process.env.APP_KEK_BASE64 ??= randomBytes(32).toString("base64");
+
+const { logPgBossError } = await import("../../src/lib/server/queue-client.js");
+const { logger } = await import("../../src/lib/server/logger.js");
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("logPgBossError", () => {
+  it("downgrades 57P01 (admin_shutdown) to warn, not error", () => {
+    const errorLog = vi.spyOn(logger, "error").mockImplementation(() => {});
+    const warnLog = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+    logPgBossError(
+      Object.assign(new Error("terminating connection due to administrator command"), {
+        code: "57P01",
+      }),
+    );
+
+    expect(errorLog).not.toHaveBeenCalled();
+    expect(warnLog).toHaveBeenCalledTimes(1);
+    expect(warnLog.mock.calls[0]![1]).toBe("pg-boss connection terminated (shutdown/restart)");
+  });
+
+  it("downgrades 57P03 (cannot_connect_now) to warn", () => {
+    const errorLog = vi.spyOn(logger, "error").mockImplementation(() => {});
+    const warnLog = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+    logPgBossError(
+      Object.assign(new Error("the database system is shutting down"), {
+        code: "57P03",
+      }),
+    );
+
+    expect(errorLog).not.toHaveBeenCalled();
+    expect(warnLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs a genuine pg-boss fault (other code) at error", () => {
+    const errorLog = vi.spyOn(logger, "error").mockImplementation(() => {});
+    const warnLog = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+    logPgBossError(Object.assign(new Error("syntax error"), { code: "42601" }));
+
+    expect(warnLog).not.toHaveBeenCalled();
+    expect(errorLog).toHaveBeenCalledTimes(1);
+    expect(errorLog.mock.calls[0]![1]).toBe("pg-boss error");
+  });
+
+  it("logs an error with no SQLSTATE code at error (default)", () => {
+    const errorLog = vi.spyOn(logger, "error").mockImplementation(() => {});
+    const warnLog = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+    logPgBossError(new Error("connection reset"));
+
+    expect(warnLog).not.toHaveBeenCalled();
+    expect(errorLog).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Two sources were logging non-errors at level 50, flooding the Grafana "Error Logs (level ≥ 50)" panel and undermining #42's clean-signal goal — discovered while reviewing prod logs after #43 deployed.

- **handleError (regression from #43):** logged EVERY unmatched-route 404 as an error. On prod the panel was dominated by scanner probes (`/wp-admin/install.php`, `/wp-json/*`, `/robots.txt`). SvelteKit's `error()` bypasses handleError, so all our legitimate not-founds (event/game/source/admin, cross-tenant) already render proper 404 pages and never reach the hook. Now:
  - `status >= 500` → `logger.error` (genuine crash)
  - `status === 404` with Referer on our canonical origin → `logger.warn` (broken internal link = our bug)
  - scanner / external-referer 404 → not logged (nginx JSON access log still records every 404)
- **pg-boss `logPgBossError`:** `57P01` (admin_shutdown) / `57P03` (cannot_connect_now) fire on every deploy when SIGTERM closes pg-boss's backend — lifecycle events, not bugs. Downgraded to `warn`; any other pg fault still logs at `error`.

Closes #44.

## Why no scanner-path allowlist
Scanners probe infinite, ever-changing paths — any allowlist rots and leaks. The **Referer signal** + SvelteKit's `error()`/unmatched split means nothing of ours is lost: real crashes → error; intentional not-founds → `error(404)` proper page; accidental broken links → internal-referer warn; every 404 → nginx access log.

## Self-review (second pass — independent agent)
No P0/P1. Acted on the P2: `isInternalReferer` originally compared the Referer to `event.url.origin`, which equals the public origin only by adapter-node's hardcoded `https` default + nginx forwarding the public Host — fragile (silently drops internal-404 warns if `ORIGIN` is set or the adapter changes). Now pinned to `new URL(env.BETTER_AUTH_URL).origin` — the explicitly-configured canonical origin, computed once. P3s: softened the pg-boss warn message (don't overclaim causation); added tests for scheme/port-mismatch referer and null/non-object err.

Lost-signal check (verified against kit@2.58.0 + adapter-node@5.5.4 source): the only newly-dropped class is scanner 404s without an internal referer — safe. Genuine crashes (status 500) still log at error.

## Test plan
- [x] `vitest` — handleError 3 branches (500 / internal-404-warn / scanner-404-skip incl. referer-query-stripped + scheme-mismatch) + logPgBossError 5 cases; green
- [x] `pnpm typecheck` (svelte-check) 0 errors; `eslint` + `prettier --check` clean on touched files
- [ ] Deploy-verify: after merge, the Escaped/Error panels no longer fill with `/wp-*` 404s; a deploy no longer emits `pg-boss error` at level 50

🤖 Generated with [Claude Code](https://claude.com/claude-code)