### PR TITLE
fix(monitoring): stop "Scrape Target Down" alert firing on a healthy app

### DIFF
--- a/monitoring/grafana/provisioning/alerting/alert-rules.yml
+++ b/monitoring/grafana/provisioning/alerting/alert-rules.yml
@@ -78,7 +78,17 @@ groups:
 
       - uid: scrape-target-down
         title: "Scrape Target Down (up == 0)"
-        condition: A
+        # Two-stage (mirrors escaped-error-logs): A = the raw `up` gauge,
+        # B = explicit threshold "up < 1". The OLD form used `up == 0` as a
+        # bare condition with noDataState: Alerting — when the app was healthy
+        # (up=1) the `== 0` filter returned EMPTY, Grafana read that as NoData,
+        # and noDataState: Alerting FIRED a critical alert on a HEALTHY app
+        # (false-positive that fired continuously for ~22h). Explicit threshold
+        # removes the implicit reduce-of-a-bare-comparison ambiguity:
+        #   up=1                → 1, not < 1 → Normal (silent)
+        #   up=0 (scrape fails, target present) → 0 < 1 → fires after for:2m
+        #   no `up` sample at all (Prometheus blind) → NoData → OK
+        condition: B
         data:
           - refId: A
             relativeTimeRange:
@@ -86,13 +96,29 @@ groups:
               to: 0
             datasourceUid: prometheus
             model:
-              expr: up{job="neotolis-app"} == 0
-              instant: false
+              expr: up{job="neotolis-app"}
+              instant: true
               intervalMs: 15000
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              conditions:
+                - evaluator:
+                    type: lt
+                    params: [1]
+              refId: B
         for: 2m
-        noDataState: Alerting
-        execErrState: Alerting
+        noDataState: OK
+        execErrState: OK
         annotations:
           summary: "Prometheus cannot scrape the app — container may be down or /metrics unreachable"
         labels:


### PR DESCRIPTION
## Why

The `scrape-target-down` Grafana alert (critical) was firing **continuously for ~22h while prod was healthy**. Root cause: `up{job="neotolis-app"} == 0` as a bare condition + `noDataState: Alerting`. When the app is up (`up=1`), the `== 0` filter returns empty → Grafana reads NoData → `Alerting` fires. It paged *because* the app was healthy. (App was demonstrably up: `up=1`, 200-only traffic, p95 ~22ms.)

## What

Rewrite to the explicit two-stage threshold form already used by `escaped-error-logs` in the same file:
- A = `up{job="neotolis-app"}` (instant gauge), B = threshold `up < 1`, `condition: B`.
- `noDataState` / `execErrState` → `OK` (match the other four rules).

Behavior: `up=1` → Normal (silent) · `up=0` (scrape fails, target present) → fires after `for: 2m` · no `up` sample at all → NoData → OK.

Removes the implicit reduce-of-a-bare-comparison ambiguity and the `instant: false` range-reducer fragility. Monitoring-only — app/worker/scheduler/postgres untouched.

## Test plan

- `js-yaml` parse + structural assertions pass (condition=B, threshold `lt 1`, OK/OK, `for: 2m`, severity critical).
- Plan reviewed by a separate agent (verdict: sound-with-changes; this PR is the revised form).
- Post-deploy (manual): restart only `grafana`, confirm no provisioning errors in logs, read the rule back via API, watch it transition to **Normal**, remove any silence added during the false-fire. CI does not lint alert YAML — validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)