### PR TITLE
fix(instagram): Phase 8 review follow-ups (identity, backfill continuation, error mapping, audit, redaction)

### DIFF
--- a/src/lib/server/http/routes/events.ts
+++ b/src/lib/server/http/routes/events.ts
@@ -236,8 +236,16 @@ const attachSchema = z.union([
 // write. The /events/new client calls this before the user submits the
 // form so they see auto-filled title + thumbnail + external_id without
 // committing the row.
+// http(s)-only at the boundary. z.string().url() alone accepts file://,
+// gopher://, etc. The downstream URL parsers reject any non-http(s)-Instagram /
+// -YouTube / -Reddit shape before a fetch ever fires, so this is harmless
+// today — but "validate at boundaries" (AGENTS.md) wants the scheme constraint
+// stated explicitly here rather than relied upon transitively.
 const previewUrlSchema = z.object({
-  url: z.string().url(),
+  url: z
+    .string()
+    .url()
+    .refine((u) => /^https?:\/\//i.test(u), { message: "url must use http(s)" }),
 });
 
 // PATCH /api/events/bulk schema (D-12). Tri-state semantics per game id

--- a/src/lib/server/logger.ts
+++ b/src/lib/server/logger.ts
@@ -65,6 +65,15 @@ export const REDACT_PATHS = [
   // snake) and the singleton field name (lowerCamel).
   "*.SERVICE_YOUTUBE_API_KEYS",
   "*.serviceYoutubeApiKeys",
+  // Operator's prepaid ScrapeCreators API key. Same lifetime trap as the
+  // YouTube key envelope above: scrubKekFromEnv() wipes SCRAPECREATORS_API_KEY
+  // from process.env after boot (see SECRET_KEYS in env.ts), but the env
+  // singleton retains it for the process lifetime — a stray logger.info({ env })
+  // would leak it. The transitive *.apiKey / *.api_key paths do NOT match the
+  // singleton field name, so the key gets its own dedicated paths (env-key
+  // uppercase snake + singleton lowerCamel), mirroring the YouTube entries.
+  "*.SCRAPECREATORS_API_KEY",
+  "*.scrapecreatorsApiKey",
   // Phase 03.1 — Reddit response/request opsec (DV-RDT-7).
   // Reddit doesn't use OAuth under DV-RDT-7 (public-`.json` adapter only),
   // but the redact list treats these field names as redacted regardless:

--- a/src/lib/server/services/events-mutation.ts
+++ b/src/lib/server/services/events-mutation.ts
@@ -540,13 +540,9 @@ export async function enrichFromUrl(
   // rare manual paste — the user simply types the title (the cost guardrail
   // still held: no credit was burned).
   if (parsed.kind === "instagram_post") {
-    // Recognition-only keeps the URL-parsed SHORTCODE — when no live fetch
-    // happens (provider unconfigured, cap-exhausted, error, deleted post) the
-    // media id is unknown and there is no instagram_posts cache row to match
-    // against anyway. Such an event won't enrich (thumbnail / stats / poll
-    // badge) until a real fetch resolves the media id; the next account-level
-    // poll inserts the canonical media-id row and the user can re-save / the
-    // walker fan-out covers it.
+    // Recognition-only keeps the URL-parsed SHORTCODE (no live fetch → the media
+    // id is unknown). Such an event won't enrich until a real fetch / the next
+    // account-level poll resolves the canonical media id.
     const recognitionOnly: EnrichmentResult = {
       kind: "instagram_post",
       externalId: parsed.externalId,

--- a/src/lib/server/services/events-mutation.ts
+++ b/src/lib/server/services/events-mutation.ts
@@ -540,6 +540,13 @@ export async function enrichFromUrl(
   // rare manual paste — the user simply types the title (the cost guardrail
   // still held: no credit was burned).
   if (parsed.kind === "instagram_post") {
+    // Recognition-only keeps the URL-parsed SHORTCODE — when no live fetch
+    // happens (provider unconfigured, cap-exhausted, error, deleted post) the
+    // media id is unknown and there is no instagram_posts cache row to match
+    // against anyway. Such an event won't enrich (thumbnail / stats / poll
+    // badge) until a real fetch resolves the media id; the next account-level
+    // poll inserts the canonical media-id row and the user can re-save / the
+    // walker fan-out covers it.
     const recognitionOnly: EnrichmentResult = {
       kind: "instagram_post",
       externalId: parsed.externalId,
@@ -591,7 +598,13 @@ export async function enrichFromUrl(
 
     return {
       kind: "instagram_post",
-      externalId: parsed.externalId,
+      // The MEDIA id (preview.externalId = post.id), NOT the URL shortcode. The
+      // single-post fetch UPSERTed instagram_posts + a snapshot keyed by the
+      // media id; saving the event with the shortcode would orphan it from the
+      // cache so feed-enrichment / metric-series / poll-state / refresh-now
+      // never match. Falls back to the parsed shortcode only if the adapter
+      // didn't surface a media id (defensive — the IG adapter always does).
+      externalId: preview.externalId ?? parsed.externalId,
       title: preview.title,
       occurredAt: preview.occurredAt ?? null,
       thumbnailUrl: preview.thumbnailUrl ?? null,

--- a/src/lib/server/services/events-mutation.ts
+++ b/src/lib/server/services/events-mutation.ts
@@ -570,6 +570,14 @@ export async function enrichFromUrl(
         );
         return recognitionOnly;
       }
+      // EXPECTED failures (AdapterError network/operator-issue, any other typed
+      // AppError) soft-degrade — manual entry must never dead-end. But an
+      // UNEXPECTED throw (a programmer bug in the adapter: bad import, undefined
+      // access, etc.) is NOT in the degrade contract — re-throw it so it
+      // surfaces as a 500 + escaped-error log rather than hiding behind a benign
+      // WARN. Mirrors the reddit branch, which lets all throws propagate.
+      const { AdapterError } = await import("$lib/sources/errors.js");
+      if (!(err instanceof AppError) && !(err instanceof AdapterError)) throw err;
       logger.warn(
         { userId, url: parsed.canonicalUrl, err: String((err as Error)?.message ?? err) },
         "instagram preview threw; degrading to recognition-only manual entry",

--- a/src/lib/server/services/events-mutation.ts
+++ b/src/lib/server/services/events-mutation.ts
@@ -530,19 +530,16 @@ export async function enrichFromUrl(
   // fully in /feed. The "Fetch" button now auto-fills title (caption first
   // line) + description + thumbnail.
   //
-  // GRACEFUL DEGRADE is load-bearing: a failed preview (provider not
-  // configured, network error, budget/cap exhaustion, deleted post) must NOT
-  // break manual entry. Every non-ok path falls through to the recognition-only
-  // shape (kind + shortcode + canonical permalink, empty title) — exactly what
-  // the form needs to lock kind=Instagram and let the user type the title (the
-  // required-asterisk field forbids an empty save). For cap-exhaustion we prefer
-  // this soft path over a hard 429 so the Add Event UX never dead-ends on a
-  // rare manual paste — the user simply types the title (the cost guardrail
-  // still held: no credit was burned).
+  // GRACEFUL DEGRADE is load-bearing: every non-ok path (provider unconfigured,
+  // network error, budget/cap exhaustion, deleted post) falls through to the
+  // recognition-only shape so manual entry never dead-ends. Cap-exhaustion takes
+  // the soft path over a hard 429 — no credit was burned, so the cost guardrail
+  // still held.
   if (parsed.kind === "instagram_post") {
-    // Recognition-only keeps the URL-parsed SHORTCODE (no live fetch → the media
-    // id is unknown). Such an event won't enrich until a real fetch / the next
-    // account-level poll resolves the canonical media id.
+    // Recognition-only carries the URL SHORTCODE, not the media id the cache keys
+    // on (no live fetch). It won't enrich, and a later account poll won't re-bind
+    // it (that poll creates a SEPARATE media-id-keyed event) — re-paste once the
+    // provider recovers to get an enriched event.
     const recognitionOnly: EnrichmentResult = {
       kind: "instagram_post",
       externalId: parsed.externalId,
@@ -565,7 +562,7 @@ export async function enrichFromUrl(
       });
     } catch (err) {
       // Cap-exhaustion (AppError 429) → soft-degrade to recognition-only rather
-      // than dead-ending the form. Any other adapter throw also degrades.
+      // than dead-ending the form.
       if (err instanceof AppError && err.code === "requests_quota_exhausted") {
         logger.info(
           { userId, url: parsed.canonicalUrl },

--- a/src/lib/sources/adapter.ts
+++ b/src/lib/sources/adapter.ts
@@ -380,6 +380,14 @@ export type EventPreviewMetadata =
       occurredAt?: Date;
       thumbnailUrl?: string;
       html?: string;
+      // The canonical id the adapter's read paths (cache lookup, snapshot,
+      // poll-state, refresh-now) key on, when it differs from the URL-parsed
+      // externalId. Instagram sets this to the MEDIA id (post.id) because the
+      // shortcode in the permalink is NOT what instagram_posts.post_id stores —
+      // saving the event with the shortcode would orphan it from its cache row.
+      // Adapters whose URL-parsed externalId already matches the cache key (e.g.
+      // YouTube's videoId) leave this undefined and the caller keeps the parsed id.
+      externalId?: string;
     }
   | { kind: "private" }
   | { kind: "unavailable" }

--- a/src/lib/sources/instagram/server/handlers/backfill-account.ts
+++ b/src/lib/sources/instagram/server/handlers/backfill-account.ts
@@ -38,6 +38,8 @@ import { dataSources } from "$lib/server/db/schema/data-sources.js";
 import { events } from "$lib/server/db/schema/events.js";
 import { logger } from "$lib/server/logger.js";
 import { writeAuditStrict } from "$lib/server/audit.js";
+import { enqueueViaOutbox } from "$lib/server/services/outbox.js";
+import { QUEUES } from "$lib/server/queues.js";
 import {
   markSourceNeedsReconnect,
   clearNeedsReconnect,
@@ -396,7 +398,61 @@ export async function handleBackfillAccount(job: BackfillAccountJob): Promise<vo
   //    (feed-enrichment) overlays it onto each IG event DTO's
   //    metadata.operator_paused, which the PollingBadge consumes.
   state.operatorPaused = pausedByBudget;
-  await writeInstagramBackfillState(channelKey, state);
+
+  // Account-level complete = BOTH feeds exhausted AND not paused mid-budget.
+  // Computed BEFORE the state write so the continuation gate below can read it
+  // inside the same transaction.
+  const accountComplete = !pausedByBudget && FEEDS.every((f) => state[f].complete);
+
+  // SELF-ENQUEUE the next page of a bounded DEEP backfill (initial / historical)
+  // so a multi-page archive completes promptly instead of crawling one page per
+  // 6h cron tick. The cursor write + the continuation intent commit ATOMICALLY
+  // via the outbox in the SAME transaction (AGENTS.md atomic-dual-write — never
+  // boss.send outside a state-mutating tx): if the worker crashes after the
+  // commit, the forwarder still delivers; if it crashes before, neither lands.
+  //
+  // Termination is load-bearing — enqueue ONLY when ALL hold:
+  //   - branch === "deep"            the resumable historical/initial walk that
+  //                                  RESUMES from the persisted cursor (strictly
+  //                                  advances each tick). The incremental /
+  //                                  exhausted branches reset every feed to page
+  //                                  1 each tick (new-only sweep, BACK-03) and
+  //                                  are bounded by the date window — a
+  //                                  continuation there would re-fetch page 1
+  //                                  forever (infinite loop). They are
+  //                                  single-page by design and rely on cron.
+  //   - !accountComplete             both feeds NOT yet exhausted → real work left.
+  //   - !pausedByBudget              a budget pause means the next reserve would
+  //                                  be refused too — let cron retry after the
+  //                                  daily-cap reset / top-up, don't spin.
+  //   - state.collected < maxPosts   the BACK-01 post-count cap bounds historical
+  //                                  depth; at the cap the deep branch already
+  //                                  marks feeds complete (→ accountComplete), but
+  //                                  this is the explicit belt-and-suspenders stop.
+  // singletonKey backfill-account-<channelKey> dedupes against a parallel
+  // user/cron trigger — at most one continuation in flight per account.
+  const shouldContinue =
+    branch === "deep" && !accountComplete && !pausedByBudget && state.collected < maxPosts;
+  await db.transaction(async (tx) => {
+    await writeInstagramBackfillState(channelKey, state, tx);
+    if (shouldContinue) {
+      await enqueueViaOutbox(
+        tx,
+        QUEUES.INSTAGRAM_BACKFILL_ACCOUNT,
+        {
+          kind: KIND,
+          channelKey,
+          // triggerUserId OMITTED — continuation pages run on the cron pool
+          // (Pitfall 5: the trigger user pays the per-user cap ONCE on the first
+          // page; subsequent pages free-ride, mirroring YouTube/Reddit).
+          depthBoundIso: job.data.depthBoundIso,
+          flow,
+          forceDeep: job.data.forceDeep,
+        },
+        { singletonKey: `backfill-account-${channelKey}` },
+      );
+    }
+  });
   if (branch === "deep" && oldestFetchedOccurredAt !== null) {
     // Frontier = the oldest event this deep walk fetched. markChannelBackfillFrontier
     // WHERE-guards the deeper-only move, so a shallower write never rolls it back.
@@ -409,8 +465,6 @@ export async function handleBackfillAccount(job: BackfillAccountJob): Promise<vo
     }
   }
 
-  // Account-level complete = BOTH feeds exhausted AND not paused mid-budget.
-  const accountComplete = !pausedByBudget && FEEDS.every((f) => state[f].complete);
   if (accountComplete) {
     await markChannelBackfillComplete(KIND, channelKey);
   }

--- a/src/lib/sources/instagram/server/handlers/backfill-account.ts
+++ b/src/lib/sources/instagram/server/handlers/backfill-account.ts
@@ -429,11 +429,11 @@ export async function handleBackfillAccount(job: BackfillAccountJob): Promise<vo
   //                                  depth; at the cap the deep branch already
   //                                  marks feeds complete (→ accountComplete), but
   //                                  this is the explicit belt-and-suspenders stop.
-  // singletonKey is a best-effort coalescing hint on a standard-policy queue, NOT
-  // a hard single-flight guard. Duplicate EVENTS are prevented by
-  // onConflictDoNothing on the insert (mirrors YouTube); a rare concurrent walk
-  // may double a provider fetch, but total spend is bounded by the prepaid-balance
-  // ceiling (reserveSocialCredits).
+  // singletonKey is a no-op for dedup on this standard-policy queue (no
+  // singletonSeconds). Duplicate EVENTS are prevented by onConflictDoNothing on
+  // the insert; a concurrent double-fetch's spend is bounded by the prepaid
+  // ceiling (reserveSocialCredits). Kept harmless + future-proof if the policy
+  // ever gains singletonSeconds.
   const shouldContinue =
     branch === "deep" && !accountComplete && !pausedByBudget && state.collected < maxPosts;
   await db.transaction(async (tx) => {

--- a/src/lib/sources/instagram/server/handlers/backfill-account.ts
+++ b/src/lib/sources/instagram/server/handlers/backfill-account.ts
@@ -429,8 +429,11 @@ export async function handleBackfillAccount(job: BackfillAccountJob): Promise<vo
   //                                  depth; at the cap the deep branch already
   //                                  marks feeds complete (→ accountComplete), but
   //                                  this is the explicit belt-and-suspenders stop.
-  // singletonKey backfill-account-<channelKey> dedupes against a parallel
-  // user/cron trigger — at most one continuation in flight per account.
+  // singletonKey is a best-effort coalescing hint on a standard-policy queue, NOT
+  // a hard single-flight guard. Duplicate EVENTS are prevented by
+  // onConflictDoNothing on the insert (mirrors YouTube); a rare concurrent walk
+  // may double a provider fetch, but total spend is bounded by the prepaid-balance
+  // ceiling (reserveSocialCredits).
   const shouldContinue =
     branch === "deep" && !accountComplete && !pausedByBudget && state.collected < maxPosts;
   await db.transaction(async (tx) => {

--- a/src/lib/sources/instagram/server/index.ts
+++ b/src/lib/sources/instagram/server/index.ts
@@ -408,29 +408,20 @@ async function enqueueRefreshNow(input: {
 /**
  * fetchEventPreviewMetadata — adapter wrapper for the Add Event "Fetch" button
  * (POST /api/events/preview-url). Mirrors Reddit's synchronous single-post
- * preview (sources/reddit/server/index.ts): ONE by-URL provider request (1
- * credit), cap-gated against the per-user 50/day social cap, then UPSERTs the
- * instagram_posts cache + a snapshot row so the saved event renders fully in
- * /feed (thumbnail + stats + media-type pill) without a second fetch.
+ * preview: ONE by-URL provider request (1 credit), cap-gated, then UPSERTs the
+ * instagram_posts cache + a snapshot so the saved event renders fully in /feed.
  *
- * Why synchronous (NOT a queue): a one-off manual paste is rare; queues are for
- * bulk backfill/polling. 1 credit per preview gated by the daily cap is fine
- * (matches the architecture decision in issue #65).
- *
- * Cap + budget order (mirrors the refresh path):
- *   1. enforceAdapterUserQuota — the per-user 50/day social cap (counter is the
- *      audit_log SUM of event.poll_refreshed/stats_refresh rows; the row is
- *      written below AFTER a successful fetch so the count reflects real spend).
- *   2. reserveSocialCredits (origin="user") runs INSIDE instagramFetch when the
- *      "user" origin is threaded through — the operator prepaid budget gate.
- * On cap exhaustion the AppError 429 propagates so the caller (enrichFromUrl)
- * decides whether to surface it or soft-degrade to recognition-only. On budget
- * exhaustion the provider's instagramFetch throws AdapterError(operator-issue /
- * rate-limited), mapped below to the "unreachable" discriminator so the form
- * degrades to a manual title rather than hard-crashing.
- *
- * Provider not configured (SOC-05) → unreachable, mirroring Reddit's
- * empty-REDDIT_USER_AGENT preview behavior.
+ * Cap + budget order is load-bearing (mirrors the refresh path):
+ *   1. enforceAdapterUserQuota — the per-user 50/day social cap. Its counter is
+ *      the audit_log SUM of event.poll_refreshed/stats_refresh rows, and that row
+ *      is written below only AFTER a successful fetch, so the count reflects real
+ *      spend (and the gate fires on the SECOND paste, not the first).
+ *   2. reserveSocialCredits (origin="user") runs INSIDE instagramFetch — the
+ *      operator prepaid budget gate.
+ * Cap exhaustion → AppError 429 propagates (the caller decides surface vs
+ * soft-degrade). Budget exhaustion → AdapterError, mapped below to "unreachable"
+ * so the form degrades to a manual title. Provider not configured (SOC-05) →
+ * unreachable.
  */
 async function fetchEventPreviewMetadata(
   canonicalUrl: string,

--- a/src/lib/sources/instagram/server/index.ts
+++ b/src/lib/sources/instagram/server/index.ts
@@ -71,9 +71,10 @@ async function registerQueues(boss: MinimalBoss): Promise<void> {
   await boss.createQueue(QUEUES.INSTAGRAM_POLL_CRON);
   await boss.createQueue(QUEUES.INSTAGRAM_QUOTA_RESET);
 
-  // batchSize=1 keeps the backfill stream single-flight per worker; the
-  // producer-side singletonKey by channelKey dedupes parallel triggers across
-  // users to the same account.
+  // batchSize=1 keeps the backfill stream single-flight per worker. The
+  // producer-side singletonKey by channelKey is a best-effort coalescing hint on
+  // this standard-policy queue, NOT a hard cross-worker guard; duplicate events
+  // are prevented by onConflictDoNothing on the insert.
   await boss.work(QUEUES.INSTAGRAM_BACKFILL_ACCOUNT, { batchSize: 1 }, async (jobs) => {
     for (const job of jobs) {
       await handleBackfillAccount(
@@ -132,10 +133,12 @@ async function scheduleCronTicks(boss: MinimalBoss): Promise<void> {
 
 /**
  * backfillSource — user-driven "Pull new content" / cron-driven initial-fetch.
- * Enqueues an account-level walk. singletonKey by channelKey dedupes parallel
- * triggers across users; priority puts user-initiated jobs ahead of cron walks.
- * The trigger user pays the per-user cap (origin==="user"); subscribers
- * free-ride on the channel-wide fan-out.
+ * Enqueues an account-level walk. singletonKey by channelKey best-effort
+ * coalesces parallel triggers across users (it is a hint, not a hard guard on a
+ * standard-policy queue — duplicate events are prevented by onConflictDoNothing
+ * on the insert); priority puts user-initiated jobs ahead of cron walks. The
+ * trigger user pays the per-user cap (origin==="user"); subscribers free-ride on
+ * the channel-wide fan-out.
  */
 async function backfillSource(
   source: PollableSource,

--- a/src/lib/sources/instagram/server/index.ts
+++ b/src/lib/sources/instagram/server/index.ts
@@ -497,6 +497,12 @@ async function fetchEventPreviewMetadata(
     authorUrl: ownerUrl,
     occurredAt: post.publishedAt,
     thumbnailUrl: post.thumbnailUrl ?? undefined,
+    // The MEDIA id is the canonical key for an instagram_post event — the
+    // walker, writeSnapshot, instagram_posts cache, poll-state, metric-series,
+    // and refresh-now all match instagram_posts.post_id == event.externalId.
+    // The URL-parsed externalId is the SHORTCODE (part of the permalink), which
+    // is NOT the media id, so the event must be saved with post.id to enrich.
+    externalId: post.id,
   };
 }
 

--- a/src/lib/sources/instagram/server/index.ts
+++ b/src/lib/sources/instagram/server/index.ts
@@ -431,6 +431,24 @@ async function fetchEventPreviewMetadata(
     return { kind: "unavailable" };
   }
 
+  // Reel-as-`/p/` media_type reconciliation (P2-2). The single-post endpoint has
+  // no product_type, so a reel shared via a `/p/<code>/` permalink (rather than
+  // `/reel/<code>/`) is URL-classified "video" by the normalizer. If the account
+  // walker already imported this same post and resolved it to "short" (it sees
+  // product_type on the feed/reels endpoints), prefer that cached value over the
+  // URL-derived one — one cache lookup, no schema change. RESIDUAL LIMIT: a
+  // genuinely-new `/p/` reel with no cache row stays "video" (a hard limit of
+  // the single-post endpoint — no product_type to disambiguate, no `/reel/` slug
+  // in the URL); the next account-level poll corrects it.
+  const { instagramPosts } = await import("$lib/server/db/schema/index.js");
+  const { eq } = await import("drizzle-orm");
+  const [cached] = await db
+    .select({ mediaType: instagramPosts.mediaType })
+    .from(instagramPosts)
+    .where(eq(instagramPosts.postId, post.id))
+    .limit(1);
+  const mediaType = cached?.mediaType === "short" ? "short" : post.kind;
+
   // UPSERT the public-data cache + snapshot so the saved event renders fully in
   // /feed (thumbnail + stats + media-type pill) — exactly like the walker does
   // per post. Failure here is fatal to the preview (the caller catches the
@@ -438,7 +456,7 @@ async function fetchEventPreviewMetadata(
   await writeSnapshot({
     postId: post.id,
     accountId: post.ownerId,
-    mediaType: post.kind,
+    mediaType,
     caption: post.caption,
     permalink: canonicalUrl,
     thumbnailUrl: post.thumbnailUrl,
@@ -474,7 +492,7 @@ async function fetchEventPreviewMetadata(
 
   return {
     kind: "ok",
-    title: buildPreviewTitle(post.caption, post.kind, post.publishedAt),
+    title: buildPreviewTitle(post.caption, mediaType, post.publishedAt),
     authorName: post.ownerUsername ?? "",
     authorUrl: ownerUrl,
     occurredAt: post.publishedAt,

--- a/src/lib/sources/instagram/server/index.ts
+++ b/src/lib/sources/instagram/server/index.ts
@@ -330,7 +330,7 @@ async function enqueueRefreshNow(input: {
   const { eq } = await import("drizzle-orm");
   const dbCtx = input.tx ?? db;
   const [row] = await dbCtx
-    .select({ accountId: instagramPosts.postId, account: instagramPosts.accountId })
+    .select({ account: instagramPosts.accountId })
     .from(instagramPosts)
     .where(eq(instagramPosts.postId, input.externalId))
     .limit(1);

--- a/src/lib/sources/instagram/server/index.ts
+++ b/src/lib/sources/instagram/server/index.ts
@@ -72,9 +72,9 @@ async function registerQueues(boss: MinimalBoss): Promise<void> {
   await boss.createQueue(QUEUES.INSTAGRAM_QUOTA_RESET);
 
   // batchSize=1 keeps the backfill stream single-flight per worker. The
-  // producer-side singletonKey by channelKey is a best-effort coalescing hint on
-  // this standard-policy queue, NOT a hard cross-worker guard; duplicate events
-  // are prevented by onConflictDoNothing on the insert.
+  // producer-side singletonKey is a no-op for dedup on this standard-policy queue
+  // (no singletonSeconds); duplicate events are prevented by onConflictDoNothing
+  // on the insert.
   await boss.work(QUEUES.INSTAGRAM_BACKFILL_ACCOUNT, { batchSize: 1 }, async (jobs) => {
     for (const job of jobs) {
       await handleBackfillAccount(
@@ -133,12 +133,11 @@ async function scheduleCronTicks(boss: MinimalBoss): Promise<void> {
 
 /**
  * backfillSource — user-driven "Pull new content" / cron-driven initial-fetch.
- * Enqueues an account-level walk. singletonKey by channelKey best-effort
- * coalesces parallel triggers across users (it is a hint, not a hard guard on a
- * standard-policy queue — duplicate events are prevented by onConflictDoNothing
- * on the insert); priority puts user-initiated jobs ahead of cron walks. The
- * trigger user pays the per-user cap (origin==="user"); subscribers free-ride on
- * the channel-wide fan-out.
+ * Enqueues an account-level walk. singletonKey is a no-op for dedup on this
+ * standard-policy queue (no singletonSeconds) — duplicate events are prevented by
+ * onConflictDoNothing on the insert; priority puts user-initiated jobs ahead of
+ * cron walks. The trigger user pays the per-user cap (origin==="user");
+ * subscribers free-ride on the channel-wide fan-out.
  */
 async function backfillSource(
   source: PollableSource,

--- a/src/lib/sources/instagram/server/index.ts
+++ b/src/lib/sources/instagram/server/index.ts
@@ -182,7 +182,52 @@ async function canonicalizeOnCreate(
       { handle_url: input.handleUrl },
     );
   }
-  const resolved = await instagramAccountAdapterCore.resolveHandleToAccountId(parsed.handle);
+  // resolveHandleToAccountId issues a provider request that can throw
+  // AdapterError on 401/402/429/5xx (bad key, rate-limit, upstream outage). The
+  // route mapper (_shared.ts mapErr) only knows AppError / NotFoundError, so an
+  // unmapped AdapterError here becomes an opaque 500. Map it to a typed AppError
+  // by category (SOURCE-REFERENCE §4.5 taxonomy; same category→code shape as the
+  // refresh-content path + fetchEventPreviewMetadata). The unconfigured case is
+  // already gated earlier in createSource (kind_not_configured); don't regress it.
+  let resolved: { accountId: string; displayName: string | null } | null;
+  try {
+    resolved = await instagramAccountAdapterCore.resolveHandleToAccountId(parsed.handle);
+  } catch (err) {
+    if (err instanceof AppError) throw err;
+    if (err instanceof AdapterError) {
+      if (err.category === "not-found") {
+        // Treated identically to the null-resolve below — the handle is
+        // missing/private/misspelled (422, no phantom source).
+        resolved = null;
+      } else if (err.category === "rate-limited") {
+        throw new AppError(
+          "Instagram is rate-limited right now — try adding this account again shortly.",
+          "instagram_rate_limited",
+          429,
+          { handle: parsed.handle },
+        );
+      } else if (err.category === "operator-issue" || err.category === "permanent") {
+        // Provider misconfigured / disabled / ToS-blocked from the operator's
+        // side — the user can't fix it; surface a clean 503, not a 500.
+        throw new AppError(
+          "Instagram import is temporarily unavailable.",
+          "instagram_provider_unavailable",
+          503,
+          { handle: parsed.handle },
+        );
+      } else {
+        // transient — upstream 5xx / network blip. 502 so the UI offers a retry.
+        throw new AppError(
+          "Could not reach Instagram to resolve that handle — try again.",
+          "instagram_unreachable",
+          502,
+          { handle: parsed.handle },
+        );
+      }
+    } else {
+      throw err;
+    }
+  }
   if (resolved === null) {
     throw new AppError(
       "Could not resolve that Instagram handle — it may be private, misspelled, or the provider is not configured.",

--- a/src/lib/sources/instagram/server/quota.ts
+++ b/src/lib/sources/instagram/server/quota.ts
@@ -126,11 +126,9 @@ export async function reserveSocialCredits(args: {
   const eighty = throttleEighty();
   const ninetyfive = throttleNinetyfive();
 
-  // Threshold-crossing audit signals computed UNDER the lock (so they reflect
-  // the real before/after of THIS reservation) but EMITTED after the tx commits
-  // (AGENTS.md item 4 — audit failure must not block / deadlock the spend path).
-  // null = no crossing this reservation. The audit fns have their own
-  // once-per-cycle guards, so a re-emit on a duplicate crossing is a no-op.
+  // Threshold-crossing signals computed UNDER the lock (real before/after of THIS
+  // reservation) but EMITTED after commit (AGENTS.md item 4 — audit must not
+  // block / deadlock the spend path).
   let crossedEighty = false;
   let crossedNinetyfive = false;
   let balanceExhausted = false;
@@ -238,17 +236,14 @@ export async function reserveSocialCredits(args: {
     return { platform, provider, poolKind: origin, units: args.units };
   };
 
-  // ALWAYS run in our own transaction (no external tx) so the F4 audit below is
-  // unambiguously post-commit — an external tx that later rolled back would
-  // otherwise persist the audit + trip the in-memory once-per-cycle guards while
-  // the spend itself reverted.
+  // Own transaction always (never an external tx) so the operator audit below is
+  // unambiguously post-commit: a caller's tx that later rolled back would persist
+  // the audit + trip the in-memory once-per-cycle guards while the spend reverted.
   const permit = await db.transaction(run);
 
-  // Operator audit AFTER the spend tx commits (a denied reservation returns null
-  // and crosses nothing, so this is a no-op then). The 80% / 95% throttle bands
-  // pause non-essential lanes (D-15); the prepaid-balance-zero is the absolute
-  // hard ceiling (D-16). Each fn is idempotent per (date, state) / (platform,
-  // provider) so a re-cross within the same cycle writes no duplicate row.
+  // Operator audit AFTER commit (a denied reservation returns null and crosses
+  // nothing → no-op). Each fn is idempotent per (date, state) / (platform,
+  // provider), so a re-cross within the same cycle writes no duplicate row.
   if (permit !== null) {
     if (crossedEighty) {
       await markSocialThrottleTransition({

--- a/src/lib/sources/instagram/server/quota.ts
+++ b/src/lib/sources/instagram/server/quota.ts
@@ -124,7 +124,18 @@ export async function reserveSocialCredits(args: {
   const datePacific = todayPacific(args.now ?? new Date());
   const { platform, provider, origin } = args;
   const poolLimit = origin === "cron" ? cronPoolDaily() : userPoolDaily();
+  const eighty = throttleEighty();
   const ninetyfive = throttleNinetyfive();
+
+  // Threshold-crossing audit signals computed UNDER the lock (so they reflect
+  // the real before/after of THIS reservation) but EMITTED after the tx commits
+  // (AGENTS.md item 4 — audit failure must not block / deadlock the spend path).
+  // null = no crossing this reservation. The audit fns have their own
+  // once-per-cycle guards, so a re-emit on a duplicate crossing is a no-op.
+  let crossedEighty = false;
+  let crossedNinetyfive = false;
+  let balanceExhausted = false;
+  let totalAfterReserve = 0;
 
   const run = async (tx: DbCtx): Promise<SocialCreditPermit | null> => {
     // Seed today's counter rows (both pools) + the prepaid balance row.
@@ -216,10 +227,48 @@ export async function reserveSocialCredits(args: {
         ),
       );
 
+    // Compute the daily-cap throttle band crossing + prepaid-balance exhaustion
+    // for THIS reservation (before vs after). Emitted after commit below.
+    const totalBefore = totalUsed;
+    const totalAfter = totalUsed + args.units;
+    totalAfterReserve = totalAfter;
+    crossedEighty = totalBefore < eighty && totalAfter >= eighty;
+    crossedNinetyfive = totalBefore < ninetyfive && totalAfter >= ninetyfive;
+    balanceExhausted = prepaidBalance - args.units <= 0;
+
     return { platform, provider, poolKind: origin, units: args.units };
   };
 
-  return args.tx ? run(args.tx) : db.transaction(run);
+  const permit = args.tx ? await run(args.tx) : await db.transaction(run);
+
+  // Operator audit AFTER the spend tx commits (a denied reservation returns null
+  // and crosses nothing, so this is a no-op then). The 80% / 95% throttle bands
+  // pause non-essential lanes (D-15); the prepaid-balance-zero is the absolute
+  // hard ceiling (D-16). Each fn is idempotent per (date, state) / (platform,
+  // provider) so a re-cross within the same cycle writes no duplicate row.
+  if (permit !== null) {
+    if (crossedEighty) {
+      await markSocialThrottleTransition({
+        platform,
+        provider,
+        state: "eighty",
+        creditsUsed: totalAfterReserve,
+      });
+    }
+    if (crossedNinetyfive) {
+      await markSocialThrottleTransition({
+        platform,
+        provider,
+        state: "ninetyfive",
+        creditsUsed: totalAfterReserve,
+      });
+    }
+    if (balanceExhausted) {
+      await markSocialBudgetExhausted({ platform, provider });
+    }
+  }
+
+  return permit;
 }
 
 /**

--- a/src/lib/sources/instagram/server/quota.ts
+++ b/src/lib/sources/instagram/server/quota.ts
@@ -77,16 +77,18 @@ function userPoolDaily(): number {
 }
 
 /**
- * Module-level audit-emission guard. Map<date_pacific, Set<state>>. Resets on
- * container restart; the cron clears it at midnight Pacific via
- * resetSocialDailyCap. Defense-in-depth: a prior-emit lookup against audit_log
- * handles the container-restart case where the Set is empty but the row was
- * already written today.
+ * Throttle audit-emission guard, keyed by `${datePacific}|${platform}|${provider}`
+ * so a second provider in the same process tracks its own crossings. Cleared at
+ * midnight Pacific by resetSocialDailyCap; the audit_log lookup is the defense-
+ * in-depth across container restart.
  */
 const auditedTransitions = new Map<string, Set<"eighty" | "ninetyfive">>();
 
-/** Module-level guard so social.budget_exhausted emits at most once per process. */
-let budgetExhaustedEmitted = false;
+/**
+ * Budget-exhausted guard, keyed by `${platform}|${provider}` (balance exhaustion
+ * is per-provider, NOT date-scoped). Cleared on cron reset + restart.
+ */
+const budgetExhaustedEmitted = new Set<string>();
 
 /**
  * Cached operator user_id resolved from ADMIN_EMAIL_ALLOWLIST[0]. `undefined` =
@@ -251,6 +253,7 @@ export async function reserveSocialCredits(args: {
         provider,
         state: "eighty",
         creditsUsed: totalAfterReserve,
+        datePacific,
       });
     }
     if (crossedNinetyfive) {
@@ -259,10 +262,11 @@ export async function reserveSocialCredits(args: {
         provider,
         state: "ninetyfive",
         creditsUsed: totalAfterReserve,
+        datePacific,
       });
     }
     if (balanceExhausted) {
-      await markSocialBudgetExhausted({ platform, provider });
+      await markSocialBudgetExhausted({ platform, provider, datePacific });
     }
   }
 
@@ -369,7 +373,7 @@ export async function getSocialSpendToday(
  */
 export async function resetSocialDailyCap(now: Date = new Date()): Promise<void> {
   auditedTransitions.clear();
-  budgetExhaustedEmitted = false;
+  budgetExhaustedEmitted.clear();
   cachedOperatorId = undefined;
   const datePacific = todayPacific(now);
   // Seed today's counter rows at zero for any (platform, provider) that has a
@@ -406,23 +410,24 @@ export async function resetSocialDailyCap(now: Date = new Date()): Promise<void>
 }
 
 /**
- * Write audit `social.provider_throttled` ONCE per (date_pacific, state).
- * Idempotency layered: module-level Set (fast path within container lifetime) +
- * audit_log lookup (handles container restart). Resolves the operator via
- * ADMIN_EMAIL_ALLOWLIST[0] (mirrors youtube markThrottleTransition).
+ * Write audit `social.provider_throttled` ONCE per (date_pacific, platform,
+ * provider, state). In-memory Set is the fast path; the audit_log lookup is the
+ * cross-restart fallback. Operator resolves via ADMIN_EMAIL_ALLOWLIST[0].
+ * `datePacific` is threaded from the reservation so a now-passing caller is
+ * consistent; defaults to today.
  */
 export async function markSocialThrottleTransition(args: {
   platform: string;
   provider: string;
   state: "eighty" | "ninetyfive";
   creditsUsed: number;
+  datePacific?: string;
 }): Promise<void> {
-  const datePacific = todayPacific();
-  const seen = auditedTransitions.get(datePacific) ?? new Set<"eighty" | "ninetyfive">();
+  const datePacific = args.datePacific ?? todayPacific();
+  const guardKey = `${datePacific}|${args.platform}|${args.provider}`;
+  const seen = auditedTransitions.get(guardKey) ?? new Set<"eighty" | "ninetyfive">();
   if (seen.has(args.state)) return;
 
-  // Defense in depth — handles container restart where the Set is empty but
-  // the row was already written earlier today.
   // eslint-disable-next-line tenant-scope/no-unfiltered-tenant-query -- system-emitted operator audit; idempotency key is (date_pacific, platform, provider, state), not user_id
   const priorRows = await db
     .select({ id: auditLog.id })
@@ -437,7 +442,7 @@ export async function markSocialThrottleTransition(args: {
     .limit(1);
   if (priorRows.length > 0) {
     seen.add(args.state);
-    auditedTransitions.set(datePacific, seen);
+    auditedTransitions.set(guardKey, seen);
     return;
   }
 
@@ -448,7 +453,7 @@ export async function markSocialThrottleTransition(args: {
       "social.provider_throttled threshold crossed but no operator user_id resolvable",
     );
     seen.add(args.state);
-    auditedTransitions.set(datePacific, seen);
+    auditedTransitions.set(guardKey, seen);
     return;
   }
 
@@ -466,20 +471,23 @@ export async function markSocialThrottleTransition(args: {
   });
 
   seen.add(args.state);
-  auditedTransitions.set(datePacific, seen);
+  auditedTransitions.set(guardKey, seen);
 }
 
 /**
- * Write audit `social.budget_exhausted` ONCE when the prepaid balance first
- * hits 0. Module-level guard (process lifetime) + audit_log lookup for
- * cross-restart idempotency.
+ * Write audit `social.budget_exhausted` ONCE per (platform, provider) when its
+ * prepaid balance first hits 0. In-memory Set keyed by `${platform}|${provider}`
+ * + audit_log lookup for cross-restart idempotency. `datePacific` is threaded
+ * from the reservation for caller consistency; defaults to today.
  */
 export async function markSocialBudgetExhausted(args: {
   platform: string;
   provider: string;
+  datePacific?: string;
 }): Promise<void> {
-  if (budgetExhaustedEmitted) return;
-  const datePacific = todayPacific();
+  const guardKey = `${args.platform}|${args.provider}`;
+  if (budgetExhaustedEmitted.has(guardKey)) return;
+  const datePacific = args.datePacific ?? todayPacific();
 
   // eslint-disable-next-line tenant-scope/no-unfiltered-tenant-query -- system-emitted operator audit; idempotency key is (platform, provider), not user_id
   const priorRows = await db
@@ -492,7 +500,7 @@ export async function markSocialBudgetExhausted(args: {
     )
     .limit(1);
   if (priorRows.length > 0) {
-    budgetExhaustedEmitted = true;
+    budgetExhaustedEmitted.add(guardKey);
     return;
   }
 
@@ -502,7 +510,7 @@ export async function markSocialBudgetExhausted(args: {
       { platform: args.platform, provider: args.provider },
       "social.budget_exhausted but no operator user_id resolvable",
     );
-    budgetExhaustedEmitted = true;
+    budgetExhaustedEmitted.add(guardKey);
     return;
   }
 
@@ -512,7 +520,7 @@ export async function markSocialBudgetExhausted(args: {
     ipAddress: "127.0.0.1",
     metadata: { date_pacific: datePacific, platform: args.platform, provider: args.provider },
   });
-  budgetExhaustedEmitted = true;
+  budgetExhaustedEmitted.add(guardKey);
 }
 
 /**

--- a/src/lib/sources/instagram/server/quota.ts
+++ b/src/lib/sources/instagram/server/quota.ts
@@ -115,7 +115,6 @@ export async function reserveSocialCredits(args: {
   origin: SocialQuotaPool;
   units: number;
   now?: Date;
-  tx?: DbCtx;
 }): Promise<SocialCreditPermit | null> {
   if (!Number.isInteger(args.units) || args.units <= 0) {
     throw new Error("Social provider credit units must be a positive integer");
@@ -239,7 +238,11 @@ export async function reserveSocialCredits(args: {
     return { platform, provider, poolKind: origin, units: args.units };
   };
 
-  const permit = args.tx ? await run(args.tx) : await db.transaction(run);
+  // ALWAYS run in our own transaction (no external tx) so the F4 audit below is
+  // unambiguously post-commit — an external tx that later rolled back would
+  // otherwise persist the audit + trip the in-memory once-per-cycle guards while
+  // the spend itself reverted.
+  const permit = await db.transaction(run);
 
   // Operator audit AFTER the spend tx commits (a denied reservation returns null
   // and crosses nothing, so this is a no-op then). The 80% / 95% throttle bands

--- a/tests/integration/events.test.ts
+++ b/tests/integration/events.test.ts
@@ -1348,6 +1348,29 @@ describe("createEventSchema + preview-url", () => {
     expect(body.error).toBe("unsupported_url");
   });
 
+  it("POST /api/events/preview-url with a non-http(s) scheme → 422 'validation_failed' at the boundary", async () => {
+    // previewUrlSchema restricts the URL scheme to http(s) (P2-3): a file:// /
+    // gopher:// URL is rejected at the route before enrichFromUrl runs, so the
+    // 422 carries the schema's "validation_failed" code (NOT "unsupported_url",
+    // which is the service-layer parse-miss). "validate at boundaries" made
+    // explicit.
+    const { createApp } = await import("../../src/lib/server/http/app.js");
+    const app = createApp();
+    const u = await seedUserDirectly({ email: `ev17t2t8b-${uniq()}@test.local` });
+
+    const res = await app.request("/api/events/preview-url", {
+      method: "POST",
+      headers: {
+        cookie: `neotolis.session_token=${u.signedSessionCookieValue}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ url: "file:///etc/passwd" }),
+    });
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("validation_failed");
+  });
+
   it("anonymous POST /api/events/preview-url → 401 unauthorized (sweep complement)", async () => {
     const { createApp } = await import("../../src/lib/server/http/app.js");
     const app = createApp();

--- a/tests/integration/instagram-create-source-error.test.ts
+++ b/tests/integration/instagram-create-source-error.test.ts
@@ -1,0 +1,126 @@
+// F3 — createSource(instagram_account) maps a provider AdapterError to a clean
+// AppError (4xx/5xx), NOT an opaque 500.
+//
+// canonicalizeOnCreate resolves the pasted handle → the stable IG account_id via
+// resolveHandleToAccountId, which issues a provider request that can throw
+// AdapterError on 401/402/429/5xx (bad key, rate-limit, upstream outage). The
+// route mapper (_shared.ts mapErr) only understands AppError / NotFoundError, so
+// an unmapped AdapterError would surface as { error: "internal_server_error" }
+// 500. This suite drives the REAL createSource against real Postgres with the
+// provider seam mocked to throw each AdapterError category and asserts a typed
+// AppError comes out (and no phantom source row is written).
+//
+// The provider seam is faked at provider/registry's getSocialProvider (the
+// configured-provider path), NEVER the DB.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { eq } from "drizzle-orm";
+import { seedUserDirectly } from "./helpers.js";
+import type { AppError as AppErrorType } from "../../src/lib/server/services/errors.js";
+
+// A controllable resolveAccount: the test sets the next AdapterError category (or
+// a successful resolve) before driving createSource.
+interface ScriptedResolve {
+  next: { throwCategory: string } | { accountId: string; displayName: string | null };
+}
+const resolve: ScriptedResolve = { next: { throwCategory: "operator-issue" } };
+
+vi.mock("../../src/lib/sources/instagram/server/provider/registry.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    // Report CONFIGURED so createSource reaches canonicalizeOnCreate (the
+    // unconfigured gate that returns kind_not_configured is bypassed here — F3
+    // is specifically the configured-but-upstream-failing path).
+    isInstagramConfigured: () => true,
+    getSocialProvider: (platform: string) => {
+      if (platform !== "instagram") return null;
+      return {
+        name: "scrapecreators",
+        async resolveAccount() {
+          if ("throwCategory" in resolve.next) {
+            const { AdapterError } = await import("../../src/lib/sources/errors.js");
+            throw new AdapterError("scripted resolve failure", {
+              category: resolve.next.throwCategory as never,
+            });
+          }
+          return resolve.next;
+        },
+        async fetchPosts() {
+          return { posts: [], nextCursor: null, endOfFeed: true, creditsUsed: 1 };
+        },
+        async fetchPostByUrl() {
+          return null;
+        },
+      };
+    },
+  };
+});
+
+const { db } = await import("../../src/lib/server/db/client.js");
+const { dataSources } = await import("../../src/lib/server/db/schema/data-sources.js");
+const { createSource } = await import("../../src/lib/server/services/data-sources.js");
+const { AppError } = await import("../../src/lib/server/services/errors.js");
+
+const HANDLE_URL = "https://www.instagram.com/natgeo/";
+
+async function expectCreateThrows(): Promise<AppErrorType> {
+  const user = await seedUserDirectly({
+    email: `ig-create-err-${Math.random().toString(36).slice(2)}@t.io`,
+  });
+  try {
+    await createSource(user.id, { kind: "instagram_account", handleUrl: HANDLE_URL }, "127.0.0.1");
+    throw new Error("expected createSource to throw");
+  } catch (e) {
+    expect(e).toBeInstanceOf(AppError);
+    const err = e as AppErrorType;
+    // The cardinal assertion: NOT an internal_server_error / 500.
+    expect(err.code).not.toBe("internal_server_error");
+    expect(err.status).not.toBe(500);
+    // No phantom source row.
+    const rows = await db.select().from(dataSources).where(eq(dataSources.userId, user.id));
+    expect(rows).toHaveLength(0);
+    return err;
+  }
+}
+
+beforeEach(() => {
+  resolve.next = { throwCategory: "operator-issue" };
+});
+
+describe("createSource(instagram_account) — AdapterError → AppError mapping (F3)", () => {
+  it("operator-issue → 503 instagram_provider_unavailable (not a 500)", async () => {
+    resolve.next = { throwCategory: "operator-issue" };
+    const err = await expectCreateThrows();
+    expect(err.code).toBe("instagram_provider_unavailable");
+    expect(err.status).toBe(503);
+  });
+
+  it("rate-limited → 429 instagram_rate_limited (not a 500)", async () => {
+    resolve.next = { throwCategory: "rate-limited" };
+    const err = await expectCreateThrows();
+    expect(err.code).toBe("instagram_rate_limited");
+    expect(err.status).toBe(429);
+  });
+
+  it("transient → 502 instagram_unreachable (not a 500)", async () => {
+    resolve.next = { throwCategory: "transient" };
+    const err = await expectCreateThrows();
+    expect(err.code).toBe("instagram_unreachable");
+    expect(err.status).toBe(502);
+  });
+
+  it("permanent → 503 instagram_provider_unavailable (not a 500)", async () => {
+    resolve.next = { throwCategory: "permanent" };
+    const err = await expectCreateThrows();
+    expect(err.code).toBe("instagram_provider_unavailable");
+    expect(err.status).toBe(503);
+  });
+
+  it("not-found → 422 instagram_handle_unresolvable (the existing null-resolve path, no regression)", async () => {
+    resolve.next = { throwCategory: "not-found" };
+    const err = await expectCreateThrows();
+    expect(err.code).toBe("instagram_handle_unresolvable");
+    expect(err.status).toBe(422);
+  });
+});

--- a/tests/integration/instagram-create-source-error.test.ts
+++ b/tests/integration/instagram-create-source-error.test.ts
@@ -1,4 +1,4 @@
-// F3 — createSource(instagram_account) maps a provider AdapterError to a clean
+// createSource(instagram_account) maps a provider AdapterError to a clean
 // AppError (4xx/5xx), NOT an opaque 500.
 //
 // canonicalizeOnCreate resolves the pasted handle → the stable IG account_id via

--- a/tests/integration/instagram-paste-preview.test.ts
+++ b/tests/integration/instagram-paste-preview.test.ts
@@ -139,14 +139,13 @@ describe("instagram live paste-preview (single-post fetch, issue #65)", () => {
     expect(single.calls[0]!.origin).toBe("user");
   });
 
-  it("end-to-end: a manually-pasted IG post saves with the MEDIA id so feed-enrichment matches the cache (thumbnail + stats) — F1", async () => {
-    // The review finding: instagramParseUrl returns the SHORTCODE as externalId,
-    // but fetchPostByUrl + writeSnapshot + the instagram_posts cache key on the
-    // MEDIA id. Saving the event with the shortcode orphans it from its cache row
-    // so the card never gets a thumbnail / stats / poll badge. This test drives
-    // the WHOLE pipeline (preview → createEvent → instagramEnrichFeedDtos) and
-    // asserts the saved event's externalId matches the cached post_id AND the
-    // feed card is enriched.
+  it("end-to-end: a manually-pasted IG post saves with the MEDIA id so feed-enrichment matches the cache (thumbnail + stats)", async () => {
+    // instagramParseUrl returns the SHORTCODE as externalId, but fetchPostByUrl +
+    // writeSnapshot + the instagram_posts cache key on the MEDIA id. Saving the
+    // event with the shortcode orphans it from its cache row so the card never
+    // gets a thumbnail / stats / poll badge. This test drives the whole pipeline
+    // (preview → createEvent → instagramEnrichFeedDtos) and asserts the saved
+    // event's externalId matches the cached post_id AND the feed card is enriched.
     const user = await seedUserDirectly({
       email: `ig-e2e-mediaid-${Math.random().toString(36).slice(2)}@t.io`,
     });

--- a/tests/integration/instagram-paste-preview.test.ts
+++ b/tests/integration/instagram-paste-preview.test.ts
@@ -72,10 +72,20 @@ const { instagramPosts, instagramPostSnapshots } =
 const { auditLog } = await import("../../src/lib/server/db/schema/audit-log.js");
 const { writeAuditStrict } = await import("../../src/lib/server/audit.js");
 const { getUserQuotaUsedToday } = await import("../../src/lib/server/services/quota.js");
-const { enrichFromUrl } = await import("../../src/lib/server/services/events-mutation.js");
+const { enrichFromUrl, createEvent } =
+  await import("../../src/lib/server/services/events-mutation.js");
+const { mapEventsToDtos } = await import("../../src/lib/server/dto.js");
+const { instagramEnrichFeedDtos } =
+  await import("../../src/lib/sources/instagram/server/feed-enrichment.js");
 const { env } = await import("../../src/lib/server/config/env.js");
 const { instagramAdapter } = await import("../../src/lib/sources/instagram/server/index.js");
 const { AppError } = await import("../../src/lib/server/services/errors.js");
+
+interface InstagramEnrichment {
+  stats: { viewCount: number | null; likeCount: number | null; commentCount: number | null } | null;
+  thumbnailUrl: string | null;
+  mediaType: string | null;
+}
 
 const PLATFORM = "instagram_account";
 
@@ -115,8 +125,11 @@ describe("instagram live paste-preview (single-post fetch, issue #65)", () => {
     expect(result.authorName).toBe("neonicle_dev");
     expect(result.authorUrl).toBe("https://www.instagram.com/neonicle_dev/");
     expect(result.occurredAt?.toISOString()).toBe("2026-06-01T12:00:00.000Z");
-    // externalId is the URL-intrinsic shortcode (parseIngestUrl), canonical URL preserved.
-    expect(result.externalId).toBe("PCODE1");
+    // externalId is the MEDIA id (post.id), NOT the URL shortcode — the cache,
+    // snapshot, feed-enrichment, metric-series, poll-state, and refresh-now all
+    // key on instagram_posts.post_id == event.externalId. The shortcode (PCODE1)
+    // is part of the permalink but is NOT the media id. Canonical URL preserved.
+    expect(result.externalId).toBe("p-ok");
     expect(result.canonicalUrl).toBe("https://www.instagram.com/p/PCODE1/");
 
     // The provider was called with the canonical permalink + the user-pool origin
@@ -124,6 +137,76 @@ describe("instagram live paste-preview (single-post fetch, issue #65)", () => {
     expect(single.calls).toHaveLength(1);
     expect(single.calls[0]!.url).toBe("https://www.instagram.com/p/PCODE1/");
     expect(single.calls[0]!.origin).toBe("user");
+  });
+
+  it("end-to-end: a manually-pasted IG post saves with the MEDIA id so feed-enrichment matches the cache (thumbnail + stats) — F1", async () => {
+    // The review finding: instagramParseUrl returns the SHORTCODE as externalId,
+    // but fetchPostByUrl + writeSnapshot + the instagram_posts cache key on the
+    // MEDIA id. Saving the event with the shortcode orphans it from its cache row
+    // so the card never gets a thumbnail / stats / poll badge. This test drives
+    // the WHOLE pipeline (preview → createEvent → instagramEnrichFeedDtos) and
+    // asserts the saved event's externalId matches the cached post_id AND the
+    // feed card is enriched.
+    const user = await seedUserDirectly({
+      email: `ig-e2e-mediaid-${Math.random().toString(36).slice(2)}@t.io`,
+    });
+
+    // Media id (post.id) is the long numeric id; the shortcode (E2ESC1) is what
+    // appears in the URL. They are DIFFERENT — that is the entire bug surface.
+    const MEDIA_ID = "3912161556549155524";
+    single.next = singlePost({
+      id: MEDIA_ID,
+      shortcode: "E2ESC1",
+      kind: "image",
+      metrics: { views: null, likes: 88, comments: 9 },
+    });
+
+    // 1. Preview (the "Fetch" button) → the route returns enriched.externalId to
+    //    the client, which then passes it back as input.externalId on save.
+    const enriched = await enrichFromUrl(
+      user.id,
+      "https://www.instagram.com/p/E2ESC1/",
+      "127.0.0.1",
+    );
+    expect(enriched.externalId).toBe(MEDIA_ID);
+
+    // 2. Save the event with the previewed externalId (mirrors the route → form
+    //    → POST /api/events round-trip — caller-supplied externalId always wins).
+    const created = await createEvent(
+      user.id,
+      {
+        kind: "instagram_post",
+        title: enriched.title || "manual IG post",
+        occurredAt: enriched.occurredAt ?? new Date(),
+        url: enriched.canonicalUrl,
+        externalId: enriched.externalId,
+      },
+      "127.0.0.1",
+    );
+
+    // The saved event carries the MEDIA id — the cache key, NOT the shortcode.
+    expect(created.externalId).toBe(MEDIA_ID);
+    const [cached] = await db
+      .select()
+      .from(instagramPosts)
+      .where(eq(instagramPosts.postId, MEDIA_ID));
+    expect(cached).toBeDefined();
+    expect(created.externalId).toBe(cached!.postId);
+
+    // 3. Run the read path the /feed loader uses. With the shortcode bug it would
+    //    find no matching instagram_posts row → no thumbnail / stats. With the
+    //    media id it enriches fully.
+    const dtos = await mapEventsToDtos(user.id, [created]);
+    await instagramEnrichFeedDtos(user.id, dtos);
+
+    const decorated = dtos[0] as (typeof dtos)[0] & { instagramEnrichment?: InstagramEnrichment };
+    expect(decorated.instagramEnrichment).toBeDefined();
+    expect(decorated.instagramEnrichment!.thumbnailUrl).toBe(
+      "https://cdn.instagram.com/media-1.jpg",
+    );
+    expect(decorated.instagramEnrichment!.stats).not.toBeNull();
+    expect(decorated.instagramEnrichment!.stats!.likeCount).toBe(88);
+    expect(decorated.instagramEnrichment!.stats!.commentCount).toBe(9);
   });
 
   it("UPSERTs the instagram_posts cache row + a snapshot so the saved event renders fully in /feed", async () => {

--- a/tests/integration/instagram-paste-preview.test.ts
+++ b/tests/integration/instagram-paste-preview.test.ts
@@ -74,6 +74,8 @@ const { writeAuditStrict } = await import("../../src/lib/server/audit.js");
 const { getUserQuotaUsedToday } = await import("../../src/lib/server/services/quota.js");
 const { enrichFromUrl } = await import("../../src/lib/server/services/events-mutation.js");
 const { env } = await import("../../src/lib/server/config/env.js");
+const { instagramAdapter } = await import("../../src/lib/sources/instagram/server/index.js");
+const { AppError } = await import("../../src/lib/server/services/errors.js");
 
 const PLATFORM = "instagram_account";
 
@@ -192,6 +194,39 @@ describe("instagram live paste-preview (single-post fetch, issue #65)", () => {
     expect(car!.mediaType).toBe("carousel");
   });
 
+  it("a reel shared as a /p/ link prefers the cached 'short' media_type over the URL-derived 'video' (P2-2)", async () => {
+    const user = await seedUserDirectly({
+      email: `ig-preview-pshort-${Math.random().toString(36).slice(2)}@t.io`,
+    });
+    // The account walker already imported this reel (it sees product_type on the
+    // feed/reels endpoints) and cached it as "short".
+    await db.insert(instagramPosts).values({
+      postId: "p-as-reel",
+      accountId: "owner-99",
+      mediaType: "short",
+      permalink: "https://www.instagram.com/p/PREEL1/",
+    });
+
+    // Now the user pastes the /p/ permalink. The single-post API has no
+    // product_type and the URL is /p/ (not /reel/), so the normalizer resolves
+    // the post to "video" — the URL-derived classification is wrong for a reel.
+    single.next = singlePost({ id: "p-as-reel", shortcode: "PREEL1", kind: "video" });
+
+    const result = await enrichFromUrl(user.id, "https://www.instagram.com/p/PREEL1/", "127.0.0.1");
+
+    // The cached "short" wins over the URL-derived "video": the pill stays
+    // correct AND the caption-less title fallback uses "short".
+    const [cached] = await db
+      .select()
+      .from(instagramPosts)
+      .where(eq(instagramPosts.postId, "p-as-reel"));
+    expect(cached!.mediaType).toBe("short");
+    // (Caption present here, so the title is the caption first line — the
+    // media_type only surfaces in the caption-less fallback. The cache value is
+    // the load-bearing assertion: the pill renders off instagram_posts.media_type.)
+    expect(result.kind).toBe("instagram_post");
+  });
+
   it("consults the per-user cap (writes the cap-counter audit row that getUserQuotaUsedToday SUMs)", async () => {
     const user = await seedUserDirectly({
       email: `ig-preview-cap-${Math.random().toString(36).slice(2)}@t.io`,
@@ -275,6 +310,51 @@ describe("instagram live paste-preview (single-post fetch, issue #65)", () => {
     expect(result.kind).toBe("instagram_post");
     expect(result.title).toBe("");
     expect(result.externalId).toBe("BOOM1");
+  });
+
+  it("an EXPECTED adapter throw (AppError) degrades to recognition-only (N-1)", async () => {
+    const user = await seedUserDirectly({
+      email: `ig-preview-apperr-${Math.random().toString(36).slice(2)}@t.io`,
+    });
+    // A typed AppError out of the adapter is an expected failure mode — the
+    // form must still let the user save a bare event.
+    const spy = vi
+      .spyOn(instagramAdapter, "fetchEventPreviewMetadata")
+      .mockRejectedValueOnce(new AppError("instagram down", "instagram_unreachable", 502));
+
+    try {
+      const result = await enrichFromUrl(
+        user.id,
+        "https://www.instagram.com/p/APPERR1/",
+        "127.0.0.1",
+      );
+      expect(result.kind).toBe("instagram_post");
+      expect(result.title).toBe("");
+      expect(result.externalId).toBe("APPERR1");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("an UNEXPECTED adapter throw (raw Error = programmer bug) re-throws instead of hiding (N-1)", async () => {
+    const user = await seedUserDirectly({
+      email: `ig-preview-bug-${Math.random().toString(36).slice(2)}@t.io`,
+    });
+    // A raw Error is NOT in the graceful-degrade contract — it represents a
+    // programmer bug in the adapter (bad import, undefined access, etc.). It
+    // must surface (→ 500 + escaped-error log) rather than be swallowed as a
+    // benign WARN. Mirrors the reddit branch (which lets all throws propagate).
+    const spy = vi
+      .spyOn(instagramAdapter, "fetchEventPreviewMetadata")
+      .mockRejectedValueOnce(new TypeError("cannot read properties of undefined"));
+
+    try {
+      await expect(
+        enrichFromUrl(user.id, "https://www.instagram.com/p/BUG1/", "127.0.0.1"),
+      ).rejects.toThrow("cannot read properties of undefined");
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("a deleted/private post (null body) degrades to recognition-only", async () => {

--- a/tests/integration/instagram-walker.test.ts
+++ b/tests/integration/instagram-walker.test.ts
@@ -297,12 +297,12 @@ describe("instagram account walker (resumable, cursor-persisted)", () => {
   });
 });
 
-// F2 — the resumable backfill walker now SELF-ENQUEUES a continuation via the
-// outbox (atomic with the cursor write) so a multi-page bounded initial/historical
+// The resumable backfill walker self-enqueues a continuation via the outbox
+// (atomic with the cursor write) so a multi-page bounded initial/historical
 // backfill completes promptly instead of crawling one page per 6h cron tick.
 // Termination is load-bearing: continue ONLY on the deep branch while NOT complete,
 // NOT paused-by-budget, AND under the post-count cap.
-describe("instagram account walker — self-enqueued continuation (F2)", () => {
+describe("instagram account walker — self-enqueued continuation", () => {
   it("a 2-page deep backfill enqueues a continuation on tick 1, then completes on tick 2 with NO further continuation", async () => {
     await seedSource();
     // Tick 1: posts page 1 has a cursor (more available); reels empty (ends).

--- a/tests/integration/instagram-walker.test.ts
+++ b/tests/integration/instagram-walker.test.ts
@@ -6,7 +6,7 @@
 // uniform ProviderPage hides the posts(next_max_id)/reels(paging_info.max_id)
 // cursor divergence (Plan 02), so the walker only ever sees nextCursor.
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { and, eq } from "drizzle-orm";
 import { seedUserDirectly } from "./helpers.js";
 import type { ProviderPage } from "../../src/lib/sources/social-provider.js";
@@ -17,9 +17,16 @@ import type { ProviderPage } from "../../src/lib/sources/social-provider.js";
 interface ScriptedProvider {
   pages: { posts: ProviderPage[]; reels: ProviderPage[] };
   calls: Array<{ feed: "posts" | "reels"; cursor: string | null }>;
+  /** When set for a feed, the next fetchPosts call for that feed throws an
+   *  AdapterError of this category (budget-pause simulation) instead of paging. */
+  throwOn: { posts?: "rate-limited" | "operator-issue"; reels?: "rate-limited" | "operator-issue" };
 }
 
-const provider: ScriptedProvider = { pages: { posts: [], reels: [] }, calls: [] };
+const provider: ScriptedProvider = {
+  pages: { posts: [], reels: [] },
+  calls: [],
+  throwOn: {},
+};
 
 function emptyPage(): ProviderPage {
   return { posts: [], nextCursor: null, endOfFeed: true, creditsUsed: 1 };
@@ -42,6 +49,13 @@ vi.mock("../../src/lib/sources/instagram/server/provider/registry.js", async (im
         ): Promise<ProviderPage> {
           const feed = opts.kindFilter ?? "posts";
           provider.calls.push({ feed, cursor });
+          const category = provider.throwOn[feed];
+          if (category !== undefined) {
+            // Simulate the BUDGET-02 reserve refusal the HTTP seam raises when the
+            // operator's prepaid budget / daily-cap is exhausted (instagram/http.ts).
+            const { AdapterError: Err } = await import("../../src/lib/sources/errors.js");
+            throw new Err("scripted budget pause", { category });
+          }
           const next = provider.pages[feed].shift();
           return next ?? emptyPage();
         },
@@ -54,8 +68,10 @@ vi.mock("../../src/lib/sources/instagram/server/provider/registry.js", async (im
 });
 
 const { db } = await import("../../src/lib/server/db/client.js");
+const { env } = await import("../../src/lib/server/config/env.js");
 const { dataSources } = await import("../../src/lib/server/db/schema/data-sources.js");
 const { events } = await import("../../src/lib/server/db/schema/events.js");
+const { outbox } = await import("../../src/lib/server/db/schema/outbox.js");
 const { dataSourceChannelState } =
   await import("../../src/lib/server/db/schema/data-source-channel-state.js");
 const { instagramPosts } = await import("../../src/lib/server/db/schema/index.js");
@@ -65,6 +81,14 @@ const { getInstagramBackfillState } =
   await import("../../src/lib/sources/instagram/server/backfill-state.js");
 
 const ACCOUNT = "acct-walker";
+
+/** Read pending continuation jobs queued for THIS account via the outbox. The
+ *  continuation is enqueued via enqueueViaOutbox (atomic with the cursor write),
+ *  so the queue intent lives in the outbox table until the forwarder ships it. */
+async function readContinuationOutbox() {
+  const rows = await db.select().from(outbox).where(eq(outbox.queue, "instagram.backfill.account"));
+  return rows.filter((r) => (r.payload as { channelKey?: string }).channelKey === ACCOUNT);
+}
 
 function post(id: string, daysAgo: number, kind: "image" | "video" = "image") {
   return {
@@ -111,9 +135,17 @@ async function readChannelState() {
   return row;
 }
 
+const envMut = env as { SOCIAL_BACKFILL_MAX_POSTS: number };
+let originalMaxPosts: number;
+
 beforeEach(() => {
   provider.pages = { posts: [], reels: [] };
   provider.calls = [];
+  provider.throwOn = {};
+  originalMaxPosts = env.SOCIAL_BACKFILL_MAX_POSTS;
+});
+afterEach(() => {
+  envMut.SOCIAL_BACKFILL_MAX_POSTS = originalMaxPosts;
 });
 
 describe("instagram account walker (resumable, cursor-persisted)", () => {
@@ -262,5 +294,189 @@ describe("instagram account walker (resumable, cursor-persisted)", () => {
     const cs = await readChannelState();
     // last_polled stamped, but NOT marked complete (would silently swallow a typo).
     expect(cs?.backfillComplete).toBe(false);
+  });
+});
+
+// F2 — the resumable backfill walker now SELF-ENQUEUES a continuation via the
+// outbox (atomic with the cursor write) so a multi-page bounded initial/historical
+// backfill completes promptly instead of crawling one page per 6h cron tick.
+// Termination is load-bearing: continue ONLY on the deep branch while NOT complete,
+// NOT paused-by-budget, AND under the post-count cap.
+describe("instagram account walker — self-enqueued continuation (F2)", () => {
+  it("a 2-page deep backfill enqueues a continuation on tick 1, then completes on tick 2 with NO further continuation", async () => {
+    await seedSource();
+    // Tick 1: posts page 1 has a cursor (more available); reels empty (ends).
+    provider.pages.posts = [
+      {
+        posts: [post("c1", 1), post("c2", 2)],
+        nextCursor: "PAGE2",
+        endOfFeed: false,
+        creditsUsed: 1,
+      },
+    ];
+    provider.pages.reels = [emptyPage()];
+
+    await handleBackfillAccount({
+      data: {
+        kind: "instagram_account",
+        channelKey: ACCOUNT,
+        depthBoundIso: "1970-01-01T00:00:00Z",
+        flow: "initial",
+      },
+    });
+
+    // Account NOT complete (posts feed still has a cursor) AND deep branch →
+    // exactly ONE continuation queued via the outbox (atomic with cursor write).
+    let cs = await readChannelState();
+    expect(cs?.backfillComplete).toBe(false);
+    let continuations = await readContinuationOutbox();
+    expect(continuations).toHaveLength(1);
+    const payload = continuations[0]!.payload as {
+      channelKey: string;
+      flow: string;
+      triggerUserId?: string;
+    };
+    expect(payload.channelKey).toBe(ACCOUNT);
+    expect(payload.flow).toBe("initial");
+    // Continuation runs on the cron pool — triggerUserId omitted (trigger pays once).
+    expect(payload.triggerUserId).toBeUndefined();
+    // singletonKey dedupes parallel triggers for this account.
+    expect((continuations[0]!.options as { singletonKey?: string }).singletonKey).toBe(
+      `backfill-account-${ACCOUNT}`,
+    );
+
+    // Tick 2 (the continuation): posts page 2 ends → both feeds complete →
+    // account complete → NO further continuation.
+    provider.pages.posts = [
+      { posts: [post("c3", 3)], nextCursor: null, endOfFeed: true, creditsUsed: 1 },
+    ];
+    provider.pages.reels = []; // reels already complete — walker skips it
+
+    await handleBackfillAccount({
+      data: {
+        kind: "instagram_account",
+        channelKey: ACCOUNT,
+        depthBoundIso: "1970-01-01T00:00:00Z",
+        flow: "initial",
+      },
+    });
+
+    cs = await readChannelState();
+    expect(cs?.backfillComplete).toBe(true);
+    // Still exactly ONE continuation row total — tick 2 did NOT enqueue another
+    // (account complete is the terminal stop; no infinite loop).
+    continuations = await readContinuationOutbox();
+    expect(continuations).toHaveLength(1);
+
+    const inserted = await db.select().from(events).where(eq(events.kind, "instagram_post"));
+    expect(inserted.map((e) => e.externalId).sort()).toEqual(["c1", "c2", "c3"]);
+  });
+
+  it("a budget-paused tick enqueues NO continuation (cron retries after the daily-cap reset)", async () => {
+    await seedSource();
+    // The posts feed reserve is refused (budget exhausted) → AdapterError
+    // rate-limited → the walker pauses this tick and persists the cursor, but
+    // MUST NOT self-continue (the next reserve would be refused too — spin).
+    provider.throwOn.posts = "rate-limited";
+    provider.pages.reels = [emptyPage()];
+
+    await handleBackfillAccount({
+      data: {
+        kind: "instagram_account",
+        channelKey: ACCOUNT,
+        depthBoundIso: "1970-01-01T00:00:00Z",
+        flow: "initial",
+      },
+    });
+
+    const cs = await readChannelState();
+    expect(cs?.backfillComplete).toBe(false);
+    const st = await getInstagramBackfillState(ACCOUNT);
+    expect(st.operatorPaused).toBe(true);
+    // No continuation — a budget pause is NOT a resume trigger.
+    const continuations = await readContinuationOutbox();
+    expect(continuations).toHaveLength(0);
+  });
+
+  it("a cap-reached tick enqueues NO continuation (the post-count cap is a terminal bound)", async () => {
+    envMut.SOCIAL_BACKFILL_MAX_POSTS = 2;
+    await seedSource();
+    // The provider would page forever (cursor always set), but the cap=2 stops
+    // the deep walk after 2 posts → the posts feed is marked complete at the cap
+    // → account complete → NO continuation.
+    provider.pages.posts = [
+      {
+        posts: [post("k1", 1), post("k2", 2)],
+        nextCursor: "MORE",
+        endOfFeed: false,
+        creditsUsed: 1,
+      },
+    ];
+    provider.pages.reels = [emptyPage()];
+
+    await handleBackfillAccount({
+      data: {
+        kind: "instagram_account",
+        channelKey: ACCOUNT,
+        depthBoundIso: "1970-01-01T00:00:00Z",
+        flow: "initial",
+      },
+    });
+
+    const st = await getInstagramBackfillState(ACCOUNT);
+    expect(st.collected).toBe(2); // exactly the cap
+    expect(st.posts.complete).toBe(true);
+    const cs = await readChannelState();
+    expect(cs?.backfillComplete).toBe(true);
+    const continuations = await readContinuationOutbox();
+    expect(continuations).toHaveLength(0);
+  });
+
+  it("an incremental new-only sweep NEVER self-continues even when a feed page returns a cursor (page-1-reset would loop)", async () => {
+    // Seed a COMPLETE account so a subsequent tick takes the incremental/exhausted
+    // branch (which resets every feed to page 1 each tick — a continuation there
+    // would re-fetch page 1 forever).
+    await seedSource();
+    // Tick 1 (deep): each feed returns ONE post then ends → account complete.
+    // (A genuinely-empty first page on a brand-new source trips the Pitfall-4
+    // not_found heuristic instead of completing — so we collect a real post.)
+    provider.pages.posts = [
+      { posts: [post("seed_p", 1)], nextCursor: null, endOfFeed: true, creditsUsed: 1 },
+    ];
+    provider.pages.reels = [
+      { posts: [post("seed_r", 1, "video")], nextCursor: null, endOfFeed: true, creditsUsed: 1 },
+    ];
+    await handleBackfillAccount({
+      data: {
+        kind: "instagram_account",
+        channelKey: ACCOUNT,
+        depthBoundIso: "1970-01-01T00:00:00Z",
+        flow: "initial",
+      },
+    });
+    expect((await readChannelState())?.backfillComplete).toBe(true);
+    // Clear any continuation noise from the deep tick (there should be none —
+    // tick 1 completed the account, so shouldContinue was false).
+    await db.delete(outbox);
+
+    // Tick 2 (incremental/exhausted): posts page 1 returns a cursor (more new
+    // posts), so the feed is NOT marked complete this tick — but the incremental
+    // branch resets to page 1 every tick, so a continuation would loop.
+    provider.pages.posts = [
+      { posts: [post("n1", 1)], nextCursor: "NEWMORE", endOfFeed: false, creditsUsed: 1 },
+    ];
+    provider.pages.reels = [emptyPage()];
+    await handleBackfillAccount({
+      data: {
+        kind: "instagram_account",
+        channelKey: ACCOUNT,
+        depthBoundIso: "1970-01-01T00:00:00Z",
+        flow: "incremental",
+      },
+    });
+
+    // No continuation — the incremental branch is single-page-by-design.
+    const continuations = await readContinuationOutbox();
+    expect(continuations).toHaveLength(0);
   });
 });

--- a/tests/integration/social-budget-throttle.test.ts
+++ b/tests/integration/social-budget-throttle.test.ts
@@ -412,4 +412,113 @@ describe("social provider budget + throttle — operator audit hooks (F4)", () =
     expect(await readBalance()).toBe(3);
     expect(await countAudit("social.budget_exhausted")).toBe(0);
   });
+
+  // F3: the in-memory guards must be keyed by platform/provider, not date alone.
+  // A SECOND provider crossing the same threshold in the same process (no cron
+  // reset between the two) must write its OWN audit row — the first's guard must
+  // not suppress it.
+  const PROVIDER_B = "providerb";
+
+  it("a second provider crossing 80% in the same process is NOT suppressed by the first's guard", async () => {
+    await seedOperator();
+    await seedBalance(100000); // PLATFORM/PROVIDER
+    await db
+      .insert(socialProviderBalance)
+      .values({ platform: PLATFORM, provider: PROVIDER_B, prepaidBalanceCredits: 100000 })
+      .onConflictDoUpdate({
+        target: [socialProviderBalance.platform, socialProviderBalance.provider],
+        set: { prepaidBalanceCredits: 100000 },
+      });
+    await seedPoolUsed("cron", 79);
+    // Park provider B's cron usage at 79 too (its own counter rows).
+    await db
+      .insert(socialProviderSpend)
+      .values({
+        datePacific: todayPacific(),
+        platform: PLATFORM,
+        provider: PROVIDER_B,
+        poolKind: "cron",
+        creditsUsed: 79,
+      })
+      .onConflictDoUpdate({
+        target: [
+          socialProviderSpend.datePacific,
+          socialProviderSpend.platform,
+          socialProviderSpend.provider,
+          socialProviderSpend.poolKind,
+        ],
+        set: { creditsUsed: 79 },
+      });
+
+    // First provider crosses 80 → one audit row + populates its in-memory guard.
+    const a = await reserveSocialCredits({
+      platform: PLATFORM,
+      provider: PROVIDER,
+      origin: "cron",
+      units: 1,
+    });
+    expect(a).not.toBeNull();
+
+    // Second provider crosses 80 in the SAME process (no resetSocialDailyCap
+    // between) → must write its OWN row, not be suppressed by provider A's guard.
+    const b = await reserveSocialCredits({
+      platform: PLATFORM,
+      provider: PROVIDER_B,
+      origin: "cron",
+      units: 1,
+    });
+    expect(b).not.toBeNull();
+
+    const rows = await db
+      .select({ provider: sql<string>`${auditLog.metadata}->>'provider'` })
+      .from(auditLog)
+      .where(
+        sql`${auditLog.action} = 'social.provider_throttled'
+          AND ${auditLog.metadata}->>'state' = 'eighty'
+          AND ${auditLog.metadata}->>'platform' = ${PLATFORM}`,
+      );
+    const providers = new Set(rows.map((r) => r.provider));
+    expect(providers.has(PROVIDER)).toBe(true);
+    expect(providers.has(PROVIDER_B)).toBe(true);
+  });
+
+  it("a second provider exhausting its balance in the same process writes its OWN budget_exhausted row", async () => {
+    await seedOperator();
+    await seedBalance(1); // PLATFORM/PROVIDER exhausts on a unit-1 reserve
+    await db
+      .insert(socialProviderBalance)
+      .values({ platform: PLATFORM, provider: PROVIDER_B, prepaidBalanceCredits: 1 })
+      .onConflictDoUpdate({
+        target: [socialProviderBalance.platform, socialProviderBalance.provider],
+        set: { prepaidBalanceCredits: 1 },
+      });
+
+    const a = await reserveSocialCredits({
+      platform: PLATFORM,
+      provider: PROVIDER,
+      origin: "user",
+      units: 1,
+    });
+    expect(a).not.toBeNull();
+
+    // Provider B exhausts in the SAME process — its own row, not suppressed.
+    const b = await reserveSocialCredits({
+      platform: PLATFORM,
+      provider: PROVIDER_B,
+      origin: "user",
+      units: 1,
+    });
+    expect(b).not.toBeNull();
+
+    const rows = await db
+      .select({ provider: sql<string>`${auditLog.metadata}->>'provider'` })
+      .from(auditLog)
+      .where(
+        sql`${auditLog.action} = 'social.budget_exhausted'
+          AND ${auditLog.metadata}->>'platform' = ${PLATFORM}`,
+      );
+    const providers = new Set(rows.map((r) => r.provider));
+    expect(providers.has(PROVIDER)).toBe(true);
+    expect(providers.has(PROVIDER_B)).toBe(true);
+  });
 });

--- a/tests/integration/social-budget-throttle.test.ts
+++ b/tests/integration/social-budget-throttle.test.ts
@@ -12,12 +12,15 @@
 // pool/throttle gates fire first; the hard-ceiling test writes a small balance
 // row directly to assert the "cannot spend what isn't there" path.
 
-import { describe, it, expect, beforeEach } from "vitest";
-import { and, eq } from "drizzle-orm";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
+import { seedUserDirectly } from "./helpers.js";
 
 const { db } = await import("../../src/lib/server/db/client.js");
 const { socialProviderSpend, socialProviderBalance } =
   await import("../../src/lib/server/db/schema/index.js");
+const { auditLog } = await import("../../src/lib/server/db/schema/audit-log.js");
+const { env } = await import("../../src/lib/server/config/env.js");
 const {
   reserveSocialCredits,
   getSocialThrottleState,
@@ -257,5 +260,157 @@ describe("social provider budget + throttle (prepaid credits)", () => {
     expect(view.creditsUsed).toBe(7);
     expect(view.dailyCap).toBe(100);
     expect(view.prepaidBalance).toBe(100000 - 7);
+  });
+});
+
+// F4 — reserveSocialCredits WIRES the operator audit hooks
+// (markSocialThrottleTransition / markSocialBudgetExhausted) that were declared
+// + documented but had ZERO call sites. A reservation that CROSSES into the 80%
+// / 95% daily-cap band writes social.provider_throttled; a reservation that
+// exhausts the prepaid balance writes social.budget_exhausted. Daily cap is 100
+// in the test env → eighty=80, ninetyfive=95, cron pool=80, user pool=20.
+describe("social provider budget + throttle — operator audit hooks (F4)", () => {
+  // ADMIN_EMAIL_ALLOWLIST is parsed (and the operator id cached) at env-load
+  // time; CI boots with an empty allowlist so the audit fns no-op without a
+  // resolvable operator. Mutate the live Set + clear the resolver cache (via
+  // resetSocialDailyCap) so the operator resolves to a seeded user — then the
+  // audit row actually lands and the WIRING is observable.
+  const allowlistMut = env as { ADMIN_EMAIL_ALLOWLIST: Set<string> };
+  let originalAllowlist: Set<string>;
+  const OPERATOR_EMAIL = "op-social-audit@test.local";
+
+  async function seedOperator(): Promise<void> {
+    await seedUserDirectly({ email: OPERATOR_EMAIL });
+    allowlistMut.ADMIN_EMAIL_ALLOWLIST = new Set([OPERATOR_EMAIL]);
+    // Clear the cached operator id + audit-emission guards so the resolver
+    // re-resolves against the mutated allowlist for this test.
+    await resetSocialDailyCap();
+  }
+
+  async function countAudit(action: string): Promise<number> {
+    const rows = await db
+      .select({ id: auditLog.id })
+      .from(auditLog)
+      .where(sql`${auditLog.action} = ${action}`);
+    return rows.length;
+  }
+
+  beforeEach(() => {
+    originalAllowlist = env.ADMIN_EMAIL_ALLOWLIST;
+  });
+  afterEach(() => {
+    allowlistMut.ADMIN_EMAIL_ALLOWLIST = originalAllowlist;
+  });
+
+  it("a reservation that crosses 80% writes ONE social.provider_throttled audit row (state=eighty)", async () => {
+    await seedOperator();
+    // Park cron usage at 79 so a cron reservation of 1 lands total at 80 (= the
+    // eighty band). Cron pool limit is 80 → 79+1=80 is allowed.
+    await seedPoolUsed("cron", 79);
+    await seedBalance(100000);
+    expect(await countAudit("social.provider_throttled")).toBe(0);
+
+    const permit = await reserveSocialCredits({
+      platform: PLATFORM,
+      provider: PROVIDER,
+      origin: "cron",
+      units: 1,
+    });
+    expect(permit).not.toBeNull();
+
+    const rows = await db
+      .select()
+      .from(auditLog)
+      .where(
+        sql`${auditLog.action} = 'social.provider_throttled'
+          AND ${auditLog.metadata}->>'state' = 'eighty'
+          AND ${auditLog.metadata}->>'platform' = ${PLATFORM}
+          AND ${auditLog.metadata}->>'provider' = ${PROVIDER}`,
+      );
+    expect(rows).toHaveLength(1);
+    expect((rows[0]!.metadata as { date_pacific?: string }).date_pacific).toBe(todayPacific());
+    expect(await getSocialThrottleState(PLATFORM, PROVIDER)).toBe("eighty");
+  });
+
+  it("a reservation that crosses 95% writes social.provider_throttled (state=ninetyfive)", async () => {
+    await seedOperator();
+    // Total at 94 (cron 80 + user 14); a user reservation of 1 lands total at 95
+    // (the ninetyfive band). User pool 14+1=15 ≤ 20; total 94+1=95 ≤ 95 allowed.
+    await seedPoolUsed("cron", 80);
+    await seedPoolUsed("user", 14);
+    await seedBalance(100000);
+
+    const permit = await reserveSocialCredits({
+      platform: PLATFORM,
+      provider: PROVIDER,
+      origin: "user",
+      units: 1,
+    });
+    expect(permit).not.toBeNull();
+
+    const rows = await db
+      .select({ id: auditLog.id })
+      .from(auditLog)
+      .where(
+        sql`${auditLog.action} = 'social.provider_throttled'
+          AND ${auditLog.metadata}->>'state' = 'ninetyfive'`,
+      );
+    expect(rows).toHaveLength(1);
+  });
+
+  it("a reservation BELOW the 80% band writes NO throttle audit (transition, not every call)", async () => {
+    await seedOperator();
+    await seedBalance(100000);
+
+    const permit = await reserveSocialCredits({
+      platform: PLATFORM,
+      provider: PROVIDER,
+      origin: "user",
+      units: 1,
+    });
+    expect(permit).not.toBeNull();
+    expect(await countAudit("social.provider_throttled")).toBe(0);
+  });
+
+  it("a reservation that exhausts the prepaid balance writes ONE social.budget_exhausted audit row", async () => {
+    await seedOperator();
+    // Balance of exactly 1 → a reservation of 1 lands the balance at 0 (exhausted).
+    await seedBalance(1);
+    expect(await countAudit("social.budget_exhausted")).toBe(0);
+
+    const permit = await reserveSocialCredits({
+      platform: PLATFORM,
+      provider: PROVIDER,
+      origin: "user",
+      units: 1,
+    });
+    expect(permit).not.toBeNull();
+    expect(await readBalance()).toBe(0);
+
+    const rows = await db
+      .select()
+      .from(auditLog)
+      .where(
+        sql`${auditLog.action} = 'social.budget_exhausted'
+          AND ${auditLog.metadata}->>'platform' = ${PLATFORM}
+          AND ${auditLog.metadata}->>'provider' = ${PROVIDER}`,
+      );
+    expect(rows).toHaveLength(1);
+    expect((rows[0]!.metadata as { date_pacific?: string }).date_pacific).toBe(todayPacific());
+  });
+
+  it("a reservation that leaves the balance above 0 writes NO budget_exhausted audit", async () => {
+    await seedOperator();
+    await seedBalance(5);
+
+    const permit = await reserveSocialCredits({
+      platform: PLATFORM,
+      provider: PROVIDER,
+      origin: "user",
+      units: 2,
+    });
+    expect(permit).not.toBeNull();
+    expect(await readBalance()).toBe(3);
+    expect(await countAudit("social.budget_exhausted")).toBe(0);
   });
 });

--- a/tests/integration/social-budget-throttle.test.ts
+++ b/tests/integration/social-budget-throttle.test.ts
@@ -263,12 +263,11 @@ describe("social provider budget + throttle (prepaid credits)", () => {
   });
 });
 
-// F4 — reserveSocialCredits WIRES the operator audit hooks
-// (markSocialThrottleTransition / markSocialBudgetExhausted) that were declared
-// + documented but had ZERO call sites. A reservation that CROSSES into the 80%
-// / 95% daily-cap band writes social.provider_throttled; a reservation that
-// exhausts the prepaid balance writes social.budget_exhausted. Daily cap is 100
-// in the test env → eighty=80, ninetyfive=95, cron pool=80, user pool=20.
+// reserveSocialCredits wires the operator audit hooks: a reservation that
+// CROSSES into the 80% / 95% daily-cap band writes social.provider_throttled; a
+// reservation that exhausts the prepaid balance writes social.budget_exhausted.
+// Daily cap is 100 in the test env → eighty=80, ninetyfive=95, cron pool=80,
+// user pool=20.
 describe("social provider budget + throttle — operator audit hooks (F4)", () => {
   // ADMIN_EMAIL_ALLOWLIST is parsed (and the operator id cached) at env-load
   // time; CI boots with an empty allowlist so the audit fns no-op without a

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -68,6 +68,18 @@ describe("logger redaction", () => {
     }
   });
 
+  it("redacts the operator API-key envelope field names (YouTube + ScrapeCreators)", async () => {
+    // Both keys survive in the env singleton for the process lifetime after
+    // scrubKekFromEnv() wipes them from process.env (env.ts SECRET_KEYS). The
+    // transitive *.apiKey path does NOT match these singleton field names, so
+    // each gets a dedicated REDACT_PATHS entry. This asserts the env-key
+    // (uppercase snake) shape — a logger.info({ env }) dump must redact them.
+    const { REDACT_PATHS } = await import("../../src/lib/server/logger.js");
+    for (const field of ["*.SERVICE_YOUTUBE_API_KEYS", "*.SCRAPECREATORS_API_KEY"]) {
+      expect(REDACT_PATHS, `${field} must be a dedicated redact path`).toContain(field);
+    }
+  });
+
   it("process.env.* is not accessed outside src/lib/server/config/env.ts", async () => {
     // Static-grep tripwire. The ESLint contract is configured separately,
     // but a runtime guard catches the case where the lint config drifts or a


### PR DESCRIPTION
## Summary

Follow-up fixes for the merged Phase 8 (Instagram), from three fresh-context reviews (two by Claude, one by the maintainer). **2 P1 + several P2/nits — no schema change, IG not yet deployed so prod is unaffected.** Each fix has a load-bearing test.

Closes #67.

## P1 (functional)
- **Identity (manual paste):** a manually-pasted IG event used the URL *shortcode* as `external_id`, but the cache + every read path (feed-enrichment, metric-series, poll-state, refresh-now) key on the *media id* → the saved event never got thumbnail/stats/poll-badge. Now the manual-paste success path uses the **media id** (`post.id`), consistent with the walker. New e2e test: preview → createEvent → enrichment reads stats/thumbnail. (`98406fb`)
- **Backfill continuation:** the resumable walker persisted its cursor but never enqueued a continuation — a multi-page initial/historical backfill only advanced one page per 6h cron tick instead of completing. Now it **self-enqueues a bounded continuation via the outbox in the same tx** as the cursor write. Strictly gated (`deep && !accountComplete && !pausedByBudget && collected < SOCIAL_BACKFILL_MAX_POSTS`) — incremental/exhausted branches never self-continue (loop-safety tests prove it; worst case is bounded by the prepaid balance anyway). (`04be985`)

## P2 / nits
- `canonicalizeOnCreate` now maps `AdapterError`→`AppError` (bad key / upstream failure on createSource was a 500; now 422/429/502/503). (`c09ec9c`)
- `reserveSocialCredits` now actually emits `social.provider_throttled` / `social.budget_exhausted` on the 80/95% crossing + balance exhaustion (the audit hooks had zero call sites). (`c7e59a7`)
- `SCRAPECREATORS_API_KEY` added to the Pino redact list by name (parity with the YouTube key; defense-in-depth). (`bf9d377`)
- `previewUrlSchema` tightened to http(s) at the route boundary. (`663c8ec`)
- Prefer cached `media_type` for a reel shared as `/p/<code>` (pill said "Video"). (`45c832b`)
- `enrichFromUrl` re-throws unexpected (non-AdapterError/AppError) errors instead of hiding them; tidied a mislabeled select alias. (`bd84695`)
- Hygiene: deleted a redundant untracked `_worker.ts` (use the gitignored `.dev-worker.ts`).

## Test plan
- CI: lint-typecheck, unit-integration, browser-tests, smoke.
- Local: `pnpm typecheck` (svelte-check) 0 errors; new/affected tests green (paste-preview e2e, walker continuation + loop-safety, create-source error mapping, throttle/budget audit, logger redact, preview-url scheme). (Pre-existing reddit-paste local failures are the known Reddit-403 dead path — CI mocks Reddit.)

## Optional follow-ups (non-blocking, from the 2nd/3rd review)
- Hard stuck-cursor guard (stop a feed if `nextCursor === current`) — needs provider misbehavior; already bounded by the prepaid ceiling.
- F4 audit-emit caveat if a transactional caller is ever added (today's only caller passes no tx).

🤖 Generated with [Claude Code](https://claude.com/claude-code)