### PR TITLE
fix(worker): stop undici/pg idle-socket errors from crashing the worker

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -30,6 +30,9 @@
 // production `node` entrypoints all hit the same single-shot call.
 // Node's module cache dedupes — second import is a no-op.
 import "./lib/server/integrations/dns-bootstrap.js";
+// HTTP/1.1-only outbound (no h2) — see undici-bootstrap.ts. Mirrors server.ts so
+// the SSR path shares the single setGlobalDispatcher call (module-cache deduped).
+import "./lib/server/integrations/undici-bootstrap.js";
 import { sequence } from "@sveltejs/kit/hooks";
 import type { Handle, HandleServerError } from "@sveltejs/kit";
 import { auth } from "./lib/auth.js";

--- a/src/lib/server/db/client.ts
+++ b/src/lib/server/db/client.ts
@@ -14,6 +14,7 @@ import { Pool } from "pg";
 import { drizzle } from "drizzle-orm/node-postgres";
 import * as schema from "./schema/index.js";
 import { env } from "../config/env.js";
+import { logger } from "../logger.js";
 
 const POOL_MAX_BY_ROLE: Record<typeof env.APP_ROLE, number> = {
   app: 10,
@@ -25,6 +26,16 @@ export const pool = new Pool({
   connectionString: env.DATABASE_URL,
   max: POOL_MAX_BY_ROLE[env.APP_ROLE],
   idleTimeoutMillis: 30_000,
+});
+
+// node-postgres emits 'error' on an IDLE pooled client whose backend connection
+// drops (DB restart, network blip, server-side idle kill). Without a listener pg
+// re-throws it as an uncaughtException — crashing the process for an event the
+// pool already recovers from (it discards the dead client; the next checkout
+// opens a fresh one). Log and let the pool heal. An ACTIVE query's error still
+// rejects that query's promise as before — this covers only idle clients.
+pool.on("error", (err) => {
+  logger.error({ err }, "pg idle client error — pool will discard and reconnect");
 });
 
 export const db = drizzle(pool, { schema });

--- a/src/lib/server/integrations/undici-bootstrap.ts
+++ b/src/lib/server/integrations/undici-bootstrap.ts
@@ -19,6 +19,18 @@
 // module cache dedupes the single setGlobalDispatcher call. Server-only by
 // placement under $lib/server/. Only `allowH2` is overridden; every other undici
 // Agent default (keep-alive timeouts, pool sizing) is preserved.
+//
+// MAINTAINER NOTE — this REPLACES the entire global dispatcher (undici has no
+// compose), and it runs very early at module load. Any future code that also
+// installs a global dispatcher must account for the ordering and preserve the
+// allowH2:false intent, or it silently reintroduces the worker-crash bug:
+//   - env outbound proxy (honoring HTTP(S)_PROXY): build it with
+//     `new ProxyAgent({ uri, ...GLOBAL_UNDICI_OPTIONS })` and run it AFTER this
+//     bootstrap (it intentionally supersedes this Agent, keeping allowH2:false).
+//   - MockAgent in tests: call `setGlobalDispatcher(mockAgent)` AFTER the import
+//     that pulls in this module, else this one-shot side effect clobbers the mock.
+// `GLOBAL_UNDICI_OPTIONS` is exported so those call sites can spread the same
+// intent instead of re-deciding it.
 
 import { Agent, setGlobalDispatcher } from "undici";
 

--- a/src/lib/server/integrations/undici-bootstrap.ts
+++ b/src/lib/server/integrations/undici-bootstrap.ts
@@ -1,0 +1,27 @@
+// undici bootstrap — force HTTP/1.1 for all process-wide outbound `fetch`.
+//
+// Why: undici's connector negotiates HTTP/2 by default (allowH2 true). When the
+// OTHER side closes an idle keep-alive h2 connection, undici emits a SocketError
+// on the h2 session-end (client-h2.js onHttp2SocketEnd) with NO in-flight request
+// to attach it to. That async error escapes every request-level try/catch and
+// reaches process 'uncaughtException' → crash-handlers exit(1) → the process dies
+// (observed: the worker crashing ~2×/day on the flaky Reddit proxy). Over HTTP/1.1
+// undici instead drops an idle-closed socket from the pool and rejects the NEXT
+// reuse inside the awaited request — a recoverable, catchable path.
+//
+// The Reddit ProxyAgent sets allowH2:false on its own dispatcher; this covers the
+// GLOBAL fetch path used by YouTube/Steam/Reddit-direct, so no h2 upstream idle
+// close can crash the process. Every upstream supports h1; h2 multiplexing is
+// irrelevant at this app's QPS.
+//
+// Side-effect on import, set once per process before the first fetch — mirrors
+// dns-bootstrap. Imported from src/server.ts and src/hooks.server.ts; Node's
+// module cache dedupes the single setGlobalDispatcher call. Server-only by
+// placement under $lib/server/. Only `allowH2` is overridden; every other undici
+// Agent default (keep-alive timeouts, pool sizing) is preserved.
+
+import { Agent, setGlobalDispatcher } from "undici";
+
+export const GLOBAL_UNDICI_OPTIONS = { allowH2: false } as const;
+
+setGlobalDispatcher(new Agent(GLOBAL_UNDICI_OPTIONS));

--- a/src/lib/sources/reddit/server/http.ts
+++ b/src/lib/sources/reddit/server/http.ts
@@ -83,11 +83,21 @@ const BURST_THRESHOLD = 3;
 // every redditFetch (keep-alive is what makes residential-proxy latency
 // tolerable — TCP+TLS handshake per call would dominate).
 // Empty/unset env var → null → direct fetch (self-host parity).
+//
+// allowH2:false forces HTTP/1.1 to the proxy/origin. undici negotiates h2 by
+// default; an idle keep-alive h2 connection the proxy closes makes undici emit
+// a SocketError on the h2 session-end (client-h2.js onHttp2SocketEnd) with NO
+// in-flight request — so it escapes the redditFetch try/catch below and reaches
+// process 'uncaughtException', crashing the worker (~2×/day on the flaky
+// Webshare proxy). h1 drops an idle-closed socket from the pool gracefully (the
+// next reuse rejects inside the awaited fetch). Reddit/the proxy support h1;
+// h2 multiplexing is irrelevant at the 10 req/min ceiling.
+export const REDDIT_PROXY_AGENT_OPTIONS = { allowH2: false } as const;
 let cachedProxyAgent: ProxyAgent | null = null;
 function getProxyDispatcher(): ProxyAgent | null {
   if (!env.REDDIT_PROXY_URL) return null;
   if (cachedProxyAgent === null) {
-    cachedProxyAgent = new ProxyAgent(env.REDDIT_PROXY_URL);
+    cachedProxyAgent = new ProxyAgent({ uri: env.REDDIT_PROXY_URL, ...REDDIT_PROXY_AGENT_OPTIONS });
     logger.info(
       { proxyHost: new URL(env.REDDIT_PROXY_URL).host },
       "reddit outbound proxy configured",

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,9 @@
 // env / logger imports keeps the resolver order set even if a downstream
 // module fires an outbound fetch at module-load time.
 import "./lib/server/integrations/dns-bootstrap.js";
+// Force HTTP/1.1 on all outbound fetch (no h2) so an idle keep-alive socket the
+// upstream closes can't escape to uncaughtException. Set before any fetch.
+import "./lib/server/integrations/undici-bootstrap.js";
 import { env } from "./lib/server/config/env.js";
 import { logger } from "./lib/server/logger.js";
 import { registerCrashHandlers } from "./lib/server/crash-handlers.js";

--- a/tests/integration/db-pool-error-handler.test.ts
+++ b/tests/integration/db-pool-error-handler.test.ts
@@ -1,0 +1,26 @@
+// Regression guard: the pg Pool MUST have an 'error' listener. node-postgres
+// emits 'error' on an idle pooled client whose backend connection drops; with no
+// listener, Node's EventEmitter re-throws it as an uncaughtException and the
+// process crashes for a recoverable event the pool already heals from. This was
+// the second escape route found in the worker-socket-crash RCA (the first being
+// undici h2 idle sockets).
+//
+// Real env/pool (integration project) — importing db/client constructs the Pool.
+
+import { describe, it, expect } from "vitest";
+
+const { pool } = await import("../../src/lib/server/db/client.js");
+
+describe("db pool error handler", () => {
+  it("has an 'error' listener so a dropped idle backend connection can't crash the process", () => {
+    expect(pool.listenerCount("error")).toBeGreaterThan(0);
+  });
+
+  it("a synthetic idle-client 'error' is absorbed, not thrown", () => {
+    // Without the listener, emitting 'error' would throw (EventEmitter contract).
+    // The handler logs and returns, so this must NOT throw.
+    expect(() =>
+      pool.emit("error", new Error("synthetic idle backend drop"), undefined as never),
+    ).not.toThrow();
+  });
+});

--- a/tests/unit/sources/reddit/http.test.ts
+++ b/tests/unit/sources/reddit/http.test.ts
@@ -148,6 +148,14 @@ describe("redditFetch (Phase 03.1 DV-RDT-7) — AdapterError taxonomy", () => {
     expect(reqHeaders["User-Agent"]).toBe(REDDIT_UA);
   });
 
+  it("proxy dispatcher forces HTTP/1.1 (allowH2:false) — avoids the h2 idle-socket crash", async () => {
+    // Regression guard for the worker crash: an idle keep-alive h2 connection the
+    // proxy closes escapes to uncaughtException. allowH2:false keeps the proxy on
+    // h1, which drops idle-closed sockets from the pool gracefully.
+    const { REDDIT_PROXY_AGENT_OPTIONS } = await import("$lib/sources/reddit/server/http.js");
+    expect(REDDIT_PROXY_AGENT_OPTIONS.allowH2).toBe(false);
+  });
+
   it("404 → AdapterError(not-found)", async () => {
     fetchSpy.mockResolvedValueOnce(new Response("", { status: 404 }));
     const { redditFetch, __resetBurstStateForTest } =

--- a/tests/unit/undici-bootstrap.test.ts
+++ b/tests/unit/undici-bootstrap.test.ts
@@ -1,0 +1,19 @@
+// undici-bootstrap forces HTTP/1.1 on the global dispatcher so an idle keep-alive
+// h2 socket the upstream closes can't escape to uncaughtException and crash the
+// process (the worker-socket-crash fix). Importing the module runs the one-shot
+// setGlobalDispatcher side effect.
+
+import { describe, it, expect } from "vitest";
+import { Agent, getGlobalDispatcher } from "undici";
+import { GLOBAL_UNDICI_OPTIONS } from "../../src/lib/server/integrations/undici-bootstrap.js";
+
+describe("undici-bootstrap", () => {
+  it("pins allowH2:false (HTTP/1.1) as the global outbound contract", () => {
+    expect(GLOBAL_UNDICI_OPTIONS.allowH2).toBe(false);
+  });
+
+  it("installs an undici Agent as the global dispatcher", () => {
+    // The import side effect already called setGlobalDispatcher(new Agent(...)).
+    expect(getGlobalDispatcher()).toBeInstanceOf(Agent);
+  });
+});


### PR DESCRIPTION
## Summary
The `worker` crashed ~2×/day with a FATAL `uncaughtException` (found via Grafana/Loki). An **idle keep-alive HTTP/2** connection in the cached Reddit `ProxyAgent` pool (Webshare proxy) is closed by the other side; undici emits `SocketError("other side closed", UND_ERR_SOCKET)` on the h2 session-end with **no in-flight request**, so it escapes `redditFetch`'s try/catch → `process 'uncaughtException'` → `exit(1)` → Docker restart.

- The class is **broader than Reddit** — undici negotiates h2 by default, so YouTube/Steam via global `fetch` are equally exposed.
- A **second escape route**: `pg.Pool` had no `'error'` listener, so an idle backend drop (`ECONNRESET`/`ETIMEDOUT`) also became an `uncaughtException`.
- Reddit's IP ban (403) is a **separate, external** problem; this PR is only the crash.

## What changed
- **Reddit ProxyAgent `allowH2:false`** → HTTP/1.1, which drops an idle-closed socket from the pool gracefully (the next reuse rejects inside the awaited fetch).
- **`undici-bootstrap.ts`** — `setGlobalDispatcher(new Agent({ allowH2:false }))` at boot (mirrors `dns-bootstrap`), covering all global-fetch egress (YouTube/Steam/Reddit-direct). Only `allowH2` is overridden; every other undici default is preserved.
- **`db/client.ts` `pool.on('error', …)`** — the documented node-postgres pattern; an idle client drop is logged and the pool reconnects instead of crashing.

## Why NOT swallow `uncaughtException`
The first design swallowed a scoped allowlist of socket error codes in `crash-handlers`. A **design review (fresh-context agent) caught a P0**: `ECONNRESET`/`ETIMEDOUT`/`EPIPE` are also emitted by the pg/pg-boss pool — that allowlist would mask real DB failures that **must** restart the worker. So the crash-semantic invariant is kept; transient socket errors are handled at their **source** (dispatcher / pool) instead. This is also what AGENTS.md asks for ("validate at boundaries", "no handling for undefined states", KISS).

## Test plan
- **Unit:** `allowH2:false` pinned for the Reddit proxy (`REDDIT_PROXY_AGENT_OPTIONS`) and the global dispatcher (`GLOBAL_UNDICI_OPTIONS`); global dispatcher is an undici `Agent`.
- **Integration (real Postgres):** the pg pool has an `'error'` listener and a synthetic idle drop is **absorbed, not thrown** (would throw without the handler — EventEmitter `'error'` contract). `anonymous-401` (29) green → the global-dispatcher boot change doesn't break the HTTP path.
- **Smoke (CI):** the production image exercises real outbound egress over HTTP/1.1 (oauth/reddit mocks) — the behavioral proof that h1 works end-to-end.
- Local: `tsc`, `svelte-check` (0 errors), `pnpm build` all green.

## Self-review
- **Principles:** one-source-of-truth bootstrap (`undici-bootstrap` mirrors `dns-bootstrap`); fix at the boundary, not a global error swallow. No new env/migration/DTO/API. Additive `pool.on('error')` — existing active-query error path unchanged.
- **Tenant scoping / secrets:** untouched.
- **Behavioral test honesty:** a full ALPN/TLS test would require committing a private key (smell) or runtime openssl (cross-platform flaky); instead the `allowH2:false` contract is pinned in unit tests and the **real egress is exercised by the smoke gate** on the prod image.

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)