### PR TITLE
fix(http): ERR_HTTP_HEADERS_SENT in SvelteKit pass-through

### DIFF
--- a/src/lib/server/http/sveltekit-passthrough.ts
+++ b/src/lib/server/http/sveltekit-passthrough.ts
@@ -1,0 +1,66 @@
+// SvelteKit pass-through for the Hono catch-all (`app.all("*")`).
+//
+// SvelteKit's adapter-node handler writes its response DIRECTLY to the Node
+// `ServerResponse` (`outgoing`). @hono/node-server then inspects whatever
+// Response our handler returns and decides whether to write it. It skips
+// writing ONLY when the Response carries the `x-hono-already-sent` header
+// (dist/index.mjs:751 → `else if (resHeaderRecord[X_ALREADY_SENT]) {}`).
+//
+// The library exports exactly that sentinel as `RESPONSE_ALREADY_SENT`. The
+// previous implementation returned a bare `new Response(null, { status })`
+// instead — which lacks the header, so node-server fell through to
+// `outgoing.writeHead(...)` a SECOND time (adapter-node already sent the
+// headers) and threw `ERR_HTTP_HEADERS_SENT`. (The old comment claimed
+// node-server "checks outgoing.writableEnded before writing" — there is no
+// such check; the header is the only signal.)
+//
+// The sentinel is INJECTED rather than imported here: this keeps the module a
+// pure, dependency-light unit (no `@hono/node-server` import) that unit tests
+// can drive with a marker Response. The composition root (roles/app.ts) owns
+// the `@hono/node-server` import and passes the real RESPONSE_ALREADY_SENT in.
+
+import type { Context } from "hono";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+export type SvelteHandler = (req: IncomingMessage, res: ServerResponse, next?: () => void) => void;
+
+/**
+ * Build the Hono catch-all handler that delegates to SvelteKit's adapter-node
+ * handler. Extracted from roles/app.ts so the resolve-path logic (sentinel vs
+ * 404 vs missing-context) is unit-testable without booting the server.
+ *
+ * @param svelteHandler adapter-node's (req,res,next) handler.
+ * @param alreadySent   the `RESPONSE_ALREADY_SENT` sentinel from
+ *   `@hono/node-server/utils/response` — returned once SvelteKit has written
+ *   directly to `outgoing`, so @hono/node-server does NOT writeHead again.
+ */
+export function createSvelteKitPassthrough(
+  svelteHandler: SvelteHandler,
+  alreadySent: Response,
+): (c: Context) => Promise<Response> {
+  return (c) => {
+    const ctx = c.env as { incoming?: IncomingMessage; outgoing?: ServerResponse } | undefined;
+    const incoming = ctx?.incoming;
+    const outgoing = ctx?.outgoing;
+    if (!incoming || !outgoing) {
+      return Promise.resolve(c.text("node adapter context missing", 500));
+    }
+    return new Promise<Response>((resolve) => {
+      let resolved = false;
+      const settle = (resp: Response): void => {
+        if (resolved) return;
+        resolved = true;
+        resolve(resp);
+      };
+      svelteHandler(incoming, outgoing, () => {
+        // SvelteKit declined this route; `outgoing` is untouched, so a real
+        // Hono 404 is safe for node-server to write.
+        settle(c.text("not found", 404));
+      });
+      // SvelteKit handled it and wrote directly to `outgoing`. Hand node-server
+      // the already-sent sentinel so it does NOT writeHead again.
+      outgoing.on("close", () => settle(alreadySent));
+      outgoing.on("finish", () => settle(alreadySent));
+    });
+  };
+}

--- a/src/lib/server/http/sveltekit-passthrough.ts
+++ b/src/lib/server/http/sveltekit-passthrough.ts
@@ -54,7 +54,10 @@ export function createSvelteKitPassthrough(
       };
       svelteHandler(incoming, outgoing, () => {
         // SvelteKit declined this route; `outgoing` is untouched, so a real
-        // Hono 404 is safe for node-server to write.
+        // Hono 404 is safe for node-server to write. NOTE: adapter-node 5.x's
+        // terminal `ssr` middleware always writes to `outgoing` and never
+        // calls next(), so this branch is a forward-compat affordance for
+        // other/custom handlers — not a live path under the current adapter.
         settle(c.text("not found", 404));
       });
       // SvelteKit handled it and wrote directly to `outgoing`. Hand node-server

--- a/src/lib/server/http/sveltekit-passthrough.ts
+++ b/src/lib/server/http/sveltekit-passthrough.ts
@@ -42,6 +42,10 @@ export function createSvelteKitPassthrough(
     const ctx = c.env as { incoming?: IncomingMessage; outgoing?: ServerResponse } | undefined;
     const incoming = ctx?.incoming;
     const outgoing = ctx?.outgoing;
+    // @hono/node-server always co-populates c.env.incoming + c.env.outgoing,
+    // so this 500 is unreachable under the real adapter — it's a
+    // composition-root contract guard that also narrows both to non-null for
+    // the call below (c.env is an untyped `unknown`).
     if (!incoming || !outgoing) {
       return Promise.resolve(c.text("node adapter context missing", 500));
     }

--- a/src/roles/app.ts
+++ b/src/roles/app.ts
@@ -13,7 +13,9 @@
 // hanging on a wedged drain.
 
 import { serve } from "@hono/node-server";
+import { RESPONSE_ALREADY_SENT } from "@hono/node-server/utils/response";
 import { createApp } from "../lib/server/http/app.js";
+import { createSvelteKitPassthrough } from "../lib/server/http/sveltekit-passthrough.js";
 import { env, scrubKekFromEnv } from "../lib/server/config/env.js";
 import { logger } from "../lib/server/logger.js";
 import { pool } from "../lib/server/db/client.js";
@@ -60,48 +62,10 @@ export async function start(): Promise<void> {
   }
 
   // SvelteKit pass-through: anything not matched above goes to SvelteKit.
-  //
-  // adapter-node writes directly to `outgoing` (Node's http.ServerResponse),
-  // so we cannot return a normal Hono Response — @hono/node-server would try
-  // to writeHead again and trip ERR_HTTP_HEADERS_SENT. Instead we return a
-  // sentinel Response and rely on @hono/node-server's outgoing.writableEnded
-  // check to bail before writing. The `next` callback is the explicit
-  // "SvelteKit didn't match this route" path — we serve a 404 in that case.
-  app.all("*", async (c) => {
-    const ctx = c.env as
-      | {
-          incoming?: import("node:http").IncomingMessage;
-          outgoing?: import("node:http").ServerResponse;
-        }
-      | undefined;
-    const incoming = ctx?.incoming;
-    const outgoing = ctx?.outgoing;
-    if (!incoming || !outgoing) {
-      return c.text("node adapter context missing", 500);
-    }
-    return new Promise<Response>((resolve) => {
-      let resolved = false;
-      const settle = (resp: Response): void => {
-        if (resolved) return;
-        resolved = true;
-        resolve(resp);
-      };
-      svelteHandler(incoming, outgoing, () => {
-        // SvelteKit decided this request is not its responsibility.
-        // outgoing has not been written; we can safely return a Hono 404.
-        settle(c.text("not found", 404));
-      });
-      // SvelteKit handled the request and wrote directly to outgoing.
-      // Return an empty Response — @hono/node-server checks
-      // outgoing.writableEnded before writing, so this is a no-op.
-      outgoing.on("close", () => {
-        settle(new Response(null, { status: outgoing.statusCode || 200 }));
-      });
-      outgoing.on("finish", () => {
-        settle(new Response(null, { status: outgoing.statusCode || 200 }));
-      });
-    });
-  });
+  // The resolve-path logic (RESPONSE_ALREADY_SENT once SvelteKit wrote to the
+  // raw response vs. a Hono 404 when it declined) lives in — and is unit
+  // tested by — sveltekit-passthrough.ts.
+  app.all("*", createSvelteKitPassthrough(svelteHandler, RESPONSE_ALREADY_SENT));
 
   const server = serve({ fetch: app.fetch, port: env.PORT }, (info) => {
     logger.info({ port: info.port, role: "app" }, "app role listening");

--- a/src/roles/app.ts
+++ b/src/roles/app.ts
@@ -15,7 +15,10 @@
 import { serve } from "@hono/node-server";
 import { RESPONSE_ALREADY_SENT } from "@hono/node-server/utils/response";
 import { createApp } from "../lib/server/http/app.js";
-import { createSvelteKitPassthrough } from "../lib/server/http/sveltekit-passthrough.js";
+import {
+  createSvelteKitPassthrough,
+  type SvelteHandler,
+} from "../lib/server/http/sveltekit-passthrough.js";
 import { env, scrubKekFromEnv } from "../lib/server/config/env.js";
 import { logger } from "../lib/server/logger.js";
 import { pool } from "../lib/server/db/client.js";
@@ -33,11 +36,7 @@ export async function start(): Promise<void> {
   // (a sibling of build/server.js). In dev (no tsup pass) the constant is
   // undefined and we fall back to the source-relative path. The `typeof`
   // guard makes both code paths typecheck with strict TS.
-  let svelteHandler: (
-    req: import("node:http").IncomingMessage,
-    res: import("node:http").ServerResponse,
-    next?: () => void,
-  ) => void;
+  let svelteHandler: SvelteHandler;
   const handlerPath =
     typeof __SVELTEKIT_HANDLER__ !== "undefined" ? __SVELTEKIT_HANDLER__ : "../../build/handler.js";
   try {

--- a/tests/unit/hono-sentinel-contract.test.ts
+++ b/tests/unit/hono-sentinel-contract.test.ts
@@ -1,0 +1,16 @@
+// Pins the upstream contract the SvelteKit pass-through fix depends on:
+// @hono/node-server's RESPONSE_ALREADY_SENT must carry the
+// `x-hono-already-sent` header (and a null body) — that header is the ONLY
+// signal node-server uses to skip a second writeHead (dist/index.mjs:751).
+// If an upstream rename/removal breaks this, fail here in <1ms rather than
+// only in the Docker smoke gate.
+
+import { describe, it, expect } from "vitest";
+import { RESPONSE_ALREADY_SENT } from "@hono/node-server/utils/response";
+
+describe("@hono/node-server RESPONSE_ALREADY_SENT contract", () => {
+  it("carries x-hono-already-sent:true and a null body", () => {
+    expect(RESPONSE_ALREADY_SENT.headers.get("x-hono-already-sent")).toBe("true");
+    expect(RESPONSE_ALREADY_SENT.body).toBeNull();
+  });
+});

--- a/tests/unit/sveltekit-passthrough.test.ts
+++ b/tests/unit/sveltekit-passthrough.test.ts
@@ -1,0 +1,99 @@
+// SvelteKit pass-through resolve-path tests.
+//
+// Locks the fix for ERR_HTTP_HEADERS_SENT: when SvelteKit writes the response
+// to the raw `outgoing` and fires finish/close, the handler must resolve with
+// the injected already-sent sentinel (in prod, @hono/node-server's
+// RESPONSE_ALREADY_SENT, which carries the `x-hono-already-sent` header) so
+// node-server does NOT writeHead a second time. When SvelteKit declines via
+// next(), a real 404 is returned instead.
+//
+// The sentinel is injected (see createSvelteKitPassthrough's signature), so
+// this test never imports @hono/node-server — it uses a marker Response and
+// asserts identity.
+
+import { describe, it, expect } from "vitest";
+import { EventEmitter } from "node:events";
+import type { Context } from "hono";
+import { createSvelteKitPassthrough } from "../../src/lib/server/http/sveltekit-passthrough.js";
+
+// Stand-in for @hono/node-server's RESPONSE_ALREADY_SENT — identity is what
+// the handler must return on finish/close.
+const ALREADY_SENT = new Response(null, { headers: { "x-hono-already-sent": "true" } });
+
+// Minimal Hono Context: the handler only reads c.env (incoming/outgoing) and
+// calls c.text(body, status).
+function fakeContext(env: unknown): Context {
+  return {
+    env,
+    text: (body: string, status?: number) => new Response(body, { status: status ?? 200 }),
+  } as unknown as Context;
+}
+
+function fakeOutgoing() {
+  return Object.assign(new EventEmitter(), { statusCode: 200 });
+}
+
+describe("createSvelteKitPassthrough", () => {
+  it("returns the already-sent sentinel when SvelteKit wrote the response (finish)", async () => {
+    const outgoing = fakeOutgoing();
+    // SvelteKit writes directly and fires 'finish' on a later tick (after the
+    // handler has attached its listeners).
+    const svelteHandler = (_req: unknown, res: unknown) => {
+      setImmediate(() => (res as EventEmitter).emit("finish"));
+    };
+    const handler = createSvelteKitPassthrough(svelteHandler as never, ALREADY_SENT);
+
+    const res = await handler(fakeContext({ incoming: {}, outgoing }));
+
+    expect(res).toBe(ALREADY_SENT);
+    expect(res.headers.get("x-hono-already-sent")).toBe("true");
+  });
+
+  it("returns the already-sent sentinel on 'close' too", async () => {
+    const outgoing = fakeOutgoing();
+    const svelteHandler = (_req: unknown, res: unknown) => {
+      setImmediate(() => (res as EventEmitter).emit("close"));
+    };
+    const handler = createSvelteKitPassthrough(svelteHandler as never, ALREADY_SENT);
+
+    const res = await handler(fakeContext({ incoming: {}, outgoing }));
+
+    expect(res).toBe(ALREADY_SENT);
+  });
+
+  it("returns a real 404 when SvelteKit declines the route (next)", async () => {
+    const outgoing = fakeOutgoing();
+    const svelteHandler = (_req: unknown, _res: unknown, next?: () => void) => {
+      next?.();
+    };
+    const handler = createSvelteKitPassthrough(svelteHandler as never, ALREADY_SENT);
+
+    const res = await handler(fakeContext({ incoming: {}, outgoing }));
+
+    expect(res).not.toBe(ALREADY_SENT);
+    expect(res.status).toBe(404);
+    expect(await res.text()).toBe("not found");
+  });
+
+  it("first signal wins — a later finish does not override the next() 404", async () => {
+    const outgoing = fakeOutgoing();
+    const svelteHandler = (_req: unknown, res: unknown, next?: () => void) => {
+      next?.();
+      setImmediate(() => (res as EventEmitter).emit("finish"));
+    };
+    const handler = createSvelteKitPassthrough(svelteHandler as never, ALREADY_SENT);
+
+    const res = await handler(fakeContext({ incoming: {}, outgoing }));
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 500 when the node adapter context is missing", async () => {
+    const handler = createSvelteKitPassthrough(((): void => {}) as never, ALREADY_SENT);
+
+    const res = await handler(fakeContext(undefined));
+
+    expect(res.status).toBe(500);
+    expect(await res.text()).toBe("node adapter context missing");
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes the recurring `ERR_HTTP_HEADERS_SENT: Cannot write headers after they are sent` (~every 10-30 min on prod from scanner traffic) — the last real bug surfaced by #42's catch-all panel + `escaped-error-logs` alert.
- Root cause: the Hono catch-all returned `new Response(null, { status })` after adapter-node already wrote to the raw `ServerResponse`. `@hono/node-server@2.0.2` skips a second `writeHead` ONLY when the Response carries the `x-hono-already-sent` header (`dist/index.mjs:751`); a bare Response lacks it → node-server `writeHead`s again → throw. The old comment's "node-server checks `outgoing.writableEnded`" was simply false.
- Fix: return the library's documented `RESPONSE_ALREADY_SENT` sentinel.

Closes #46.

## Design
Extracted the pass-through into `src/lib/server/http/sveltekit-passthrough.ts` with the sentinel **injected** — the module stays a pure, dependency-light unit (no `@hono/node-server` import) that unit tests drive with a marker Response; `roles/app.ts` (composition root) owns the import and passes the real `RESPONSE_ALREADY_SENT`.

## Once deployed
The `escaped-error-logs` alert should stop firing and the "Escaped Errors" panel should go quiet — that's the live confirmation.

## Test plan
- [x] `vitest` — 5 cases: finish→sentinel, close→sentinel, next→404, first-signal-wins, missing-ctx→500
- [x] `pnpm typecheck` (svelte-check) 0 errors; `eslint` + `prettier --check` clean on touched files
- [ ] **smoke** (CI) — exercises the real `serve()` + adapter-node stack end-to-end through unmatched routes
- [ ] Deploy-verify: after merge, no new `ERR_HTTP_HEADERS_SENT` in the Escaped Errors panel; `escaped-error-logs` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)