### PR TITLE
fix(instagram): pasted-post enrichment, same-origin thumbnails & per-post Refresh (#69)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -276,9 +276,12 @@ SOCIAL_REFRESH_LANE_CONCURRENCY=10
 # spend to ≤ N credits/post — the first week is the wishlist-correlation window.
 INSTAGRAM_WARM_WINDOW_DAYS=7
 # Staleness gate (hours): a warm post is re-refreshed only when not polled within
-# this window. < 24h so an off-page-1 post gets one paid refresh/day without
-# racing the once-daily free account poll into a double-charge.
-INSTAGRAM_WARM_STALENESS_HOURS=22
+# this window. Must be JUST OVER the 24h free account-poll interval — the daily
+# account poll re-stamps last_polled_at on every page-1 post, so >24h keeps page-1
+# posts under the gate (free poll covers them, we never pay) and only off-page-1
+# posts go stale enough to earn a paid refresh. <24h would pay for page-1 posts the
+# free poll already covers. 26h = 24h + 2h jitter margin.
+INSTAGRAM_WARM_STALENESS_HOURS=26
 # Consecutive non-ok polls before a post drops out of warm auto-refresh. IG maps
 # transient + budget-exhaustion to auth_error; this bounds a blip (self-heals) and
 # a persistent failure (stops churning credits). Resets on the next ok poll.

--- a/.env.example
+++ b/.env.example
@@ -264,6 +264,12 @@ SOCIAL_PROVIDER_DAILY_CAP_CREDITS=0
 # daily-cap counter, never this balance. 0 default ⇒ degrade.
 SOCIAL_PROVIDER_PREPAID_BALANCE_CREDITS=0
 
+# Concurrency of the social-provider per-post Refresh lane. The single-post
+# endpoint can't batch (1 request = 1 post), so the lane worker claims up to N
+# rows per tick and fetches them CONCURRENTLY — this is the parallelism knob, not
+# a batch-in-one-request size. Keep conservative for provider rate limits.
+SOCIAL_REFRESH_LANE_CONCURRENCY=10
+
 # ---- Phase 7 -- Observability (docker-compose.monitoring.yml) ----
 
 # Bearer token protecting /metrics endpoint. Empty (default) = /metrics

--- a/.env.example
+++ b/.env.example
@@ -270,6 +270,20 @@ SOCIAL_PROVIDER_PREPAID_BALANCE_CREDITS=0
 # a batch-in-one-request size. Keep conservative for provider rate limits.
 SOCIAL_REFRESH_LANE_CONCURRENCY=10
 
+# Warm auto-refresh window (#69 follow-on). A post is auto-refreshed ~1×/day for
+# its first N days of life (free while on page-1 of the account feed; paid via the
+# single-post lane once it rolls off), then frozen (manual Refresh only). Bounds
+# spend to ≤ N credits/post — the first week is the wishlist-correlation window.
+INSTAGRAM_WARM_WINDOW_DAYS=7
+# Staleness gate (hours): a warm post is re-refreshed only when not polled within
+# this window. < 24h so an off-page-1 post gets one paid refresh/day without
+# racing the once-daily free account poll into a double-charge.
+INSTAGRAM_WARM_STALENESS_HOURS=22
+# Consecutive non-ok polls before a post drops out of warm auto-refresh. IG maps
+# transient + budget-exhaustion to auth_error; this bounds a blip (self-heals) and
+# a persistent failure (stops churning credits). Resets on the next ok poll.
+INSTAGRAM_WARM_MAX_FAILURES=5
+
 # ---- Phase 7 -- Observability (docker-compose.monitoring.yml) ----
 
 # Bearer token protecting /metrics endpoint. Empty (default) = /metrics

--- a/src/lib/components/PollingBadge.svelte
+++ b/src/lib/components/PollingBadge.svelte
@@ -97,6 +97,13 @@
     lastPolledAt: Date | string | null;
     lastPollStatus: string | null;
     metadata: Record<string, unknown> | null;
+    // The upstream media id. An EXPLICIT null on a pollable kind means a manual
+    // entry with no id to poll (e.g. an Instagram post pasted without the
+    // preview "Fetch") → render the "Manual" variant, not "Pending" (#69 — a
+    // pending badge that would never resolve). Optional + strict `=== null`
+    // below: an UNSET externalId (older callers / fixtures not plumbing it)
+    // keeps the prior tier-driven behavior.
+    externalId?: string | null;
   };
 
   let { event }: { event: EventForBadge } = $props();
@@ -105,6 +112,12 @@
   // kind-display config (pollable: youtube_video / reddit_post / instagram_post).
   // event.kind is widened to `string` here; isPollable narrows via the Set.
   const isPollable = $derived(POLLABLE_EVENT_KINDS.has(event.kind as EventKind));
+
+  // A pollable-kind event whose externalId is EXPLICITLY null is a manual entry
+  // with no upstream id — nothing will ever poll it, so a NULL publishedAt here
+  // is "manual", NOT "pending" (#69). Strict `=== null` so callers that haven't
+  // plumbed externalId (undefined) keep the prior tier-driven behavior.
+  const isManualEntry = $derived(event.externalId === null);
 
   // Defensive Date coercion — props may arrive as ISO strings.
   const publishedAt = $derived(
@@ -179,6 +192,9 @@
   });
 
   const variant: Variant = $derived.by((): Variant => {
+    // Manual entry (no upstream id) outranks the pending tier: there is no
+    // backfill in flight, so "Pending · fetching…" would never resolve (#69).
+    if (isManualEntry) return "manual";
     if (tier === "pending") return "pending";
     if (refreshQueued) return "refreshing";
     // Operator-budget pause outranks tier/unavailable: the source isn't being
@@ -207,7 +223,7 @@
   // swallow), the user has an explicit refresh button to rescue.
   // 'pending' tier still hides refresh — backfill is in flight, manual
   // poll would race it. Refresh-poll service rejects 'pending' with 422.
-  const refreshVisible = $derived(isPollable && tier !== "pending");
+  const refreshVisible = $derived(isPollable && tier !== "pending" && !isManualEntry);
 
   // Copy resolution. The visible text uses "Updated X ago" relative time
   // (user-meaningful) rather than tier vocabulary ("Cold", "Frozen").

--- a/src/lib/components/add-event/AddEventForm.svelte
+++ b/src/lib/components/add-event/AddEventForm.svelte
@@ -291,11 +291,20 @@
         authorName?: string | null;
         authorUrl?: string | null;
         externalId?: string | null;
+        canonicalUrl?: string | null;
       };
       // The resolved media id — forwarded on save so the event keys on the
       // snapshot/enrichment cache id (issue #69). Null for kinds/URLs the
       // adapter couldn't resolve a stable id for.
       fetchedExternalId = data.externalId ?? null;
+      // Adopt the adapter's canonical permalink (IG: query/tracking stripped;
+      // YouTube: keeps ?v, drops ?t) so the saved link is clean + identical for
+      // the same post. The URL field locks on `fetched` below, so the user sees
+      // and saves this value. A programmatic assignment does NOT fire the input's
+      // oninput handler (which would clear the just-set fetch state).
+      if (data.canonicalUrl) {
+        url = data.canonicalUrl;
+      }
       if (data.title && title.trim().length === 0) {
         title = data.title;
       }

--- a/src/lib/components/add-event/AddEventForm.svelte
+++ b/src/lib/components/add-event/AddEventForm.svelte
@@ -124,6 +124,10 @@
     fetched = false;
     fetchedSrc = "";
     fetchedExternalId = null;
+    // Clear fetched metadata too (#70 ultrareview P3): otherwise a fetch of URL A
+    // (e.g. Reddit subreddit) survives a Reset/edit and gets forwarded on submit
+    // for the new URL B — stale denormalized metadata on the saved event.
+    fetchedMetadata = {};
     urlError = null;
   }
   let urlError = $state<string | null>(null);
@@ -503,6 +507,7 @@
         oninput={() => {
           fetched = false;
           fetchedExternalId = null;
+          fetchedMetadata = {};
           urlError = null;
         }}
         onkeydown={(e) => {

--- a/src/lib/components/add-event/AddEventForm.svelte
+++ b/src/lib/components/add-event/AddEventForm.svelte
@@ -51,6 +51,11 @@
     // author_name, Reddit subreddit/author, etc). Persisted to
     // events.metadata so FeedCard.sourceLabel can read it back.
     metadata?: Record<string, unknown>;
+    // The MEDIA id the preview flow resolved (POST /api/events/preview-url
+    // returns it). Forwarded on save so the event keys on the same id the
+    // snapshot/enrichment caches use. Load-bearing for Instagram: its URL
+    // carries only the shortcode, NOT the media-id cache key (issue #69).
+    externalId?: string | null;
   };
 
   let {
@@ -105,6 +110,11 @@
   // in FeedCard sourceLabel (e.g. "Rick Astley (YouTube channel)") via
   // metadata.channelTitle / metadata.subreddit / metadata.author.
   let fetchedMetadata = $state<Record<string, unknown>>({});
+  // The media id resolved by the URL preview (POST /api/events/preview-url),
+  // forwarded on save so the event keys on the snapshot/enrichment cache id —
+  // load-bearing for Instagram, whose URL is only a shortcode (issue #69).
+  // Null until a successful fetch; cleared on Reset / URL edit.
+  let fetchedExternalId = $state<string | null>(null);
 
   // After a successful fetch, the URL + kind are AUTHORITATIVE — the
   // adapter parsed them from the live URL. Lock both inputs so the user
@@ -113,6 +123,7 @@
   function resetFetch(): void {
     fetched = false;
     fetchedSrc = "";
+    fetchedExternalId = null;
     urlError = null;
   }
   let urlError = $state<string | null>(null);
@@ -279,7 +290,12 @@
         sourceLabel?: string | null;
         authorName?: string | null;
         authorUrl?: string | null;
+        externalId?: string | null;
       };
+      // The resolved media id — forwarded on save so the event keys on the
+      // snapshot/enrichment cache id (issue #69). Null for kinds/URLs the
+      // adapter couldn't resolve a stable id for.
+      fetchedExternalId = data.externalId ?? null;
       if (data.title && title.trim().length === 0) {
         title = data.title;
       }
@@ -377,6 +393,7 @@
         authorIsMe,
         occurredAt: new Date(occurredAt).toISOString(),
         metadata: Object.keys(fetchedMetadata).length > 0 ? fetchedMetadata : undefined,
+        externalId: fetchedExternalId,
       });
     } catch {
       errorText = m.error_server_generic();
@@ -476,6 +493,7 @@
         bind:value={url}
         oninput={() => {
           fetched = false;
+          fetchedExternalId = null;
           urlError = null;
         }}
         onkeydown={(e) => {

--- a/src/lib/components/charts/EventHistoryChart.svelte
+++ b/src/lib/components/charts/EventHistoryChart.svelte
@@ -84,6 +84,14 @@
     const base = baseChartOptions({ reducedMotion });
     return {
       ...base,
+      // svelte-echarts <Chart> applies options with notMerge:true, so EVERY
+      // setOption (e.g. a Refresh-Now invalidateAll re-running the loader) RESETS
+      // the chart and replays the entry animation — the "graph redraws from 0"
+      // jank (#69). Disable animation on this chart so a data reload updates in
+      // place (instant), not from 0. The custom legend toggle still works (it
+      // filters the series array, which notMerge:true replaces each setOption).
+      // Mirrors what reduced-motion users already get.
+      animation: false,
       grid: { left: 8, right: 12, top: 12, bottom: 8, containLabel: true },
       tooltip: {
         trigger: "axis" as const,

--- a/src/lib/components/event-detail/EventDetailHeader.svelte
+++ b/src/lib/components/event-detail/EventDetailHeader.svelte
@@ -150,6 +150,10 @@
         lastPolledAt: event.lastPolledAt ?? null,
         lastPollStatus: event.lastPollStatus ?? null,
         metadata: (event.metadata ?? null) as Record<string, unknown> | null,
+        // Explicit null (not undefined) so PollingBadge renders "Manual" — not a
+        // never-resolving "Pending" — for a pollable-kind event with no upstream
+        // id (e.g. an IG post pasted without the preview "Fetch", #69).
+        externalId: event.externalId ?? null,
       }}
     />
   {/if}

--- a/src/lib/components/feed/parts/BaseFeedCard.svelte
+++ b/src/lib/components/feed/parts/BaseFeedCard.svelte
@@ -373,11 +373,17 @@
     {#if showThumb}
       <div class="card-thumb" class:empty={!thumbnailUrl}>
         {#if thumbnailUrl}
+          <!-- NO crossorigin: these thumbnails are display-only (never read into
+               a canvas), and Instagram's cdninstagram.com serves the bytes
+               WITHOUT Access-Control-Allow-Origin headers. With
+               crossorigin="anonymous" the browser fetches 200 but DISCARDS the
+               image on the failed CORS check → broken thumbnail (#69). YouTube /
+               Reddit CDNs send CORS headers so they were unaffected, which
+               masked this. referrerpolicy stays (CDN hotlink hygiene). -->
           <img
             src={thumbnailUrl}
             alt={m.feed_card_thumbnail_alt({ title: event.title })}
             referrerpolicy="no-referrer"
-            crossorigin="anonymous"
             loading="lazy"
             onerror={onThumbnailError ? () => onThumbnailError() : undefined}
           />

--- a/src/lib/components/feed/parts/derive-card-data.ts
+++ b/src/lib/components/feed/parts/derive-card-data.ts
@@ -215,7 +215,13 @@ export function deriveThumbnailUrl(event: CardEventLite): string | null {
     // media id (#69) — only when a thumbnail actually exists in the cache (the
     // enrichment URL is present) and we have the post id to key on.
     if (event.instagramEnrichment?.thumbnailUrl == null || !event.externalId) return null;
-    return `/api/instagram/thumbnail/${encodeURIComponent(event.externalId)}`;
+    const base = `/api/instagram/thumbnail/${encodeURIComponent(event.externalId)}`;
+    // Cache-buster: version the stable proxy URL by the latest poll timestamp.
+    // A re-poll (Refresh-Now or a scheduled tick) writes a new snapshot → new
+    // polledAt → new URL → the browser refetches the fresh cover; between polls
+    // it serves from the 1h cache. The proxy ignores the query param.
+    const polledAt = event.instagramEnrichment.stats?.polledAt;
+    return polledAt ? `${base}?v=${new Date(polledAt).getTime()}` : base;
   }
   return null;
 }

--- a/src/lib/components/feed/parts/derive-card-data.ts
+++ b/src/lib/components/feed/parts/derive-card-data.ts
@@ -209,9 +209,13 @@ export function deriveThumbnailUrl(event: CardEventLite): string | null {
     return readMediaUrlFromMetadata(event.metadata);
   }
   if (event.kind === "instagram_post") {
-    // The fresh CDN hotlink lives on instagramEnrichment (set by
-    // sources/instagram/server/feed-enrichment.ts), NOT in event.metadata.
-    return event.instagramEnrichment?.thumbnailUrl ?? null;
+    // IG's CDN serves thumbnails with Cross-Origin-Resource-Policy: same-origin,
+    // so the raw hotlink (instagramEnrichment.thumbnailUrl) is BLOCKED by the
+    // browser cross-origin. Route through the same-origin proxy keyed by the
+    // media id (#69) — only when a thumbnail actually exists in the cache (the
+    // enrichment URL is present) and we have the post id to key on.
+    if (event.instagramEnrichment?.thumbnailUrl == null || !event.externalId) return null;
+    return `/api/instagram/thumbnail/${encodeURIComponent(event.externalId)}`;
   }
   return null;
 }

--- a/src/lib/server/config/env.ts
+++ b/src/lib/server/config/env.ts
@@ -285,6 +285,25 @@ const RawSchema = z.object({
   // the parallelism knob, NOT a batch-in-one-request size like YouTube's 50.
   // Keep conservative to respect ScrapeCreators rate limits; raise per plan.
   SOCIAL_REFRESH_LANE_CONCURRENCY: z.coerce.number().int().positive().default(10),
+
+  // Warm auto-refresh (#69 follow-on). A post is "warm" (gets a PAID single-post
+  // refresh via the service_post lane) while it is YOUNGER than this many days
+  // AND has gone stale (not refreshed within INSTAGRAM_WARM_STALENESS_HOURS).
+  // Older than the window → frozen (manual Refresh only). The first week is where
+  // metrics move + wishlist correlation matters; bounding the window caps spend
+  // to ≤ window credits/post.
+  INSTAGRAM_WARM_WINDOW_DAYS: z.coerce.number().int().positive().default(7),
+  // Staleness gate: a warm post is re-refreshed only when its last_polled_at is
+  // older than this. < 24h so a post that rolled off page-1 (no longer covered by
+  // the daily free account poll) gets exactly one paid refresh/day; the slightly-
+  // under-24h value avoids racing the once-daily free poll into a double-charge.
+  INSTAGRAM_WARM_STALENESS_HOURS: z.coerce.number().int().positive().default(22),
+  // Bound on consecutive non-ok polls before a post drops OUT of warm
+  // auto-refresh (IG's HTTP seam collapses transient + budget-exhaustion into
+  // last_poll_status='auth_error'; a single blip must NOT freeze a post forever,
+  // and a PERSISTENT failure must NOT churn credits forever — poll_failure_count
+  // bounds both). Resets to 0 on the next ok poll.
+  INSTAGRAM_WARM_MAX_FAILURES: z.coerce.number().int().positive().default(5),
 });
 
 const raw = RawSchema.parse(process.env);
@@ -410,6 +429,9 @@ export const env = {
   SOCIAL_PROVIDER_DAILY_CAP_CREDITS: raw.SOCIAL_PROVIDER_DAILY_CAP_CREDITS,
   SOCIAL_PROVIDER_PREPAID_BALANCE_CREDITS: raw.SOCIAL_PROVIDER_PREPAID_BALANCE_CREDITS,
   SOCIAL_REFRESH_LANE_CONCURRENCY: raw.SOCIAL_REFRESH_LANE_CONCURRENCY,
+  INSTAGRAM_WARM_WINDOW_DAYS: raw.INSTAGRAM_WARM_WINDOW_DAYS,
+  INSTAGRAM_WARM_STALENESS_HOURS: raw.INSTAGRAM_WARM_STALENESS_HOURS,
+  INSTAGRAM_WARM_MAX_FAILURES: raw.INSTAGRAM_WARM_MAX_FAILURES,
 } as const;
 
 export type Env = typeof env;

--- a/src/lib/server/config/env.ts
+++ b/src/lib/server/config/env.ts
@@ -278,6 +278,13 @@ const RawSchema = z.object({
   // there"). The quota_reset cron clears only the daily-cap counter, never
   // this balance. 0 default => degrade.
   SOCIAL_PROVIDER_PREPAID_BALANCE_CREDITS: z.coerce.number().int().nonnegative().default(0),
+
+  // Concurrency of the social-provider per-post Refresh lane (#69 follow-on).
+  // The single-post endpoint can't batch (1 request = 1 post), so the lane
+  // worker claims up to N rows per tick and fetches them CONCURRENTLY — this is
+  // the parallelism knob, NOT a batch-in-one-request size like YouTube's 50.
+  // Keep conservative to respect ScrapeCreators rate limits; raise per plan.
+  SOCIAL_REFRESH_LANE_CONCURRENCY: z.coerce.number().int().positive().default(10),
 });
 
 const raw = RawSchema.parse(process.env);
@@ -402,6 +409,7 @@ export const env = {
   SOCIAL_BACKFILL_WINDOW_DAYS: raw.SOCIAL_BACKFILL_WINDOW_DAYS,
   SOCIAL_PROVIDER_DAILY_CAP_CREDITS: raw.SOCIAL_PROVIDER_DAILY_CAP_CREDITS,
   SOCIAL_PROVIDER_PREPAID_BALANCE_CREDITS: raw.SOCIAL_PROVIDER_PREPAID_BALANCE_CREDITS,
+  SOCIAL_REFRESH_LANE_CONCURRENCY: raw.SOCIAL_REFRESH_LANE_CONCURRENCY,
 } as const;
 
 export type Env = typeof env;

--- a/src/lib/server/config/env.ts
+++ b/src/lib/server/config/env.ts
@@ -294,10 +294,14 @@ const RawSchema = z.object({
   // to ≤ window credits/post.
   INSTAGRAM_WARM_WINDOW_DAYS: z.coerce.number().int().positive().default(7),
   // Staleness gate: a warm post is re-refreshed only when its last_polled_at is
-  // older than this. < 24h so a post that rolled off page-1 (no longer covered by
-  // the daily free account poll) gets exactly one paid refresh/day; the slightly-
-  // under-24h value avoids racing the once-daily free poll into a double-charge.
-  INSTAGRAM_WARM_STALENESS_HOURS: z.coerce.number().int().positive().default(22),
+  // older than this. Must be JUST OVER the 24h free account-poll interval: the
+  // daily account poll re-stamps last_polled_at on EVERY page-1 post, so a value
+  // >24h keeps page-1 posts UNDER the gate (the free poll covers them — we never
+  // pay) and only OFF-page-1 posts (the free poll no longer reaches them) go stale
+  // enough to earn a paid warm refresh ~1×/day. A value <24h would pay daily for
+  // page-1 posts the free poll already covers — the exact opposite of the cost
+  // goal. 26h = 24h interval + 2h margin for free-poll scheduling jitter.
+  INSTAGRAM_WARM_STALENESS_HOURS: z.coerce.number().int().positive().default(26),
   // Bound on consecutive non-ok polls before a post drops OUT of warm
   // auto-refresh (IG's HTTP seam collapses transient + budget-exhaustion into
   // last_poll_status='auth_error'; a single blip must NOT freeze a post forever,

--- a/src/lib/server/http/routes/events.ts
+++ b/src/lib/server/http/routes/events.ts
@@ -150,6 +150,13 @@ const createEventSchema = z
     // "Author: me / not me" at create time. Service defaults to false when
     // omitted (preserves existing semantics).
     authorIsMe: z.boolean().optional(),
+    // The MEDIA id resolved by the preview flow (POST /api/events/preview-url
+    // returns it). Round-trips through the save body so the saved event keys on
+    // the same id the snapshot/enrichment caches use. Load-bearing for
+    // instagram_post: its URL carries only the shortcode, which is NOT the
+    // media-id cache key — so it must come from the preview, not be re-derived
+    // from the URL. createEvent prefers this caller-supplied value.
+    externalId: z.string().min(1).nullable().optional(),
   })
   .superRefine(urlRequiredForPollableKinds)
   .transform((obj) => {

--- a/src/lib/server/http/routes/events.ts
+++ b/src/lib/server/http/routes/events.ts
@@ -427,6 +427,10 @@ eventsRoutes.post(
         authorUrl: enriched.authorUrl,
         // ISO string when set; null when oEmbed has no published_at.
         occurredAt: enriched.occurredAt ? enriched.occurredAt.toISOString() : null,
+        // The adapter's canonical permalink (IG: query stripped; YouTube: keeps
+        // ?v, drops ?t). The form swaps the pasted URL for this on a successful
+        // Fetch so the saved event stores a clean link, not a tracking-tailed one.
+        canonicalUrl: enriched.canonicalUrl,
       });
     } catch (err) {
       return mapErr(c, err, "POST /api/events/preview-url");

--- a/src/lib/server/http/routes/events.ts
+++ b/src/lib/server/http/routes/events.ts
@@ -152,10 +152,11 @@ const createEventSchema = z
     authorIsMe: z.boolean().optional(),
     // The MEDIA id resolved by the preview flow (POST /api/events/preview-url
     // returns it). Round-trips through the save body so the saved event keys on
-    // the same id the snapshot/enrichment caches use. Load-bearing for
-    // instagram_post: its URL carries only the shortcode, which is NOT the
-    // media-id cache key — so it must come from the preview, not be re-derived
-    // from the URL. createEvent prefers this caller-supplied value.
+    // the same id the snapshot/enrichment caches use. createEvent prefers it for
+    // URL-derivable kinds (youtube_video / reddit_post). For instagram_post the
+    // body is UNTRUSTED and IGNORED: createEvent re-derives the media id from our
+    // own cache by canonical permalink (an adapter resolveCachedExternalId hook),
+    // so a client cannot pair post A's URL with post B's media id (#70 P1).
     externalId: z.string().min(1).nullable().optional(),
   })
   .superRefine(urlRequiredForPollableKinds)

--- a/src/lib/server/services/events-mutation.ts
+++ b/src/lib/server/services/events-mutation.ts
@@ -19,7 +19,7 @@ import { env } from "../config/env.js";
 import { AppError, NotFoundError } from "./errors.js";
 import { withQuotaGuard, getUserQuotaUsedToday } from "./quota.js";
 import { eventKindToSourceKind } from "$lib/sources/event-to-source-kind.js";
-import { getAdapter } from "$lib/sources/registry.js";
+import { getAdapter, hasAdapter } from "$lib/sources/registry.js";
 import { logger } from "../logger.js";
 import { mapEventsToDtos, type EventDto } from "../dto.js";
 import {
@@ -207,21 +207,27 @@ export async function createEvent(
     }
   }
 
-  // #70 review P1 — instagram_post external_id is the MEDIA id: NOT URL-derivable
-  // (the permalink carries only the shortcode) and supplied by the client preview
-  // round-trip, so the request body's externalId is UNTRUSTED. A caller could pair
-  // post A's URL with post B's media id, binding feed-enrichment / thumbnail proxy
-  // / refresh to the wrong cache key. Re-derive from OUR OWN cache via the adapter
-  // seam (instagram_posts.permalink = the canonical url the preview UPSERTed),
-  // OVERRIDING the body value (this runs regardless of input.externalId — the
-  // opposite of the "caller wins" rule above, which is the whole point). No cache
-  // row (create without a prior preview) → null → an honest stats-less card,
-  // identical to the recognition-only paste path.
-  if (input.kind === "instagram_post" && input.url != null && input.url !== "") {
-    const igAdapter = getAdapter("instagram_account");
-    derivedExternalId = igAdapter.resolveCachedExternalId
-      ? await igAdapter.resolveCachedExternalId(input.url)
-      : null;
+  // Cache-derived external_id (registry-driven; #70 review P1 + ultrareview).
+  // An adapter that declares `resolveCachedExternalId` owns its event-kind's
+  // external_id AUTHORITATIVELY because the id is NOT URL-derivable and the request
+  // body is untrusted (instagram_post: the MEDIA id is keyed by canonical permalink
+  // in our own cache, populated by the preview — a client could otherwise pair post
+  // A's URL with post B's media id). When the matched adapter provides it, it
+  // OVERRIDES any body/parsed value above (this runs REGARDLESS of input.externalId
+  // — the opposite of the "caller wins" rule, which is the whole point). Adapters
+  // whose id IS URL-derivable (YouTube videoId, Reddit t3) don't implement it → the
+  // parseAnyUrl result above stands. No cache row → null → honest stats-less card.
+  const cacheKindSource = eventKindToSourceKind(input.kind);
+  if (
+    cacheKindSource !== null &&
+    hasAdapter(cacheKindSource) &&
+    input.url != null &&
+    input.url !== ""
+  ) {
+    const adapter = getAdapter(cacheKindSource);
+    if (adapter.resolveCachedExternalId !== undefined) {
+      derivedExternalId = await adapter.resolveCachedExternalId(input.url);
+    }
   }
 
   // The events INSERT + junction INSERT loop run in a single tx so a

--- a/src/lib/server/services/events-mutation.ts
+++ b/src/lib/server/services/events-mutation.ts
@@ -543,13 +543,14 @@ export async function enrichFromUrl(
   // the soft path over a hard 429 — no credit was burned, so the cost guardrail
   // still held.
   if (parsed.kind === "instagram_post") {
-    // Recognition-only carries the URL SHORTCODE, not the media id the cache keys
-    // on (no live fetch). It won't enrich, and a later account poll won't re-bind
-    // it (that poll creates a SEPARATE media-id-keyed event) — re-paste once the
-    // provider recovers to get an enriched event.
+    // Recognition-only has NO media id (no live fetch resolved one). externalId
+    // is null, NOT the URL shortcode: the shortcode is not the cache key, so
+    // storing it would strand the event on the "pending" badge with no stats
+    // forever (issue #69). null yields an honest stats-less manual card; re-paste
+    // once the provider recovers to get an enriched, media-id-keyed event.
     const recognitionOnly: EnrichmentResult = {
       kind: "instagram_post",
-      externalId: parsed.externalId,
+      externalId: null,
       title: "",
       occurredAt: null,
       thumbnailUrl: null,
@@ -602,9 +603,10 @@ export async function enrichFromUrl(
       // single-post fetch UPSERTed instagram_posts + a snapshot keyed by the
       // media id; saving the event with the shortcode would orphan it from the
       // cache so feed-enrichment / metric-series / poll-state / refresh-now
-      // never match. Falls back to the parsed shortcode only if the adapter
-      // didn't surface a media id (defensive — the IG adapter always does).
-      externalId: preview.externalId ?? parsed.externalId,
+      // never match. Falls back to null (never the shortcode) if the adapter
+      // somehow didn't surface a media id (defensive — the IG adapter always
+      // does): an unenriched-but-honest card beats a permanently-pending one.
+      externalId: preview.externalId ?? null,
       title: preview.title,
       occurredAt: preview.occurredAt ?? null,
       thumbnailUrl: preview.thumbnailUrl ?? null,

--- a/src/lib/server/services/events-mutation.ts
+++ b/src/lib/server/services/events-mutation.ts
@@ -207,6 +207,23 @@ export async function createEvent(
     }
   }
 
+  // #70 review P1 — instagram_post external_id is the MEDIA id: NOT URL-derivable
+  // (the permalink carries only the shortcode) and supplied by the client preview
+  // round-trip, so the request body's externalId is UNTRUSTED. A caller could pair
+  // post A's URL with post B's media id, binding feed-enrichment / thumbnail proxy
+  // / refresh to the wrong cache key. Re-derive from OUR OWN cache via the adapter
+  // seam (instagram_posts.permalink = the canonical url the preview UPSERTed),
+  // OVERRIDING the body value (this runs regardless of input.externalId — the
+  // opposite of the "caller wins" rule above, which is the whole point). No cache
+  // row (create without a prior preview) → null → an honest stats-less card,
+  // identical to the recognition-only paste path.
+  if (input.kind === "instagram_post" && input.url != null && input.url !== "") {
+    const igAdapter = getAdapter("instagram_account");
+    derivedExternalId = igAdapter.resolveCachedExternalId
+      ? await igAdapter.resolveCachedExternalId(input.url)
+      : null;
+  }
+
   // The events INSERT + junction INSERT loop run in a single tx so a
   // junction-INSERT failure rolls the parent INSERT back. Validation +
   // ownership pre-checks above are pure and stay outside. withQuotaGuard

--- a/src/lib/server/services/events-mutation.ts
+++ b/src/lib/server/services/events-mutation.ts
@@ -195,7 +195,14 @@ export async function createEvent(
     // services through syncStats/create flows.
     const { parseAnyUrl } = await import("$lib/sources/url.js");
     const parsed = parseAnyUrl(input.url);
-    if (parsed !== null && parsed.kind === input.kind) {
+    // instagram_post is excluded: its URL carries only the shortcode, which is
+    // NOT the media-id key the snapshot / feed-enrichment caches use. The media
+    // id is resolved ONLY by the preview flow and arrives as an explicit
+    // input.externalId (handled above). Deriving the shortcode here would save
+    // an event whose external_id never matches any snapshot — stuck on the
+    // "pending" badge with no stats forever (issue #69). Leaving it null yields
+    // an honest stats-less manual card instead.
+    if (parsed !== null && parsed.kind === input.kind && parsed.kind !== "instagram_post") {
       derivedExternalId = parsed.externalId;
     }
   }

--- a/src/lib/sources/adapter.ts
+++ b/src/lib/sources/adapter.ts
@@ -689,6 +689,18 @@ export interface SourceAdapter {
    *  URL parseable as youtube_video. Throws AppError on invalid input. */
   validateEventInput?(input: { kind: string; url?: string | null }): void;
 
+  /** Resolve an event's canonical external_id from the adapter's OWN cache,
+   *  given the event URL. Declare this ONLY when the external_id is NOT
+   *  URL-derivable and the request body's value is therefore untrusted at the
+   *  create boundary. Instagram: the media id is keyed by canonical permalink in
+   *  instagram_posts (populated by the preview), so the create path re-derives
+   *  it here instead of trusting the client (a client could pair post A's URL
+   *  with post B's media id — #70 review P1). Returns null when the cache has no
+   *  row for the URL (create without a prior preview) → the caller saves a
+   *  stats-less card. Adapters whose external_id IS URL-derivable (YouTube
+   *  videoId, Reddit t3 id) omit this — the parseAnyUrl path already covers them. */
+  resolveCachedExternalId?(url: string): Promise<string | null>;
+
   /** Batch lookup of live poll-state for events of this adapter's kinds.
    *  dto.ts's overlayPollStateOnEvents iterates allAdapters and merges
    *  results. YouTube: SELECT publishedAt/lastPolledAt/lastPollStatus

--- a/src/lib/sources/instagram/server/handlers/enqueue-service-post-stats.ts
+++ b/src/lib/sources/instagram/server/handlers/enqueue-service-post-stats.ts
@@ -1,0 +1,63 @@
+// Warm auto-refresh producer — enqueues service_post rows into
+// adapter_refresh_queue (#70). Mirrors youtube enqueue-service-video-stats.ts:
+// advisory-lock per id (serialize concurrent producers) + skip-if-pending dedup
+// (the auto path MUST dedup — between enqueue and processing last_polled_at is
+// still stale, so the next warm tick would re-select the same post; the manual
+// user_post path stays cooldown-only). user_id=NULL → public-data cron lane.
+
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { db } from "$lib/server/db/client.js";
+import { adapterRefreshQueue } from "$lib/server/db/schema/index.js";
+
+const ADAPTER_KIND = "instagram_account";
+const QUEUE_NAME = "service_post";
+
+export async function enqueueServiceInstagramPostStats(postIds: string[]): Promise<number> {
+  const unique = [...new Set(postIds.filter((id) => id.length > 0))];
+  if (unique.length === 0) return 0;
+
+  return db.transaction(async (tx) => {
+    // Deterministic lock order (sorted) avoids deadlocks between concurrent ticks.
+    for (const postId of [...unique].sort()) {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtext(${"instagram_service_post:" + postId}))`,
+      );
+    }
+
+    // eslint-disable-next-line tenant-scope/no-unfiltered-tenant-query -- service_post lane scan: cron writes user_id=NULL across all tenants
+    const existing = await tx
+      .select({ postId: sql<string>`${adapterRefreshQueue.payload}->>'post_id'` })
+      .from(adapterRefreshQueue)
+      .where(
+        and(
+          eq(adapterRefreshQueue.adapterKind, ADAPTER_KIND),
+          eq(adapterRefreshQueue.queueName, QUEUE_NAME),
+          inArray(adapterRefreshQueue.status, ["pending", "processing"]),
+          sql`${adapterRefreshQueue.payload}->>'post_id' IN (${sql.join(
+            unique.map((id) => sql`${id}`),
+            sql`, `,
+          )})`,
+        ),
+      );
+    const existingIds = new Set(existing.map((row) => row.postId));
+
+    const rows = unique
+      .filter((postId) => !existingIds.has(postId))
+      .map((postId) => ({
+        adapterKind: ADAPTER_KIND,
+        queueName: QUEUE_NAME,
+        type: "post_stats",
+        payload: { post_id: postId },
+        userId: null,
+        priority: 10,
+        status: "pending" as const,
+      }));
+
+    if (rows.length === 0) return 0;
+    const inserted = await tx
+      .insert(adapterRefreshQueue)
+      .values(rows)
+      .returning({ id: adapterRefreshQueue.id });
+    return inserted.length;
+  });
+}

--- a/src/lib/sources/instagram/server/handlers/poll-cron.ts
+++ b/src/lib/sources/instagram/server/handlers/poll-cron.ts
@@ -33,6 +33,7 @@ import { logger } from "$lib/server/logger.js";
 import { QUEUES } from "$lib/server/queues.js";
 import { getSocialThrottleState } from "../quota.js";
 import { TIER_BOUNDARY_COLD_MS } from "$lib/server/services/tier-resolver.js";
+import { handleInstagramWarmRefresh } from "./warm-refresh.js";
 import type { MinimalBoss } from "$lib/sources/adapter.js";
 
 const PLATFORM = "instagram";
@@ -47,11 +48,20 @@ const INCREMENTAL_WINDOW_DAYS = 14;
 
 interface PollCronJob {
   id?: string;
-  data: { tier: "active" | "cold" } & Record<string, unknown>;
+  data: { tier: "active" | "cold" | "warm" } & Record<string, unknown>;
 }
 
 export async function handleInstagramPollCron(job: PollCronJob, boss: MinimalBoss): Promise<void> {
   const tier = job.data.tier;
+
+  // Warm per-post auto-refresh (#70) is a DIFFERENT operation from the account-
+  // level page-1 walk below (it enqueues service_post rows; it does not walk
+  // feeds). Branch BEFORE the account-picker SELECT so none of the active/cold
+  // machinery runs, and it carries its own throttle skip-gate.
+  if (tier === "warm") {
+    await handleInstagramWarmRefresh(job);
+    return;
+  }
 
   // Throttle skip-gate. The cron pool funds only non-essential background work.
   const throttle = await getSocialThrottleState(PLATFORM, PROVIDER);

--- a/src/lib/sources/instagram/server/handlers/refresh-queue-tick.ts
+++ b/src/lib/sources/instagram/server/handlers/refresh-queue-tick.ts
@@ -1,11 +1,18 @@
-// Instagram per-post stats refresh — SQL lane worker (#69 follow-on).
+// Instagram per-post stats refresh — SQL lane worker (#69 + #70 warm follow-on).
 //
-// Manual "Refresh now" enqueues ONE adapter_refresh_queue row per post
-// (enqueueRefreshNow, queue_name "user_post"). This worker claims up to N rows
-// per tick (N = env.SOCIAL_REFRESH_LANE_CONCURRENCY; batchScope "global" — across
-// users) and refreshes them CONCURRENTLY: Instagram's single-post endpoint can't
-// batch (1 request = 1 post), so scale comes from concurrency, not a multi-id
-// call like YouTube's videos.list.
+// Two slots over adapter_refresh_queue, mirroring YouTube's user_video/service_video:
+//   - "user_post"    — MANUAL "Refresh now" (enqueueRefreshNow). Payload
+//                      {event_id, post_id}, user_id SET. Resolved TENANT-SCOPED
+//                      (the user owns the event); fetch charges the USER pool.
+//   - "service_post" — CRON warm auto-refresh (warm-scheduler / #70). Payload
+//                      {post_id}, user_id NULL. PUBLIC-DATA, NO event lookup;
+//                      fetch charges the OPERATOR (cron) pool.
+//
+// This worker claims up to N rows of ONE slot per tick (N =
+// env.SOCIAL_REFRESH_LANE_CONCURRENCY; batchScope "global" — across users) and
+// refreshes them CONCURRENTLY: Instagram's single-post endpoint can't batch
+// (1 request = 1 post), so scale comes from concurrency, not a multi-id call like
+// YouTube's videos.list.
 //
 // Each post is independent, so dispatch uses Promise.allSettled and writes a
 // per-post snapshot (ok or non-ok via categoryToSnapshotStatus) and NEVER throws
@@ -37,7 +44,7 @@ import { getSocialProvider } from "../provider/registry.js";
 import { getSocialSpendToday } from "../quota.js";
 import { writeSnapshot } from "../snapshots.js";
 
-export const INSTAGRAM_REFRESH_SLOTS = ["user_post"] as const;
+export const INSTAGRAM_REFRESH_SLOTS = ["user_post", "service_post"] as const;
 export type InstagramRefreshQueueName = (typeof INSTAGRAM_REFRESH_SLOTS)[number];
 
 const MAX_ATTEMPTS = 5;
@@ -58,6 +65,15 @@ const instagramRefreshWorker = createAdapterBatchLaneWorker({
   staleRecoveryIntervalMs: STALE_RECOVERY_INTERVAL_MS,
   claimGate: claimInstagramThrottleSlot,
   dispatch: dispatchRefreshBatch,
+  // Observability (#70 P3-A): one INFO per drained tick, tagged by slot, so warm
+  // (service_post) credit spend is visible in Loki/Grafana SEPARATE from manual
+  // (user_post) spend — the lane is where credits are actually burned.
+  emitDrained: ({ queueName, entriesProcessed, durationMs }) => {
+    logger.info(
+      { queueName, entriesProcessed, durationMs },
+      "instagram refresh lane: tick drained",
+    );
+  },
 });
 
 export async function instagramRefreshQueueTick(): Promise<AdapterBatchLaneWorkerTickResult> {
@@ -73,6 +89,11 @@ export async function instagramRefreshQueueTick(): Promise<AdapterBatchLaneWorke
 //     row completes and the button settles (post shows unavailable).
 //   - Daily cap ≥ 95% (balance still funded) resets at midnight Pacific — DEFER;
 //     it recovers on its own (mirrors the YouTube/Reddit "wait for reset" defer).
+//
+// Two-pool coupling (#70 P2-B, accepted): getSocialSpendToday SUMS both pools, so
+// this coarse gate can defer a service_post tick on user-pool spend (or vice-versa).
+// That's fine — the real per-pool ceiling is the in-fetch origin-scoped reserve
+// (user_post→user pool, service_post→cron pool); this stays a cheap tick throttle.
 async function claimInstagramThrottleSlot(
   _ctx: AdapterLaneClaimGateContext<InstagramRefreshQueueName>,
 ): Promise<AdapterLaneClaimGateResult> {
@@ -93,19 +114,47 @@ async function claimInstagramThrottleSlot(
 
 // allSettled + per-row snapshot + NEVER throw → the lane worker marks every
 // claimed row `done` (independent posts; a per-row failure must not re-fetch the
-// successes).
+// successes via a batch-wide throw-to-retry).
 async function dispatchRefreshBatch(rows: AdapterLaneWorkerRow[]): Promise<void> {
   await Promise.allSettled(rows.map((row) => processOne(row)));
 }
 
-async function processOne(row: AdapterLaneWorkerRow): Promise<void> {
-  // Tenant-scope P0 (S1): a row without a userId can't be safely scoped — skip,
-  // mirroring youtube/refresh-queue-tick.ts. Refresh-now rows always carry one.
-  if (row.userId === null) return;
-  const eventId = row.payload?.event_id;
-  if (typeof eventId !== "string") return;
+interface ResolvedPost {
+  postId: string;
+  permalink: string;
+}
 
-  // Resolve the post's media id from the event, tenant-scoped.
+async function processOne(row: AdapterLaneWorkerRow): Promise<void> {
+  try {
+    const resolved =
+      row.queueName === "service_post"
+        ? await resolveServicePostRow(row)
+        : await resolveUserPostRow(row);
+    if (resolved === null) return; // skip reasons are logged inside the resolvers
+    // user_post → user pool (the clicking user pays); service_post → cron pool
+    // (operator-funded warm auto-refresh, like YouTube service_video).
+    const origin = row.queueName === "service_post" ? "cron" : "user";
+    await refreshPost(resolved.postId, resolved.permalink, origin);
+  } catch (err) {
+    // #70 P1: a failure must NEVER vanish silently into allSettled. A resolution
+    // failure (a DB select threw) has no postId yet → it can't write a snapshot,
+    // so LOG it here (the prior code let it disappear). refreshPost owns its own
+    // non-ok snapshot for fetch/write failures (it has the postId). The row still
+    // completes `done`; recovery is the warm predicate re-selecting the stale post
+    // next scheduler tick (auto path) or a manual re-click (user_post).
+    logger.warn(
+      { rowId: row.id, queueName: row.queueName, err: String((err as Error)?.message ?? err) },
+      "instagram refresh: row failed before snapshot — recovered by re-selection",
+    );
+  }
+}
+
+// MANUAL path: resolve the post media id from the event, TENANT-SCOPED. A row
+// without a userId can't be safely scoped (refresh-now rows always carry one).
+async function resolveUserPostRow(row: AdapterLaneWorkerRow): Promise<ResolvedPost | null> {
+  if (row.userId === null) return null;
+  const eventId = row.payload?.event_id;
+  if (typeof eventId !== "string") return null;
   const [event] = await db
     .select({ externalId: events.externalId })
     .from(events)
@@ -119,11 +168,22 @@ async function processOne(row: AdapterLaneWorkerRow): Promise<void> {
     )
     .limit(1);
   const postId = event?.externalId ?? null;
-  if (postId === null) return;
+  if (postId === null) return null;
+  return resolvePermalink(postId);
+}
 
-  // The single-post endpoint needs the shortcode permalink, which lives on the
-  // public-data instagram_posts row. No row / no permalink (e.g. a paste before
-  // the first account poll) → graceful skip; the next scheduled poll fills it (D4).
+// CRON warm path: the post media id is in the payload directly. PUBLIC-DATA — no
+// event lookup, no userId (mirrors youtube loadVideoWork's service_video branch).
+async function resolveServicePostRow(row: AdapterLaneWorkerRow): Promise<ResolvedPost | null> {
+  const postId = row.payload?.post_id;
+  if (typeof postId !== "string") return null;
+  return resolvePermalink(postId);
+}
+
+// The single-post endpoint needs the shortcode permalink, which lives on the
+// public-data instagram_posts row. No row / no permalink (e.g. a paste before the
+// first account poll) → graceful skip; the next scheduled poll fills it (D4).
+async function resolvePermalink(postId: string): Promise<ResolvedPost | null> {
   const [postRow] = await db
     .select({ permalink: instagramPosts.permalink })
     .from(instagramPosts)
@@ -131,16 +191,28 @@ async function processOne(row: AdapterLaneWorkerRow): Promise<void> {
     .limit(1);
   const permalink = postRow?.permalink ?? null;
   if (permalink === null) {
-    logger.info({ eventId, postId }, "instagram refresh: post not cached yet — skip");
-    return;
+    logger.info({ postId }, "instagram refresh: post not cached yet — skip");
+    return null;
   }
+  return { postId, permalink };
+}
 
+// Fetch one post + write its snapshot. Owns its own try/catch so a per-row failure
+// lands a VISIBLE non-ok snapshot (stamps last_polled_at — the manual button
+// settles; the warm predicate's poll_failure_count bound advances) and NEVER
+// throws (the lane marks the row done; no batch-wide retry that would re-fetch +
+// re-charge the successes). `origin` picks the credit pool (user vs cron).
+async function refreshPost(
+  postId: string,
+  permalink: string,
+  origin: "cron" | "user",
+): Promise<void> {
   const provider = getSocialProvider("instagram");
   if (provider === null) return; // unconfigured — isEnabled gates the lane; defensive.
 
   try {
-    // origin "user" → fetchPostByUrl reserves one prepaid credit internally.
-    const post = await provider.fetchPostByUrl("instagram", permalink, { origin: "user" });
+    // fetchPostByUrl reserves one prepaid credit internally from the `origin` pool.
+    const post = await provider.fetchPostByUrl("instagram", permalink, { origin });
     if (post === null) {
       // Deleted / private — the envelope carried no media object.
       await writeSnapshot({ postId, permalink, metrics: null, status: "not_found" });
@@ -162,17 +234,13 @@ async function processOne(row: AdapterLaneWorkerRow): Promise<void> {
       status: "ok",
     });
   } catch (err) {
-    // Per-row failure → write a non-ok snapshot so last_polled_at is stamped (the
-    // button stop-loop settles) and the failure is VISIBLE — never a silent drop
-    // (P2-A). The row is still marked done (no batch-wide retry that would
-    // re-fetch the successes); recovery is a re-click after cooldown or the next
-    // scheduled source poll. An AdapterError maps to its category; an unexpected
-    // throw (e.g. a programmer bug) degrades to "auth_error" and is logged.
+    // An AdapterError maps to its category; an unexpected throw (a programmer bug)
+    // degrades to "auth_error" and is logged.
     const status =
       err instanceof AdapterError ? categoryToSnapshotStatus(err.category) : "auth_error";
     if (!(err instanceof AdapterError)) {
       logger.warn(
-        { eventId, postId, err: String((err as Error)?.message ?? err) },
+        { postId, err: String((err as Error)?.message ?? err) },
         "instagram refresh: unexpected error",
       );
     }

--- a/src/lib/sources/instagram/server/handlers/refresh-queue-tick.ts
+++ b/src/lib/sources/instagram/server/handlers/refresh-queue-tick.ts
@@ -149,21 +149,28 @@ async function processOne(row: AdapterLaneWorkerRow): Promise<void> {
       status: "ok",
     });
   } catch (err) {
-    if (err instanceof AdapterError) {
-      // Per-row failure → non-ok snapshot (stamps last_polled_at so the button
-      // stop-loop settles); the row is still marked done (no batch-wide retry).
-      await writeSnapshot({
-        postId,
-        permalink,
-        metrics: null,
-        status: categoryToSnapshotStatus(err.category),
-      });
-      return;
+    // Per-row failure → write a non-ok snapshot so last_polled_at is stamped (the
+    // button stop-loop settles) and the failure is VISIBLE — never a silent drop
+    // (P2-A). The row is still marked done (no batch-wide retry that would
+    // re-fetch the successes); recovery is a re-click after cooldown or the next
+    // scheduled source poll. An AdapterError maps to its category; an unexpected
+    // throw (e.g. a programmer bug) degrades to "auth_error" and is logged.
+    const status =
+      err instanceof AdapterError ? categoryToSnapshotStatus(err.category) : "auth_error";
+    if (!(err instanceof AdapterError)) {
+      logger.warn(
+        { eventId, postId, err: String((err as Error)?.message ?? err) },
+        "instagram refresh: unexpected error",
+      );
     }
-    logger.warn(
-      { eventId, postId, err: String((err as Error)?.message ?? err) },
-      "instagram refresh: unexpected error",
-    );
+    // Best-effort: if the original failure WAS the snapshot write (DB down), this
+    // re-write also fails — swallow so the row still completes, don't re-throw.
+    await writeSnapshot({ postId, permalink, metrics: null, status }).catch((e) => {
+      logger.warn(
+        { postId, err: String((e as Error)?.message ?? e) },
+        "instagram refresh: snapshot write failed",
+      );
+    });
   }
 }
 

--- a/src/lib/sources/instagram/server/handlers/refresh-queue-tick.ts
+++ b/src/lib/sources/instagram/server/handlers/refresh-queue-tick.ts
@@ -1,0 +1,172 @@
+// Instagram per-post stats refresh — SQL lane worker (#69 follow-on).
+//
+// Manual "Refresh now" enqueues ONE adapter_refresh_queue row per post
+// (enqueueRefreshNow, queue_name "user_post"). This worker claims up to N rows
+// per tick (N = env.SOCIAL_REFRESH_LANE_CONCURRENCY; batchScope "global" — across
+// users) and refreshes them CONCURRENTLY: Instagram's single-post endpoint can't
+// batch (1 request = 1 post), so scale comes from concurrency, not a multi-id
+// call like YouTube's videos.list.
+//
+// Each post is independent, so dispatch uses Promise.allSettled and writes a
+// per-post snapshot (ok or non-ok via categoryToSnapshotStatus) and NEVER throws
+// — the lane worker then marks every claimed row `done` (no batch-wide retry that
+// would re-fetch the successes). A transient failure (429/network) lands a non-ok
+// snapshot — which still stamps instagram_posts.last_polled_at, so the
+// RefreshNowButton stop-loop settles — and is recovered by the user re-clicking
+// after cooldown or the next scheduled source poll.
+//
+// The credit reserve happens INSIDE provider.fetchPostByUrl (origin "user"), so
+// claimGate is a throttle gate ONLY (defer at 95%), never a second reserve —
+// avoiding a double-charge (plan D2).
+
+import { and, eq, isNull } from "drizzle-orm";
+import { events } from "$lib/server/db/schema/events.js";
+import { instagramPosts } from "$lib/server/db/schema/index.js";
+import { db } from "$lib/server/db/client.js";
+import {
+  createAdapterBatchLaneWorker,
+  type AdapterBatchLaneWorkerTickResult,
+  type AdapterLaneClaimGateContext,
+  type AdapterLaneClaimGateResult,
+  type AdapterLaneWorkerRow,
+} from "$lib/server/services/adapter-lane-worker.js";
+import { env } from "$lib/server/config/env.js";
+import { logger } from "$lib/server/logger.js";
+import { AdapterError, categoryToSnapshotStatus } from "$lib/sources/errors.js";
+import { getSocialProvider } from "../provider/registry.js";
+import { getSocialThrottleState } from "../quota.js";
+import { writeSnapshot } from "../snapshots.js";
+
+export const INSTAGRAM_REFRESH_SLOTS = ["user_post"] as const;
+export type InstagramRefreshQueueName = (typeof INSTAGRAM_REFRESH_SLOTS)[number];
+
+const MAX_ATTEMPTS = 5;
+const STALE_PROCESSING_MS = 5 * 60_000;
+const STALE_RECOVERY_INTERVAL_MS = 60_000;
+const THROTTLE_DEFER_MS = 5 * 60_000;
+
+const instagramRefreshWorker = createAdapterBatchLaneWorker({
+  adapterKind: "instagram_account",
+  slots: INSTAGRAM_REFRESH_SLOTS,
+  fallthrough: INSTAGRAM_REFRESH_SLOTS,
+  maxAttempts: MAX_ATTEMPTS,
+  // Concurrency knob (NOT a batch-in-one-request size): claim up to N rows and
+  // fetch them in parallel in dispatch.
+  maxBatchSize: env.SOCIAL_REFRESH_LANE_CONCURRENCY,
+  batchScope: "global",
+  staleProcessingMs: STALE_PROCESSING_MS,
+  staleRecoveryIntervalMs: STALE_RECOVERY_INTERVAL_MS,
+  claimGate: claimInstagramThrottleSlot,
+  dispatch: dispatchRefreshBatch,
+});
+
+export async function instagramRefreshQueueTick(): Promise<AdapterBatchLaneWorkerTickResult> {
+  return instagramRefreshWorker.tick();
+}
+
+// Throttle gate (D2): defer the tick when the operator budget pool is at 95% —
+// consistent with the IG adapter's refreshQueue.canRun. NOT a reserve (the single
+// reserve happens inside fetchPostByUrl), so no double-charge. Deferring (vs a
+// non-ok snapshot) keeps the rows pending so they refresh once the pool frees.
+async function claimInstagramThrottleSlot(
+  _ctx: AdapterLaneClaimGateContext<InstagramRefreshQueueName>,
+): Promise<AdapterLaneClaimGateResult> {
+  const throttle = await getSocialThrottleState("instagram", "scrapecreators");
+  if (throttle === "ninetyfive") {
+    return { action: "defer", retryAfterMs: THROTTLE_DEFER_MS, reason: "instagram budget at 95%" };
+  }
+  return { action: "run" };
+}
+
+// allSettled + per-row snapshot + NEVER throw → the lane worker marks every
+// claimed row `done` (independent posts; a per-row failure must not re-fetch the
+// successes).
+async function dispatchRefreshBatch(rows: AdapterLaneWorkerRow[]): Promise<void> {
+  await Promise.allSettled(rows.map((row) => processOne(row)));
+}
+
+async function processOne(row: AdapterLaneWorkerRow): Promise<void> {
+  // Tenant-scope P0 (S1): a row without a userId can't be safely scoped — skip,
+  // mirroring youtube/refresh-queue-tick.ts. Refresh-now rows always carry one.
+  if (row.userId === null) return;
+  const eventId = row.payload?.event_id;
+  if (typeof eventId !== "string") return;
+
+  // Resolve the post's media id from the event, tenant-scoped.
+  const [event] = await db
+    .select({ externalId: events.externalId })
+    .from(events)
+    .where(
+      and(
+        eq(events.id, eventId),
+        eq(events.userId, row.userId),
+        eq(events.kind, "instagram_post"),
+        isNull(events.deletedAt),
+      ),
+    )
+    .limit(1);
+  const postId = event?.externalId ?? null;
+  if (postId === null) return;
+
+  // The single-post endpoint needs the shortcode permalink, which lives on the
+  // public-data instagram_posts row. No row / no permalink (e.g. a paste before
+  // the first account poll) → graceful skip; the next scheduled poll fills it (D4).
+  const [postRow] = await db
+    .select({ permalink: instagramPosts.permalink })
+    .from(instagramPosts)
+    .where(eq(instagramPosts.postId, postId))
+    .limit(1);
+  const permalink = postRow?.permalink ?? null;
+  if (permalink === null) {
+    logger.info({ eventId, postId }, "instagram refresh: post not cached yet — skip");
+    return;
+  }
+
+  const provider = getSocialProvider("instagram");
+  if (provider === null) return; // unconfigured — isEnabled gates the lane; defensive.
+
+  try {
+    // origin "user" → fetchPostByUrl reserves one prepaid credit internally.
+    const post = await provider.fetchPostByUrl("instagram", permalink, { origin: "user" });
+    if (post === null) {
+      // Deleted / private — the envelope carried no media object.
+      await writeSnapshot({ postId, permalink, metrics: null, status: "not_found" });
+      return;
+    }
+    await writeSnapshot({
+      postId,
+      accountId: post.ownerId,
+      mediaType: post.kind,
+      caption: post.caption,
+      permalink,
+      thumbnailUrl: post.thumbnailUrl,
+      publishedAt: post.publishedAt,
+      metrics: {
+        views: post.metrics.views,
+        likes: post.metrics.likes,
+        comments: post.metrics.comments,
+      },
+      status: "ok",
+    });
+  } catch (err) {
+    if (err instanceof AdapterError) {
+      // Per-row failure → non-ok snapshot (stamps last_polled_at so the button
+      // stop-loop settles); the row is still marked done (no batch-wide retry).
+      await writeSnapshot({
+        postId,
+        permalink,
+        metrics: null,
+        status: categoryToSnapshotStatus(err.category),
+      });
+      return;
+    }
+    logger.warn(
+      { eventId, postId, err: String((err as Error)?.message ?? err) },
+      "instagram refresh: unexpected error",
+    );
+  }
+}
+
+export function __resetInstagramRefreshQueueWorkerForTest(): void {
+  instagramRefreshWorker.resetForTest();
+}

--- a/src/lib/sources/instagram/server/handlers/refresh-queue-tick.ts
+++ b/src/lib/sources/instagram/server/handlers/refresh-queue-tick.ts
@@ -34,7 +34,7 @@ import { env } from "$lib/server/config/env.js";
 import { logger } from "$lib/server/logger.js";
 import { AdapterError, categoryToSnapshotStatus } from "$lib/sources/errors.js";
 import { getSocialProvider } from "../provider/registry.js";
-import { getSocialThrottleState } from "../quota.js";
+import { getSocialSpendToday } from "../quota.js";
 import { writeSnapshot } from "../snapshots.js";
 
 export const INSTAGRAM_REFRESH_SLOTS = ["user_post"] as const;
@@ -64,16 +64,29 @@ export async function instagramRefreshQueueTick(): Promise<AdapterBatchLaneWorke
   return instagramRefreshWorker.tick();
 }
 
-// Throttle gate (D2): defer the tick when the operator budget pool is at 95% —
-// consistent with the IG adapter's refreshQueue.canRun. NOT a reserve (the single
-// reserve happens inside fetchPostByUrl), so no double-charge. Deferring (vs a
-// non-ok snapshot) keeps the rows pending so they refresh once the pool frees.
+// Throttle gate (D2): NOT a reserve (the single reserve happens inside
+// fetchPostByUrl), so no double-charge. It distinguishes the two "exhausted"
+// states that getSocialThrottleState would both report as "ninetyfive" (#69 P1-B):
+//   - Prepaid balance ≤ 0 is the MONOTONIC hard ceiling — it never resets, so a
+//     defer would loop forever and the RefreshNowButton would spin indefinitely.
+//     RUN instead: dispatch's in-fetch reserve fails → a non-ok snapshot → the
+//     row completes and the button settles (post shows unavailable).
+//   - Daily cap ≥ 95% (balance still funded) resets at midnight Pacific — DEFER;
+//     it recovers on its own (mirrors the YouTube/Reddit "wait for reset" defer).
 async function claimInstagramThrottleSlot(
   _ctx: AdapterLaneClaimGateContext<InstagramRefreshQueueName>,
 ): Promise<AdapterLaneClaimGateResult> {
-  const throttle = await getSocialThrottleState("instagram", "scrapecreators");
-  if (throttle === "ninetyfive") {
-    return { action: "defer", retryAfterMs: THROTTLE_DEFER_MS, reason: "instagram budget at 95%" };
+  const { creditsUsed, dailyCap, prepaidBalance } = await getSocialSpendToday(
+    "instagram",
+    "scrapecreators",
+  );
+  if (prepaidBalance <= 0) return { action: "run" };
+  if (dailyCap > 0 && creditsUsed >= Math.floor(dailyCap * 0.95)) {
+    return {
+      action: "defer",
+      retryAfterMs: THROTTLE_DEFER_MS,
+      reason: "instagram daily cap at 95%",
+    };
   }
   return { action: "run" };
 }

--- a/src/lib/sources/instagram/server/handlers/warm-refresh.ts
+++ b/src/lib/sources/instagram/server/handlers/warm-refresh.ts
@@ -9,7 +9,7 @@
 // walk, so handleInstagramPollCron branches here BEFORE its account-picker runs.
 //
 // Throttle skip-gate: warm is NON-ESSENTIAL background spend (like the cold tier)
-// — skip at >= "eighty". The hourly cadence + 22h staleness gate + skip-if-pending
+// — skip at >= "eighty". The hourly cadence + the >24h staleness gate + skip-if-pending
 // dedup mean a post gets at most ~1 paid refresh/day.
 
 import { logger } from "$lib/server/logger.js";

--- a/src/lib/sources/instagram/server/handlers/warm-refresh.ts
+++ b/src/lib/sources/instagram/server/handlers/warm-refresh.ts
@@ -14,6 +14,7 @@
 
 import { logger } from "$lib/server/logger.js";
 import { getSocialThrottleState } from "../quota.js";
+import { getSocialProvider } from "../provider/registry.js";
 import { selectWarmInstagramPostIds } from "../warm-eligibility.js";
 import { enqueueServiceInstagramPostStats } from "./enqueue-service-post-stats.js";
 
@@ -21,6 +22,17 @@ const PLATFORM = "instagram";
 const PROVIDER = "scrapecreators";
 
 export async function handleInstagramWarmRefresh(job: { id?: string }): Promise<void> {
+  // Don't enqueue work the lane can't run: the refresh lane worker is disabled
+  // (isEnabled) when the provider is unconfigured, so service_post rows would
+  // orphan as pending forever (#70 ultrareview P1). Mirror the manual canRun gate.
+  if (getSocialProvider("instagram") === null) {
+    logger.debug(
+      { jobId: job.id },
+      "instagram.poll.cron tier=warm: provider unconfigured — skip (lane disabled)",
+    );
+    return;
+  }
+
   const throttle = await getSocialThrottleState(PLATFORM, PROVIDER);
   if (throttle === "ninetyfive" || throttle === "eighty") {
     logger.info(

--- a/src/lib/sources/instagram/server/handlers/warm-refresh.ts
+++ b/src/lib/sources/instagram/server/handlers/warm-refresh.ts
@@ -1,0 +1,44 @@
+// instagram.poll.cron tier=warm — per-post auto-refresh producer (#70).
+//
+// Fires hourly ({tier:"warm"}). Selects warm posts (warm-eligibility) and enqueues
+// ONE dedup'd service_post row per post; the IG lane worker owns the upstream
+// fetch + writeSnapshot + cron-pool accounting. Mirrors youtube poll-active →
+// selectEligibleVideoIds → enqueueServiceVideoStats.
+//
+// Thin by design: a DIFFERENT operation from the active/cold account-level page-1
+// walk, so handleInstagramPollCron branches here BEFORE its account-picker runs.
+//
+// Throttle skip-gate: warm is NON-ESSENTIAL background spend (like the cold tier)
+// — skip at >= "eighty". The hourly cadence + 22h staleness gate + skip-if-pending
+// dedup mean a post gets at most ~1 paid refresh/day.
+
+import { logger } from "$lib/server/logger.js";
+import { getSocialThrottleState } from "../quota.js";
+import { selectWarmInstagramPostIds } from "../warm-eligibility.js";
+import { enqueueServiceInstagramPostStats } from "./enqueue-service-post-stats.js";
+
+const PLATFORM = "instagram";
+const PROVIDER = "scrapecreators";
+
+export async function handleInstagramWarmRefresh(job: { id?: string }): Promise<void> {
+  const throttle = await getSocialThrottleState(PLATFORM, PROVIDER);
+  if (throttle === "ninetyfive" || throttle === "eighty") {
+    logger.info(
+      { jobId: job.id, throttle },
+      "instagram.poll.cron tier=warm: budget throttled — skipping non-essential warm refresh",
+    );
+    return;
+  }
+
+  const postIds = await selectWarmInstagramPostIds(new Date());
+  if (postIds.length === 0) {
+    logger.debug({ jobId: job.id }, "instagram.poll.cron tier=warm: no warm posts due");
+    return;
+  }
+
+  const enqueued = await enqueueServiceInstagramPostStats(postIds);
+  logger.info(
+    { jobId: job.id, selected: postIds.length, enqueued },
+    "instagram.poll.cron tier=warm: service_post rows enqueued",
+  );
+}

--- a/src/lib/sources/instagram/server/index.ts
+++ b/src/lib/sources/instagram/server/index.ts
@@ -141,9 +141,10 @@ async function scheduleCronTicks(boss: MinimalBoss): Promise<void> {
     { tier: "cold" },
     { key: "cold", tz: "America/Los_Angeles" },
   );
-  // Warm per-post auto-refresh (#70) — hourly. The 22h staleness gate means a post
-  // gets at most ~1 paid refresh/day; hourly just picks it up promptly after it
-  // crosses the gate (skip-if-pending dedup prevents pile-up).
+  // Warm per-post auto-refresh (#70) — hourly. The staleness gate (>24h, just over
+  // the daily free-poll interval) means a post gets at most ~1 paid refresh/day;
+  // hourly just picks it up promptly after it crosses the gate (skip-if-pending
+  // dedup prevents pile-up).
   await boss.schedule(QUEUES.INSTAGRAM_POLL_CRON, "0 * * * *", { tier: "warm" }, { key: "warm" });
   // Daily-cap reset — midnight Pacific (the social-provider daily-cap boundary;
   // the prepaid balance is never touched).

--- a/src/lib/sources/instagram/server/index.ts
+++ b/src/lib/sources/instagram/server/index.ts
@@ -585,11 +585,20 @@ async function resolveCachedExternalId(url: string): Promise<string | null> {
   const permalink = parsed?.metadata?.permalink;
   if (typeof permalink !== "string") return null;
   const { instagramPosts } = await import("$lib/server/db/schema/index.js");
-  const { eq } = await import("drizzle-orm");
+  const { eq, desc } = await import("drizzle-orm");
+  // permalink is not unique-constrained (PK is post_id). A single physical post
+  // can transiently land TWO rows with the same permalink — the bare `<pk>` form
+  // (single-post fetch, owner unknown) vs the canonical `<pk>_<owner>` form (feed)
+  // — so `LIMIT 1` alone could bind to an arbitrary id. Since this lookup is a
+  // trust boundary (#70 ultrareview P2), make it DETERMINISTIC: prefer the
+  // most-recently-updated row (the freshest write — normally the canonical
+  // `<pk>_<owner>` form the preview/walk produce). A permalink UNIQUE index is the
+  // heavier alternative but would fail the migration on any pre-existing dup.
   const [row] = await db
     .select({ postId: instagramPosts.postId })
     .from(instagramPosts)
     .where(eq(instagramPosts.permalink, permalink))
+    .orderBy(desc(instagramPosts.updatedAt))
     .limit(1);
   return row?.postId ?? null;
 }
@@ -626,6 +635,15 @@ export const instagramAdapter: SourceAdapter & typeof instagramAccountAdapterCor
   refreshQueue: {
     canRefresh: (eventKind: EventKind): boolean => eventKind === "instagram_post",
     canRun: async () => {
+      // Block when the provider is unconfigured: the lane worker's isEnabled gates
+      // OFF when getSocialProvider is null, so an enqueued row would NEVER run — an
+      // orphan pending row + a forever-spinning Refresh button (#70 ultrareview P1).
+      // A funded budget with an unconstructable provider (e.g. INSTAGRAM_PROVIDER
+      // set but the key missing) is exactly that misconfig — getSocialThrottleState
+      // reads the budget, not provider-constructability, so it can't catch this.
+      if (getSocialProvider("instagram") === null) {
+        return { action: "skip", reason: "instagram not configured" };
+      }
       const throttle = await getSocialThrottleState("instagram", "scrapecreators");
       return throttle === "ninetyfive"
         ? { action: "skip", reason: "instagram budget at 95%" }

--- a/src/lib/sources/instagram/server/index.ts
+++ b/src/lib/sources/instagram/server/index.ts
@@ -106,7 +106,10 @@ async function registerQueues(boss: MinimalBoss): Promise<void> {
   await boss.work(QUEUES.INSTAGRAM_POLL_CRON, { batchSize: 2 }, async (jobs) => {
     for (const job of jobs) {
       await handleInstagramPollCron(
-        job as { id?: string; data: { tier: "active" | "cold" } & Record<string, unknown> },
+        job as {
+          id?: string;
+          data: { tier: "active" | "cold" | "warm" } & Record<string, unknown>;
+        },
         boss,
       );
     }
@@ -120,10 +123,14 @@ async function registerQueues(boss: MinimalBoss): Promise<void> {
 }
 
 async function scheduleCronTicks(boss: MinimalBoss): Promise<void> {
-  // Active tier — every 6 hours UTC (matches YouTube's active cadence).
+  // Active tier — daily 06:00 UTC (#70). The account page-1 walk amortizes one
+  // feed credit across the newest ~12 posts; daily (was every 6h) cuts the
+  // dominant recurring spend ~4× and matches the daily wishlist-correlation
+  // cadence. Individual posts that roll off page-1 are topped up by the warm
+  // per-post lane below (1×/day while < INSTAGRAM_WARM_WINDOW_DAYS old).
   await boss.schedule(
     QUEUES.INSTAGRAM_POLL_CRON,
-    "0 */6 * * *",
+    "0 6 * * *",
     { tier: "active" },
     { key: "active" },
   );
@@ -134,6 +141,10 @@ async function scheduleCronTicks(boss: MinimalBoss): Promise<void> {
     { tier: "cold" },
     { key: "cold", tz: "America/Los_Angeles" },
   );
+  // Warm per-post auto-refresh (#70) — hourly. The 22h staleness gate means a post
+  // gets at most ~1 paid refresh/day; hourly just picks it up promptly after it
+  // crosses the gate (skip-if-pending dedup prevents pile-up).
+  await boss.schedule(QUEUES.INSTAGRAM_POLL_CRON, "0 * * * *", { tier: "warm" }, { key: "warm" });
   // Daily-cap reset — midnight Pacific (the social-provider daily-cap boundary;
   // the prepaid balance is never touched).
   await boss.schedule(QUEUES.INSTAGRAM_QUOTA_RESET, "0 0 * * *", {}, { tz: "America/Los_Angeles" });
@@ -558,6 +569,32 @@ function buildPreviewTitle(caption: string | null, mediaType: string, publishedA
 }
 
 /**
+ * resolveCachedExternalId — re-derive an instagram_post event's media id from
+ * OUR cache, given the (canonical or raw) event URL. The single-post PREVIEW
+ * (fetchEventPreviewMetadata) UPSERTed instagram_posts with
+ * permalink = the canonical `/p/`|`/reel/` URL and post_id = the media id, so the
+ * create boundary looks the media id up by permalink instead of trusting the
+ * request body (#70 review P1 — a client could pair post A's URL with post B's
+ * media id; the body is untrusted). instagramParseUrl canonicalizes the URL the
+ * SAME way the preview did (`/reels/`→`/reel/`), so the permalink match is exact.
+ * null when no cache row exists (create without a prior preview) → an honest
+ * stats-less card, identical to the recognition-only paste path.
+ */
+async function resolveCachedExternalId(url: string): Promise<string | null> {
+  const parsed = instagramParseUrl(url);
+  const permalink = parsed?.metadata?.permalink;
+  if (typeof permalink !== "string") return null;
+  const { instagramPosts } = await import("$lib/server/db/schema/index.js");
+  const { eq } = await import("drizzle-orm");
+  const [row] = await db
+    .select({ postId: instagramPosts.postId })
+    .from(instagramPosts)
+    .where(eq(instagramPosts.permalink, permalink))
+    .limit(1);
+  return row?.postId ?? null;
+}
+
+/**
  * registerRoutes — mounts the per-source HTTP routes on the shared Hono app
  * (createApp iterates allAdapters; mirrors youtube/reddit). Instagram mounts the
  * same-origin thumbnail proxy: IG's CDN sends Cross-Origin-Resource-Policy:
@@ -584,6 +621,7 @@ export const instagramAdapter: SourceAdapter & typeof instagramAccountAdapterCor
   onSourceCreated,
   resetWalkerStateOnWidening,
   fetchEventPreviewMetadata,
+  resolveCachedExternalId,
   registerRoutes,
   refreshQueue: {
     canRefresh: (eventKind: EventKind): boolean => eventKind === "instagram_post",

--- a/src/lib/sources/instagram/server/index.ts
+++ b/src/lib/sources/instagram/server/index.ts
@@ -22,6 +22,7 @@ import type {
   BackfillWindow,
   CanonicalizeInput,
   CanonicalizeResult,
+  AdapterAppContext,
   CreateContext,
   EventKind,
   EventPreviewMetadata,
@@ -30,6 +31,7 @@ import type {
   SourceAdapter,
   SourceCreatedHookSource,
 } from "$lib/sources/adapter.js";
+import type { Hono } from "hono";
 import type { DbOrTx, Tx } from "$lib/server/db/client.js";
 import { QUEUES } from "$lib/server/queues.js";
 import { getBoss } from "$lib/server/queue-client.js";
@@ -47,6 +49,7 @@ import { resetInstagramBackfillState } from "./backfill-state.js";
 import { getSocialThrottleState } from "./quota.js";
 import { getSocialProvider } from "./provider/registry.js";
 import { writeSnapshot } from "./snapshots.js";
+import { instagramThumbnailRoutes } from "./thumbnail-proxy.js";
 import { handleBackfillAccount } from "./handlers/backfill-account.js";
 import { handleInstagramPollCron } from "./handlers/poll-cron.js";
 import { handleInstagramQuotaReset } from "./handlers/quota-reset.js";
@@ -557,6 +560,17 @@ function buildPreviewTitle(caption: string | null, mediaType: string, publishedA
   return `Instagram ${mediaType} · ${publishedAt.toISOString().slice(0, 10)}`;
 }
 
+/**
+ * registerRoutes — mounts the per-source HTTP routes on the shared Hono app
+ * (createApp iterates allAdapters; mirrors youtube/reddit). Instagram mounts the
+ * same-origin thumbnail proxy: IG's CDN sends Cross-Origin-Resource-Policy:
+ * same-origin, so a raw <img> hotlink is blocked browser-side — the proxy
+ * re-serves the bytes from our origin (#69).
+ */
+function registerRoutes(app: Hono<AdapterAppContext>): void {
+  app.route("/api", instagramThumbnailRoutes);
+}
+
 // instagramAdapter — composes the polling core (./adapter.ts) with the
 // infrastructure-touching methods (registerQueues / scheduleCronTicks /
 // backfillSource) and the create-time hooks (canonicalizeOnCreate /
@@ -573,6 +587,7 @@ export const instagramAdapter: SourceAdapter & typeof instagramAccountAdapterCor
   onSourceCreated,
   resetWalkerStateOnWidening,
   fetchEventPreviewMetadata,
+  registerRoutes,
   refreshQueue: {
     canRefresh: (eventKind: EventKind): boolean => eventKind === "instagram_post",
     canRun: async () => {

--- a/src/lib/sources/instagram/server/index.ts
+++ b/src/lib/sources/instagram/server/index.ts
@@ -42,7 +42,6 @@ import { getUserQuotaUsedToday, nextPacificMidnight } from "$lib/server/services
 import { AppError } from "$lib/server/services/errors.js";
 import { AdapterError } from "$lib/sources/errors.js";
 import { writeAudit } from "$lib/server/audit.js";
-import { logger } from "$lib/server/logger.js";
 import { instagramAccountAdapterCore } from "./adapter.js";
 import { instagramParseUrl, instagramParseSourceUrl } from "./url.js";
 import { resetInstagramBackfillState } from "./backfill-state.js";
@@ -50,9 +49,15 @@ import { getSocialThrottleState } from "./quota.js";
 import { getSocialProvider } from "./provider/registry.js";
 import { writeSnapshot } from "./snapshots.js";
 import { instagramThumbnailRoutes } from "./thumbnail-proxy.js";
+import { adapterRefreshQueue } from "$lib/server/db/schema/index.js";
+import { adapterRefreshQueueLabel } from "$lib/server/services/adapter-lane-worker.js";
 import { handleBackfillAccount } from "./handlers/backfill-account.js";
 import { handleInstagramPollCron } from "./handlers/poll-cron.js";
 import { handleInstagramQuotaReset } from "./handlers/quota-reset.js";
+import {
+  instagramRefreshQueueTick,
+  INSTAGRAM_REFRESH_SLOTS,
+} from "./handlers/refresh-queue-tick.js";
 
 const KIND = "instagram_account" as const;
 const EPOCH_ISO = "1970-01-01T00:00:00Z";
@@ -361,10 +366,17 @@ async function resetWalkerStateOnWidening(
 }
 
 /**
- * enqueueRefreshNow — the per-event Refresh-Now path. An IG post's fresh metrics
- * come from an account-level page-1 incremental walk (the walker re-polls every
- * post on the page via writeSnapshot). triggerUserId set → the user pays the
- * per-user cap.
+ * enqueueRefreshNow — the per-event Refresh-Now path. PER-POST (#69): inserts ONE
+ * row into the shared adapter_refresh_queue (queue_name "user_post"); the IG lane
+ * worker (handlers/refresh-queue-tick.ts) fetches exactly that post via the
+ * single-post endpoint + writeSnapshot. This replaces the old account-level walk
+ * (which re-snapshotted every page-1 neighbour and couldn't reach old posts).
+ *
+ * INSERT via the passed `tx` (requestRefreshPoll calls this inside its tx) — no
+ * boss.send outside the mutating transaction. No skip-if-pending dedup (D1): the
+ * 5-min cooldown in requestRefreshPoll is the dedup; a conscious Refresh always
+ * fetches fresh (mirrors Reddit's deliberate choice). The per-user cap is already
+ * enforced by requestRefreshPoll before this runs.
  */
 async function enqueueRefreshNow(input: {
   eventId: string;
@@ -373,38 +385,23 @@ async function enqueueRefreshNow(input: {
   eventKind: EventKind;
   tx?: DbOrTx;
 }): Promise<{ queue: string; jobId: string | null }> {
-  // Resolve the post's account_id from the public-data cache so the walk targets
-  // the right account. The post may not be cached yet (paste before first poll);
-  // in that case the refresh is a no-op (the next cron tick picks it up).
-  const { instagramPosts } = await import("$lib/server/db/schema/index.js");
-  const { eq } = await import("drizzle-orm");
   const dbCtx = input.tx ?? db;
-  const [row] = await dbCtx
-    .select({ account: instagramPosts.accountId })
-    .from(instagramPosts)
-    .where(eq(instagramPosts.postId, input.externalId))
-    .limit(1);
-  const channelKey = row?.account ?? null;
-  if (channelKey === null) {
-    logger.info(
-      { eventId: input.eventId, externalId: input.externalId },
-      "instagram.enqueueRefreshNow: post not cached yet — refresh deferred to next cron tick",
-    );
-    return { queue: QUEUES.INSTAGRAM_BACKFILL_ACCOUNT, jobId: null };
-  }
-  const boss = await getBoss();
-  const jobId = await boss.send(
-    QUEUES.INSTAGRAM_BACKFILL_ACCOUNT,
-    {
-      kind: KIND,
-      channelKey,
-      triggerUserId: input.userId,
-      depthBoundIso: EPOCH_ISO,
-      flow: "incremental",
-    },
-    { singletonKey: `refresh-now-${channelKey}-${input.userId}`, priority: 1 },
-  );
-  return { queue: QUEUES.INSTAGRAM_BACKFILL_ACCOUNT, jobId };
+  const [inserted] = await dbCtx
+    .insert(adapterRefreshQueue)
+    .values({
+      adapterKind: KIND,
+      queueName: "user_post",
+      type: "post_stats",
+      payload: { event_id: input.eventId, post_id: input.externalId },
+      userId: input.userId,
+      priority: -10,
+      status: "pending",
+    })
+    .returning({ id: adapterRefreshQueue.id });
+  return {
+    queue: adapterRefreshQueueLabel(KIND, "user_post"),
+    jobId: inserted ? String(inserted.id) : null,
+  };
 }
 
 /**
@@ -597,5 +594,28 @@ export const instagramAdapter: SourceAdapter & typeof instagramAccountAdapterCor
         : { action: "run" };
     },
     enqueue: enqueueRefreshNow,
+  },
+  // Per-post Refresh lane (#69). The generic worker bootstrap auto-starts each
+  // declared scheduledWorker; isEnabled gates it off when the provider is
+  // unconfigured (self-host without IG) so the lane never ticks/throws.
+  workQueue: {
+    scheduledWorkers: [
+      {
+        name: "instagram.refresh",
+        intervalMs: 1000,
+        replicaPolicy: "parallel",
+        readyMessage: "instagram refresh queue worker ready",
+        disabledMessage: "instagram refresh queue worker disabled (provider unconfigured)",
+        laneQueue: {
+          strategy: "fixed-slot-round-robin",
+          adapterKind: KIND,
+          slots: INSTAGRAM_REFRESH_SLOTS,
+          fallthrough: INSTAGRAM_REFRESH_SLOTS,
+          batchScope: "global",
+        },
+        isEnabled: () => getSocialProvider("instagram") !== null,
+        tick: instagramRefreshQueueTick,
+      },
+    ],
   },
 };

--- a/src/lib/sources/instagram/server/normalize.ts
+++ b/src/lib/sources/instagram/server/normalize.ts
@@ -288,6 +288,12 @@ export function mapSinglePostToNormalized(
     // it is a divergent, never-refreshed orphan: different stats and an expiring
     // (never re-fetched) thumbnail. #69 follow-up. Skip if owner is absent or
     // the id already carries the suffix.
+    //
+    // ASSUMPTION: media.owner.id == the `<owner_id>` the feed/reels endpoints use.
+    // True for own-account tracking (the diary use case). For a reshare/collab the
+    // single-post owner could differ → the paste would key on a different id than
+    // the source import (the orphan we guard against). Acceptable risk for the use
+    // case; revisit (key on `<pk>` everywhere) if cross-account posts become common.
     id: ownerId !== null && !media.id.includes("_") ? `${media.id}_${ownerId}` : media.id,
     shortcode: media.shortcode ?? null,
     kind: typenameToKind(media.__typename, isReelUrl),

--- a/src/lib/sources/instagram/server/normalize.ts
+++ b/src/lib/sources/instagram/server/normalize.ts
@@ -279,8 +279,16 @@ export function mapSinglePostToNormalized(
   isReelUrl: boolean,
 ): NormalizedSinglePost {
   const caption = media.edge_media_to_caption?.edges?.[0]?.node?.text ?? null;
+  const ownerId = media.owner?.id ?? null;
   return {
-    id: media.id,
+    // The feed/reels endpoints key a post as `<media_pk>_<owner_id>`, but the
+    // single-post GraphQL endpoint returns the bare `<media_pk>` here. Build the
+    // suffixed form so a PASTED post shares its instagram_posts cache row +
+    // snapshots + polling with the SAME post imported from a source — otherwise
+    // it is a divergent, never-refreshed orphan: different stats and an expiring
+    // (never re-fetched) thumbnail. #69 follow-up. Skip if owner is absent or
+    // the id already carries the suffix.
+    id: ownerId !== null && !media.id.includes("_") ? `${media.id}_${ownerId}` : media.id,
     shortcode: media.shortcode ?? null,
     kind: typenameToKind(media.__typename, isReelUrl),
     publishedAt: new Date(media.taken_at_timestamp * 1000), // unix SECONDS
@@ -291,7 +299,7 @@ export function mapSinglePostToNormalized(
     },
     caption,
     thumbnailUrl: media.thumbnail_src ?? null,
-    ownerId: media.owner?.id ?? null,
+    ownerId,
     ownerUsername: media.owner?.username ?? null,
   };
 }

--- a/src/lib/sources/instagram/server/snapshots.ts
+++ b/src/lib/sources/instagram/server/snapshots.ts
@@ -73,14 +73,16 @@ export async function writeSnapshot(args: WriteSnapshotArgs): Promise<void> {
         target: instagramPosts.postId,
         set: {
           // Refresh snippet fields. COALESCE keeps a prior non-null value when
-          // the caller passes null (e.g. a metrics-only re-poll that did not
-          // re-resolve the account id), but ALWAYS refreshes thumbnail_url —
-          // the expiring CDN URL must reflect the latest poll.
+          // the caller passes null. An OK poll always carries a fresh
+          // thumbnail_url (so COALESCE refreshes the expiring CDN URL, D-08); a
+          // NON-OK poll (a failed/deleted refresh) carries none → COALESCE
+          // PRESERVES the last good URL instead of blanking the cover (#69 P1-A —
+          // a transient Refresh failure must not erase a working thumbnail).
           accountId: sql`COALESCE(${args.accountId ?? null}, ${instagramPosts.accountId})`,
           mediaType: sql`COALESCE(${args.mediaType ?? null}, ${instagramPosts.mediaType})`,
           caption: args.caption ?? null,
           permalink: sql`COALESCE(${args.permalink ?? null}, ${instagramPosts.permalink})`,
-          thumbnailUrl: args.thumbnailUrl ?? null,
+          thumbnailUrl: sql`COALESCE(${args.thumbnailUrl ?? null}, ${instagramPosts.thumbnailUrl})`,
           publishedAt: sql`COALESCE(${args.publishedAt ?? null}, ${instagramPosts.publishedAt})`,
           lastPolledAt: now,
           lastPollStatus: args.status,

--- a/src/lib/sources/instagram/server/thumbnail-proxy.ts
+++ b/src/lib/sources/instagram/server/thumbnail-proxy.ts
@@ -1,0 +1,91 @@
+// GET /api/instagram/thumbnail/:postId — same-origin proxy for Instagram CDN
+// thumbnails (#69 follow-up).
+//
+// Instagram's cdninstagram.com serves post thumbnails with
+// `Cross-Origin-Resource-Policy: same-origin` — an anti-hotlink header that makes
+// the browser BLOCK a cross-origin <img> (ERR_BLOCKED_BY_RESPONSE.NotSameOrigin),
+// so the raw CDN URL cannot be displayed directly from our origin (unlike the
+// YouTube/Reddit/Google CDNs, which send CORP `cross-origin`). The SERVER can
+// fetch the URL (CORP is a browser-side embedding rule, not enforced on a direct
+// fetch), so we re-serve the bytes from our OWN origin, where CORP no longer
+// applies because the image is now same-origin as the page.
+//
+// Security:
+//   - Auth: the tenantScope chain gates all of /api/* (anonymous → 401); only a
+//     signed-in user's same-origin <img> (which carries the session cookie)
+//     reaches here.
+//   - NOT an open proxy: the URL is NEVER taken from the request. We look up the
+//     post's stored thumbnail_url by post_id and host-validate it against the
+//     Instagram/Facebook CDN before fetching, so we only ever proxy URLs we
+//     ourselves persisted from the provider (no SSRF).
+//
+// instagram_posts is PUBLIC-DATA (post-keyed, no user_id) — the tenant guarantee
+// is the auth gate, not row ownership; the thumbnail is public IG content shared
+// across every tenant referencing the post (mirrors feed-enrichment).
+
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+import { db } from "$lib/server/db/client.js";
+import { instagramPosts } from "$lib/server/db/schema/index.js";
+import { logger } from "$lib/server/logger.js";
+
+// The only hosts the provider ever returns for instagram_posts.thumbnail_url.
+// Suffix-matched against the stored URL's host — defence-in-depth so a future
+// provider change can never turn this into a general-purpose fetch.
+const ALLOWED_HOST_SUFFIXES = [".cdninstagram.com", ".fbcdn.net"];
+
+/**
+ * Resolve a post's stored thumbnail URL, host-validated. Returns null when the
+ * post is unknown, has no thumbnail, or the stored host is not an Instagram /
+ * Facebook CDN. instagram_posts is public-data (allowlisted, no user_id scope).
+ */
+export async function resolveInstagramThumbnailUrl(postId: string): Promise<string | null> {
+  const [row] = await db
+    .select({ url: instagramPosts.thumbnailUrl })
+    .from(instagramPosts)
+    .where(eq(instagramPosts.postId, postId))
+    .limit(1);
+  const url = row?.url ?? null;
+  if (url === null) return null;
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+  return ALLOWED_HOST_SUFFIXES.some((suffix) => host.endsWith(suffix)) ? url : null;
+}
+
+export const instagramThumbnailRoutes = new Hono<{
+  Variables: { userId: string; sessionId: string };
+}>();
+
+instagramThumbnailRoutes.get("/instagram/thumbnail/:postId", async (c) => {
+  const url = await resolveInstagramThumbnailUrl(c.req.param("postId"));
+  if (url === null) return c.body(null, 404);
+
+  // No Referer to the CDN (the original <img> used referrerpolicy=no-referrer).
+  // An expired/failed CDN URL → 502 → the <img> onerror falls back to the
+  // KindIcon placeholder. The next account poll refreshes the stored URL.
+  const upstream = await fetch(url, { redirect: "follow" }).catch((err: unknown) => {
+    logger.warn(
+      { err: String((err as Error)?.message ?? err) },
+      "instagram thumbnail proxy: upstream fetch failed",
+    );
+    return null;
+  });
+  if (upstream === null || !upstream.ok || upstream.body === null) {
+    return c.body(null, 502);
+  }
+
+  // Re-served same-origin → IG's CORP no longer blocks it. Cache briefly: the
+  // proxy URL is stable per post, but the underlying CDN URL rotates on each
+  // poll, so keep the window short enough to pick up a refreshed thumbnail.
+  return new Response(upstream.body, {
+    status: 200,
+    headers: {
+      "content-type": upstream.headers.get("content-type") ?? "image/jpeg",
+      "cache-control": "private, max-age=600",
+    },
+  });
+});

--- a/src/lib/sources/instagram/server/thumbnail-proxy.ts
+++ b/src/lib/sources/instagram/server/thumbnail-proxy.ts
@@ -67,7 +67,17 @@ instagramThumbnailRoutes.get("/instagram/thumbnail/:postId", async (c) => {
   // No Referer to the CDN (the original <img> used referrerpolicy=no-referrer).
   // An expired/failed CDN URL → 502 → the <img> onerror falls back to the
   // KindIcon placeholder. The next account poll refreshes the stored URL.
-  const upstream = await fetch(url, { redirect: "follow" }).catch((err: unknown) => {
+  //
+  // redirect:"manual" — the host allow-list validates only the INITIAL URL, so
+  // FOLLOWING a redirect would re-open SSRF (a 3xx → internal host). IG/FB CDNs
+  // serve image bytes directly and never legitimately redirect, so a 3xx comes
+  // back as a non-ok opaque-redirect response and falls through to the 502
+  // below — we never fetch the redirect target. The timeout bounds a slow/hung
+  // CDN (the route is auth-gated, but cheap insurance against a held request).
+  const upstream = await fetch(url, {
+    redirect: "manual",
+    signal: AbortSignal.timeout(8000),
+  }).catch((err: unknown) => {
     logger.warn(
       { err: String((err as Error)?.message ?? err) },
       "instagram thumbnail proxy: upstream fetch failed",

--- a/src/lib/sources/instagram/server/thumbnail-proxy.ts
+++ b/src/lib/sources/instagram/server/thumbnail-proxy.ts
@@ -78,14 +78,17 @@ instagramThumbnailRoutes.get("/instagram/thumbnail/:postId", async (c) => {
     return c.body(null, 502);
   }
 
-  // Re-served same-origin → IG's CORP no longer blocks it. Cache briefly: the
-  // proxy URL is stable per post, but the underlying CDN URL rotates on each
-  // poll, so keep the window short enough to pick up a refreshed thumbnail.
+  // Re-served same-origin → IG's CORP no longer blocks it. Cache 1h in the
+  // browser: the cover image is effectively immutable, so the upper bound can be
+  // long. Freshness does NOT rely on this expiring — the card versions the proxy
+  // URL by the last poll timestamp (?v=), so a re-poll (incl. Refresh-Now) yields
+  // a NEW URL that bypasses the cache immediately. `private` keeps it out of
+  // shared caches (the route is auth-gated).
   return new Response(upstream.body, {
     status: 200,
     headers: {
       "content-type": upstream.headers.get("content-type") ?? "image/jpeg",
-      "cache-control": "private, max-age=600",
+      "cache-control": "private, max-age=3600",
     },
   });
 });

--- a/src/lib/sources/instagram/server/warm-eligibility.ts
+++ b/src/lib/sources/instagram/server/warm-eligibility.ts
@@ -1,0 +1,69 @@
+// Warm-post eligibility for Instagram auto-refresh (#70).
+//
+// A post is "warm" — it gets a PAID single-post refresh ~1×/day via the
+// service_post lane — while it is YOUNG and has gone STALE:
+//   - published_at > now − INSTAGRAM_WARM_WINDOW_DAYS  (the first week of a post's
+//     life, where metrics move + wishlist correlation matters; older → frozen)
+//   - last_polled_at IS NULL OR < now − INSTAGRAM_WARM_STALENESS_HOURS  (the gate:
+//     while a post is on page-1 of the account feed the FREE daily account poll
+//     keeps last_polled_at fresh, so the predicate excludes it — we do NOT pay for
+//     what the free poll already covers. Once it rolls off page-1 it goes stale and
+//     the warm lane tops it up. Self-paces to ~1×/day.)
+//
+// Terminal/failure exclusion — IG-OWN, deliberately NOT YouTube's
+// UNAVAILABLE_POLL_STATUSES (#70 P1-A): IG's HTTP seam collapses transient (5xx/
+// timeout/network) AND operator-issue (budget-exhausted) into
+// last_poll_status='auth_error'. Excluding auth_error wholesale (as YouTube's
+// constant does, for its permanent-key-rejection semantics) would FREEZE a post
+// out of auto-refresh on a single blip. So:
+//   - exclude only genuinely-terminal not_found/private (post is gone — stop paying)
+//   - bound transient churn via poll_failure_count: a persistent failure stops after
+//     INSTAGRAM_WARM_MAX_FAILURES tries; a blip self-heals (poll_failure_count resets
+//     to 0 on the next ok poll — snapshots.ts).
+//
+// Cross-tenant by design (mirrors poll-eligibility.ts): the scheduler fan-out is
+// service-wide; instagram_posts is public-data; the per-post writeSnapshot
+// downstream is public-data. ONE row per post regardless of how many tenants
+// reference it (a single single-post fetch serves all — no per-tenant fan-out).
+
+import { and, eq, gt, isNotNull, isNull, lt, or, sql } from "drizzle-orm";
+import { db } from "$lib/server/db/client.js";
+import { events } from "$lib/server/db/schema/events.js";
+import { instagramPosts } from "$lib/server/db/schema/index.js";
+import { env } from "$lib/server/config/env.js";
+
+const DAY_MS = 86_400_000;
+const HOUR_MS = 3_600_000;
+
+/**
+ * Resolve the distinct post_ids eligible for a warm auto-refresh now. Returns []
+ * when nothing is due. Pure read — no queue handle (the scheduler wraps it in the
+ * throttle gate + enqueue), mirroring selectEligibleVideoIds.
+ */
+export async function selectWarmInstagramPostIds(now: Date): Promise<string[]> {
+  const windowStart = new Date(now.getTime() - env.INSTAGRAM_WARM_WINDOW_DAYS * DAY_MS);
+  const staleBefore = new Date(now.getTime() - env.INSTAGRAM_WARM_STALENESS_HOURS * HOUR_MS);
+
+  // eslint-disable-next-line tenant-scope/no-unfiltered-tenant-query -- scheduler fan-out is service-wide by design; one warm tick batches eligible posts across ALL tenants. instagram_posts is public-data; the per-post writeSnapshot downstream is public-data; tenant scope does not apply.
+  const rows = await db
+    .selectDistinct({ postId: instagramPosts.postId })
+    .from(events)
+    .innerJoin(instagramPosts, eq(events.externalId, instagramPosts.postId))
+    .where(
+      and(
+        sql`${events.kind} = 'instagram_post'`,
+        isNotNull(events.externalId),
+        isNull(events.deletedAt),
+        // Young: within the warm window. NULL published_at (pre-backfill 'pending')
+        // is excluded — we don't know the age yet; the account poll fills it.
+        gt(instagramPosts.publishedAt, windowStart),
+        // Stale: never polled, or last poll older than the staleness gate.
+        or(isNull(instagramPosts.lastPolledAt), lt(instagramPosts.lastPolledAt, staleBefore)),
+        // Terminal exclusion — IG-own (not_found/private only). See header (#70 P1-A).
+        sql`(${instagramPosts.lastPollStatus} IS NULL OR ${instagramPosts.lastPollStatus} NOT IN ('not_found','private'))`,
+        // Bounded-failure exclusion — stop churning credits on a persistent failure.
+        lt(instagramPosts.pollFailureCount, env.INSTAGRAM_WARM_MAX_FAILURES),
+      ),
+    );
+  return rows.map((r) => r.postId);
+}

--- a/src/routes/events/new/+page.svelte
+++ b/src/routes/events/new/+page.svelte
@@ -36,6 +36,7 @@
         url: payload.url,
         notes: payload.notes,
         authorIsMe: payload.authorIsMe,
+        externalId: payload.externalId,
       }),
     });
     if (res.ok) {

--- a/src/routes/feed/+page.svelte
+++ b/src/routes/feed/+page.svelte
@@ -380,6 +380,7 @@
         notes: payload.notes,
         authorIsMe: payload.authorIsMe,
         metadata: payload.metadata,
+        externalId: payload.externalId,
       }),
     });
     if (res.ok) {

--- a/tests/integration/add-event-external-id-wiring.test.ts
+++ b/tests/integration/add-event-external-id-wiring.test.ts
@@ -43,4 +43,18 @@ describe("Add-Event externalId wiring (issue #69)", () => {
       );
     }
   });
+
+  it("the preview-url route returns the adapter canonicalUrl, and the form adopts it", () => {
+    // Canonicalize the saved link on Fetch: the route surfaces the adapter's
+    // canonical permalink and the form swaps it into the url field (IG: query
+    // stripped; YouTube: keeps ?v, drops ?t).
+    const route = read("src/lib/server/http/routes/events.ts");
+    expect(route, "preview-url response includes canonicalUrl").toMatch(
+      /canonicalUrl:\s*enriched\.canonicalUrl/,
+    );
+    const form = read("src/lib/components/add-event/AddEventForm.svelte");
+    expect(form, "form adopts the preview canonicalUrl into the url field").toMatch(
+      /url\s*=\s*data\.canonicalUrl/,
+    );
+  });
 });

--- a/tests/integration/add-event-external-id-wiring.test.ts
+++ b/tests/integration/add-event-external-id-wiring.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+// Add-Event externalId wiring guard (issue #69).
+//
+// The media id resolved by POST /api/events/preview-url must round-trip through
+// the form → POST /api/events → createEvent so an Instagram post saves under its
+// media id (the snapshot/feed-enrichment cache key), NOT the URL shortcode. The
+// service contract is already covered by instagram-paste-preview.test.ts — but
+// the bug that actually shipped (#69) was the FORM discarding the previewed
+// externalId, which no service test could catch because it calls createEvent
+// with the externalId directly. These source-text assertions guard that
+// cross-file wiring (the same idiom audit-render.test.ts uses for component
+// wiring it can't drive headless). Each would FAIL on the pre-fix code.
+
+const read = (p: string): string => fs.readFileSync(path.resolve(p), "utf8");
+
+describe("Add-Event externalId wiring (issue #69)", () => {
+  it("AddEventForm captures the preview externalId and forwards it on save", () => {
+    const src = read("src/lib/components/add-event/AddEventForm.svelte");
+    expect(src, "AddEventPayload / preview response declare externalId").toMatch(
+      /externalId\?:\s*string\s*\|\s*null/,
+    );
+    expect(src, "fetchUrlMetadata captures externalId from the preview response").toMatch(
+      /fetchedExternalId\s*=\s*data\.externalId/,
+    );
+    expect(src, "submit() forwards externalId in the onSave payload").toMatch(
+      /externalId:\s*fetchedExternalId/,
+    );
+  });
+
+  it("the create route schema accepts externalId (Zod strips unknown keys otherwise)", () => {
+    const src = read("src/lib/server/http/routes/events.ts");
+    expect(src, "createEventSchema accepts externalId").toMatch(/externalId:\s*z\.string\(\)/);
+  });
+
+  it("both /api/events POST consumers forward payload.externalId", () => {
+    for (const route of ["src/routes/feed/+page.svelte", "src/routes/events/new/+page.svelte"]) {
+      const src = read(route);
+      expect(src, `${route} forwards externalId in the POST body`).toMatch(
+        /externalId:\s*payload\.externalId/,
+      );
+    }
+  });
+});

--- a/tests/integration/anonymous-401.test.ts
+++ b/tests/integration/anonymous-401.test.ts
@@ -99,6 +99,12 @@ describe("anonymous-401 sweep", () => {
     // tenantScope middleware fires before redditFetch ever reaches
     // the Reddit servers, so anonymous probes never burn a unit.
     "/api/reddit/fetch-metadata",
+    // Instagram same-origin thumbnail proxy (#69). IG's CDN sends
+    // Cross-Origin-Resource-Policy: same-origin, so a raw <img> hotlink is
+    // browser-blocked; the feed card loads /api/instagram/thumbnail/<postId>
+    // instead. adapter.registerRoutes mounts it; tenantScope gates it so an
+    // anonymous probe → 401 before any CDN fetch.
+    "/api/instagram/thumbnail/:postId",
     // Phase 3.4 design-v2-ux — bulk endpoints (PATCH + DELETE on the
     // same /api/events/bulk path). Wave 2 Plan 06 mounted the Hono
     // route; the path participates in the load-bearing toContain guard

--- a/tests/integration/event-history-chart-animation.test.ts
+++ b/tests/integration/event-history-chart-animation.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+// EventHistoryChart must disable animation (#69 Issue 2).
+//
+// svelte-echarts' <Chart> applies options with notMerge:true, so EVERY setOption
+// (a Refresh-Now invalidateAll re-running the page loader) RESETS the chart and
+// replays the entry animation — the "graph redraws from 0 every reload" jank the
+// user hit during refresh. Disabling animation on this chart makes a data reload
+// update in place (instant). Guard: the chart's options override the shared
+// baseChartOptions default with animation:false.
+
+const src = fs.readFileSync(
+  path.resolve("src/lib/components/charts/EventHistoryChart.svelte"),
+  "utf8",
+);
+
+describe("EventHistoryChart animation (#69 Issue 2)", () => {
+  it("disables animation so a Refresh-Now data reload doesn't redraw the graph from 0", () => {
+    expect(src, "EventHistoryChart options set animation: false").toMatch(/animation:\s*false/);
+  });
+});

--- a/tests/integration/events-external-id-derivation.test.ts
+++ b/tests/integration/events-external-id-derivation.test.ts
@@ -1,18 +1,21 @@
 import { describe, it, expect } from "vitest";
 import { createEvent } from "../../src/lib/server/services/events.js";
+import { db } from "../../src/lib/server/db/client.js";
+import { instagramPosts } from "../../src/lib/server/db/schema/index.js";
 import { seedUserDirectly } from "./helpers.js";
 
-// External-id derivation on the manual-create path (issue #69).
+// External-id derivation on the manual-create path (issue #69 + #70 P1).
 //
-// createEvent derives external_id from the pasted URL ONLY when the caller did
-// not supply one. The derived id must be the canonical CACHE KEY for the kind —
-// the value the snapshot / feed-enrichment tables join on:
-//   - youtube_video / reddit_post: the URL-parsed id IS the cache key → derive.
-//   - instagram_post: the URL carries only the SHORTCODE, which is NOT the
-//     media-id cache key. Deriving it would save an event whose external_id
-//     never matches a snapshot — stranded on the "pending" badge with no stats
-//     forever. IG is excluded from URL-derivation; its media id arrives only as
-//     an explicit externalId from the preview flow (POST /api/events/preview-url).
+// createEvent resolves external_id to the canonical CACHE KEY for the kind — the
+// value the snapshot / feed-enrichment tables join on:
+//   - youtube_video / reddit_post: the URL-parsed id IS the cache key → derive
+//     from the URL when the caller didn't supply one (caller value wins).
+//   - instagram_post: the media id is NOT URL-derivable (the permalink carries
+//     only the shortcode) AND the request body's externalId is UNTRUSTED — a
+//     client could pair post A's URL with post B's media id. createEvent
+//     RE-DERIVES it from OUR OWN cache (instagram_posts.permalink = the canonical
+//     url the preview UPSERTed), IGNORING the body value (#70 review P1). No cache
+//     row → null → an honest stats-less card.
 
 const uniq = (): string => Math.random().toString(36).slice(2, 10);
 
@@ -32,7 +35,7 @@ describe("createEvent external_id derivation (issue #69)", () => {
     expect(ev.externalId).toBe("dQw4w9WgXcQ");
   });
 
-  it("instagram_post with a permalink and no externalId LEAVES external_id null (shortcode != media-id key)", async () => {
+  it("instagram_post with a permalink NOT in our cache LEAVES external_id null", async () => {
     const u = await seedUserDirectly({ email: `extid-ig-noid-${uniq()}@test.local` });
     const ev = await createEvent(
       u.id,
@@ -44,22 +47,80 @@ describe("createEvent external_id derivation (issue #69)", () => {
       },
       "127.0.0.1",
     );
-    // The shortcode DZKyjVKDTrE must NOT be stored — it would never match a
-    // snapshot keyed by the media id, stranding the event on the pending badge.
+    // No instagram_posts row for this permalink (no prior preview) → null. An
+    // honest stats-less card, never the unusable shortcode.
     expect(ev.externalId).toBeNull();
   });
 
-  it("instagram_post with an explicit externalId (media id from preview) STORES it verbatim", async () => {
-    const u = await seedUserDirectly({ email: `extid-ig-id-${uniq()}@test.local` });
-    const mediaId = "3456789012345678901";
+  it("instagram_post RE-DERIVES the media id from OUR cache by permalink, ignoring the body (#70 P1)", async () => {
+    const u = await seedUserDirectly({ email: `extid-ig-cache-${uniq()}@test.local` });
+    const mediaId = `media_${uniq()}`;
+    const canonical = "https://www.instagram.com/p/DZKyjVKDTrE/";
+    // The preview would have UPSERTed this: permalink = canonical, post_id = media id.
+    await db
+      .insert(instagramPosts)
+      .values({ postId: mediaId, permalink: canonical })
+      .onConflictDoNothing();
     const ev = await createEvent(
       u.id,
       {
         kind: "instagram_post",
         occurredAt: new Date("2026-05-01T10:00:00Z"),
-        title: "ig fetched",
-        url: "https://www.instagram.com/p/DZKyjVKDTrE/",
-        externalId: mediaId,
+        title: "ig cached",
+        url: canonical,
+        // A LYING body value — must be IGNORED in favor of the cache-derived id.
+        externalId: "999_attacker_supplied_wrong_id",
+      },
+      "127.0.0.1",
+    );
+    expect(ev.externalId).toBe(mediaId);
+  });
+
+  it("instagram_post binds to the URL's cache row, NOT the body's (cross-post mismatch neutralized) (#70 P1)", async () => {
+    const u = await seedUserDirectly({ email: `extid-ig-mismatch-${uniq()}@test.local` });
+    const idA = `mediaA_${uniq()}`;
+    const idB = `mediaB_${uniq()}`;
+    const urlA = `https://www.instagram.com/p/PA${uniq()}/`;
+    await db
+      .insert(instagramPosts)
+      .values([
+        { postId: idA, permalink: urlA },
+        { postId: idB, permalink: `https://www.instagram.com/p/PB${uniq()}/` },
+      ])
+      .onConflictDoNothing();
+    const ev = await createEvent(
+      u.id,
+      {
+        kind: "instagram_post",
+        occurredAt: new Date("2026-05-01T10:00:00Z"),
+        title: "mismatch",
+        url: urlA, // the URL points at post A
+        externalId: idB, // the body LIES, claiming post B's media id
+      },
+      "127.0.0.1",
+    );
+    expect(ev.externalId).toBe(idA); // bound to the URL's post…
+    expect(ev.externalId).not.toBe(idB); // …never the body's
+  });
+
+  it("instagram_post canonicalizes /reels/ → /reel/ so a paste variant still matches the cache (#70)", async () => {
+    const u = await seedUserDirectly({ email: `extid-ig-reels-${uniq()}@test.local` });
+    const mediaId = `reelmedia_${uniq()}`;
+    const code = `RL${uniq()}`;
+    // Cache stored under the canonical /reel/ form (what the preview writes).
+    await db
+      .insert(instagramPosts)
+      .values({ postId: mediaId, permalink: `https://www.instagram.com/reel/${code}/` })
+      .onConflictDoNothing();
+    // User pastes the plural /reels/ variant — instagramParseUrl canonicalizes it.
+    const ev = await createEvent(
+      u.id,
+      {
+        kind: "instagram_post",
+        occurredAt: new Date("2026-05-01T10:00:00Z"),
+        title: "ig reel variant",
+        url: `https://www.instagram.com/reels/${code}/`,
+        externalId: "ignored",
       },
       "127.0.0.1",
     );

--- a/tests/integration/events-external-id-derivation.test.ts
+++ b/tests/integration/events-external-id-derivation.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { createEvent } from "../../src/lib/server/services/events.js";
+import { seedUserDirectly } from "./helpers.js";
+
+// External-id derivation on the manual-create path (issue #69).
+//
+// createEvent derives external_id from the pasted URL ONLY when the caller did
+// not supply one. The derived id must be the canonical CACHE KEY for the kind —
+// the value the snapshot / feed-enrichment tables join on:
+//   - youtube_video / reddit_post: the URL-parsed id IS the cache key → derive.
+//   - instagram_post: the URL carries only the SHORTCODE, which is NOT the
+//     media-id cache key. Deriving it would save an event whose external_id
+//     never matches a snapshot — stranded on the "pending" badge with no stats
+//     forever. IG is excluded from URL-derivation; its media id arrives only as
+//     an explicit externalId from the preview flow (POST /api/events/preview-url).
+
+const uniq = (): string => Math.random().toString(36).slice(2, 10);
+
+describe("createEvent external_id derivation (issue #69)", () => {
+  it("youtube_video with URL and no externalId DERIVES the videoId (cache key == URL id)", async () => {
+    const u = await seedUserDirectly({ email: `extid-yt-${uniq()}@test.local` });
+    const ev = await createEvent(
+      u.id,
+      {
+        kind: "youtube_video",
+        occurredAt: new Date("2026-05-01T10:00:00Z"),
+        title: "yt no externalId",
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      },
+      "127.0.0.1",
+    );
+    expect(ev.externalId).toBe("dQw4w9WgXcQ");
+  });
+
+  it("instagram_post with a permalink and no externalId LEAVES external_id null (shortcode != media-id key)", async () => {
+    const u = await seedUserDirectly({ email: `extid-ig-noid-${uniq()}@test.local` });
+    const ev = await createEvent(
+      u.id,
+      {
+        kind: "instagram_post",
+        occurredAt: new Date("2026-05-01T10:00:00Z"),
+        title: "ig permalink, no fetch",
+        url: "https://www.instagram.com/p/DZKyjVKDTrE/",
+      },
+      "127.0.0.1",
+    );
+    // The shortcode DZKyjVKDTrE must NOT be stored — it would never match a
+    // snapshot keyed by the media id, stranding the event on the pending badge.
+    expect(ev.externalId).toBeNull();
+  });
+
+  it("instagram_post with an explicit externalId (media id from preview) STORES it verbatim", async () => {
+    const u = await seedUserDirectly({ email: `extid-ig-id-${uniq()}@test.local` });
+    const mediaId = "3456789012345678901";
+    const ev = await createEvent(
+      u.id,
+      {
+        kind: "instagram_post",
+        occurredAt: new Date("2026-05-01T10:00:00Z"),
+        title: "ig fetched",
+        url: "https://www.instagram.com/p/DZKyjVKDTrE/",
+        externalId: mediaId,
+      },
+      "127.0.0.1",
+    );
+    expect(ev.externalId).toBe(mediaId);
+  });
+});

--- a/tests/integration/events.test.ts
+++ b/tests/integration/events.test.ts
@@ -786,10 +786,12 @@ describe("createEvent kind-aware enrichment", () => {
 
   it("enrichFromUrl RECOGNIZES an Instagram permalink (kind+URL, empty title, no fetch, no DB write)", async () => {
     // Phase 08 recognition-only: there is no IG single-post metadata/stats
-    // API, so enrichFromUrl must NOT throw 'unsupported_url' / 'kind_not_yet_
-    // functional' for a valid IG URL. It returns kind=instagram_post + the
-    // shortcode externalId + the canonical permalink with an EMPTY title (the
-    // user types the title manually). No network call, no event row written.
+    // API when the provider is unconfigured, so enrichFromUrl must NOT throw
+    // 'unsupported_url' / 'kind_not_yet_functional' for a valid IG URL. It
+    // returns kind=instagram_post + a NULL externalId (the URL shortcode is NOT
+    // the media-id cache key — storing it would strand the event on the pending
+    // badge, #69) + the canonical permalink with an EMPTY title (the user types
+    // the title manually). No network call, no event row written.
     const u = await seedUserDirectly({ email: `ev17ig-${uniq()}@test.local` });
 
     const result = await enrichFromUrl(
@@ -798,7 +800,7 @@ describe("createEvent kind-aware enrichment", () => {
       "127.0.0.1",
     );
     expect(result.kind).toBe("instagram_post");
-    expect(result.externalId).toBe("XyZ_-789");
+    expect(result.externalId).toBeNull();
     expect(result.canonicalUrl).toBe("https://www.instagram.com/reel/XyZ_-789/");
     expect(result.title).toBe(""); // No live preview — user supplies the title.
     expect(result.thumbnailUrl).toBeNull();
@@ -809,12 +811,14 @@ describe("createEvent kind-aware enrichment", () => {
     expect(rows).toHaveLength(0);
   });
 
-  it("createEvent saves a bare instagram_post event (externalId derived from the pasted URL)", async () => {
-    // The accepted manual-entry result: a user pastes an IG link (recognized
-    // above), types a Title, and saves. createEvent derives the externalId
-    // (shortcode) from the URL via parseAnyUrl and persists a bare event —
-    // no stats, no thumbnail. It renders in /feed with the central "Instagram"
-    // label and a plain card (no media_type pill, no enrichment row).
+  it("createEvent saves a bare instagram_post event with NULL externalId (shortcode is not the media-id cache key, #69)", async () => {
+    // The accepted manual-entry result: a user pastes an IG link, types a Title,
+    // and saves WITHOUT a preview fetch. createEvent does NOT derive an
+    // externalId from the URL for instagram_post — the URL shortcode is not the
+    // media-id key the snapshot/enrichment caches use, so storing it would
+    // strand the event on the "pending" badge with no stats forever (#69).
+    // externalId stays null → a bare, honest stats-less card. (A media-id-keyed
+    // enriched event requires the preview's externalId, covered elsewhere.)
     const u = await seedUserDirectly({ email: `ev17igsave-${uniq()}@test.local` });
 
     const ev = await createEvent(
@@ -831,9 +835,8 @@ describe("createEvent kind-aware enrichment", () => {
     expect(ev.kind).toBe("instagram_post");
     expect(ev.title).toBe("My launch reel");
     expect(ev.url).toBe("https://www.instagram.com/p/CabcDEF123/");
-    // externalId derived from the pasted permalink shortcode by createEvent's
-    // parseAnyUrl enrichment (kind matches → externalId used).
-    expect(ev.externalId).toBe("CabcDEF123");
+    // No URL-derived externalId for IG — the shortcode is not the cache key (#69).
+    expect(ev.externalId).toBeNull();
 
     // It appears in the user's feed.
     const feed = await listFeedPage(u.id, {}, null);

--- a/tests/integration/feed-card-thumbnail-cors.test.ts
+++ b/tests/integration/feed-card-thumbnail-cors.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+// Feed-card thumbnail must NOT set crossorigin (#69).
+//
+// The thumbnail <img> is display-only (never read into a canvas). Instagram's
+// cdninstagram.com serves the image bytes WITHOUT Access-Control-Allow-Origin
+// headers, so `crossorigin="anonymous"` makes the browser fetch 200 then DISCARD
+// the image on the failed CORS check → every Instagram thumbnail breaks. The
+// YouTube/Reddit CDNs DO send CORS headers, which masked the bug until real IG
+// thumbnails finally rendered (after the #69 paste fixes). Guard: the shared
+// feed card keeps referrerpolicy (CDN hotlink hygiene) but carries no crossorigin.
+
+const read = (p: string): string => fs.readFileSync(path.resolve(p), "utf8");
+
+describe("feed card thumbnail CORS (#69)", () => {
+  it("BaseFeedCard thumbnail img keeps referrerpolicy but sets NO crossorigin", () => {
+    // Strip HTML comments first — the markup carries a why-comment that names
+    // crossorigin; this guard targets the actual attribute, not the prose.
+    const src = read("src/lib/components/feed/parts/BaseFeedCard.svelte").replace(
+      /<!--[\s\S]*?-->/g,
+      "",
+    );
+    expect(src, "referrerpolicy kept for CDN hotlink hygiene").toMatch(
+      /referrerpolicy="no-referrer"/,
+    );
+    expect(
+      src,
+      "no crossorigin attribute — IG CDN sends no CORS headers; the img is display-only",
+    ).not.toMatch(/crossorigin/);
+  });
+});

--- a/tests/integration/instagram-paste-preview.test.ts
+++ b/tests/integration/instagram-paste-preview.test.ts
@@ -362,10 +362,12 @@ describe("instagram live paste-preview (single-post fetch, issue #65)", () => {
     // No throw — the form must still let the user save a bare event.
     const result = await enrichFromUrl(user.id, "https://www.instagram.com/p/NOPE1/", "127.0.0.1");
 
-    // Recognition-only shape: kind + shortcode + canonical permalink, EMPTY title.
+    // Recognition-only shape: kind + canonical permalink, EMPTY title, and a
+    // NULL externalId (NOT the shortcode — storing it would strand the event on
+    // the pending badge, issue #69).
     expect(result.kind).toBe("instagram_post");
     expect(result.title).toBe("");
-    expect(result.externalId).toBe("NOPE1");
+    expect(result.externalId).toBeNull();
     expect(result.canonicalUrl).toBe("https://www.instagram.com/p/NOPE1/");
     expect(result.thumbnailUrl).toBeNull();
 
@@ -391,7 +393,7 @@ describe("instagram live paste-preview (single-post fetch, issue #65)", () => {
 
     expect(result.kind).toBe("instagram_post");
     expect(result.title).toBe("");
-    expect(result.externalId).toBe("BOOM1");
+    expect(result.externalId).toBeNull();
   });
 
   it("an EXPECTED adapter throw (AppError) degrades to recognition-only (N-1)", async () => {
@@ -412,7 +414,7 @@ describe("instagram live paste-preview (single-post fetch, issue #65)", () => {
       );
       expect(result.kind).toBe("instagram_post");
       expect(result.title).toBe("");
-      expect(result.externalId).toBe("APPERR1");
+      expect(result.externalId).toBeNull();
     } finally {
       spy.mockRestore();
     }
@@ -449,6 +451,7 @@ describe("instagram live paste-preview (single-post fetch, issue #65)", () => {
 
     expect(result.kind).toBe("instagram_post");
     expect(result.title).toBe("");
+    expect(result.externalId).toBeNull();
     // The provider WAS called (the cap was consulted) but no cache row landed.
     expect(single.calls).toHaveLength(1);
     const cached = await db.select().from(instagramPosts);

--- a/tests/integration/instagram-refresh-queue.test.ts
+++ b/tests/integration/instagram-refresh-queue.test.ts
@@ -1,0 +1,244 @@
+// Instagram per-post Refresh lane (#69 follow-on).
+//
+// Manual "Refresh now" for IG now enqueues ONE adapter_refresh_queue row per post
+// (queue_name "user_post"); the IG lane worker (handlers/refresh-queue-tick.ts)
+// claims up to N rows/tick (concurrent, global) and refreshes EXACTLY those posts
+// via the single-post endpoint — not the old account-level walk.
+//
+// Integration test — real Postgres via ./helpers.js. Two seams are mocked: the
+// provider's getSocialProvider (the upstream HTTP) and getSocialThrottleState
+// (the claimGate's throttle band, so the test controls it deterministically
+// instead of depending on the operator-budget env). NEVER mocks the DB.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { and, eq } from "drizzle-orm";
+import { seedUserDirectly } from "./helpers.js";
+import type { NormalizedSinglePost } from "../../src/lib/sources/social-provider.js";
+
+interface ScriptedSinglePost {
+  next: NormalizedSinglePost | null;
+  calls: Array<{ url: string; origin?: string }>;
+}
+const single: ScriptedSinglePost = { next: null, calls: [] };
+let throttleState: "ok" | "eighty" | "ninetyfive" = "ok";
+
+vi.mock("../../src/lib/sources/instagram/server/provider/registry.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    isInstagramConfigured: () => true,
+    getSocialProvider: (platform: string) => {
+      if (platform !== "instagram") return null;
+      return {
+        name: "scrapecreators",
+        async fetchPostByUrl(
+          _platform: string,
+          url: string,
+          opts: { origin?: string },
+        ): Promise<NormalizedSinglePost | null> {
+          single.calls.push({ url, origin: opts.origin });
+          return single.next;
+        },
+        async fetchPosts() {
+          return { posts: [], nextCursor: null, endOfFeed: true, creditsUsed: 1 };
+        },
+        async resolveAccount() {
+          return { accountId: "acct", displayName: "X" };
+        },
+      };
+    },
+  };
+});
+
+vi.mock("../../src/lib/sources/instagram/server/quota.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, getSocialThrottleState: async () => throttleState };
+});
+
+const { db } = await import("../../src/lib/server/db/client.js");
+const { events, instagramPosts, instagramPostSnapshots, adapterRefreshQueue } =
+  await import("../../src/lib/server/db/schema/index.js");
+const { createEvent } = await import("../../src/lib/server/services/events-mutation.js");
+const { instagramAdapter } = await import("../../src/lib/sources/instagram/server/index.js");
+const { instagramRefreshQueueTick, __resetInstagramRefreshQueueWorkerForTest } =
+  await import("../../src/lib/sources/instagram/server/handlers/refresh-queue-tick.js");
+
+const uniq = (): string => Math.random().toString(36).slice(2, 10);
+
+function post(overrides: Partial<NormalizedSinglePost> = {}): NormalizedSinglePost {
+  return {
+    id: "3912161556549155524_24549572243",
+    shortcode: "ABC",
+    kind: "carousel",
+    publishedAt: new Date("2026-06-01T12:00:00Z"),
+    metrics: { views: null, likes: 99, comments: 3 },
+    caption: "cap",
+    thumbnailUrl: "https://scontent.cdninstagram.com/x.jpg",
+    ownerId: "24549572243",
+    ownerUsername: "d954mas",
+    ...overrides,
+  };
+}
+
+/** Seed an IG event (+ its public-data instagram_posts cache row with a permalink)
+ *  for `userId`, returning the media id used as external_id + the event id. */
+async function seedIgEvent(
+  userId: string,
+  postId: string,
+): Promise<{ postId: string; eventId: string }> {
+  await db
+    .insert(instagramPosts)
+    .values({
+      postId,
+      accountId: "24549572243",
+      permalink: `https://www.instagram.com/p/${postId.slice(0, 6)}/`,
+      mediaType: "carousel",
+    })
+    .onConflictDoNothing();
+  const ev = await createEvent(
+    userId,
+    {
+      kind: "instagram_post",
+      title: "ig",
+      externalId: postId,
+      occurredAt: new Date("2026-06-02T00:00:00Z").toISOString(),
+      gameIds: [],
+    },
+    "127.0.0.1",
+  );
+  return { postId, eventId: ev.id };
+}
+
+async function snapshotCount(postId: string): Promise<number> {
+  const rows = await db
+    .select({ id: instagramPostSnapshots.id })
+    .from(instagramPostSnapshots)
+    .where(eq(instagramPostSnapshots.postId, postId));
+  return rows.length;
+}
+
+async function enqueue(eventId: string, userId: string, postId: string): Promise<void> {
+  await instagramAdapter.refreshQueue!.enqueue({
+    eventId,
+    userId,
+    externalId: postId,
+    eventKind: "instagram_post",
+  });
+}
+
+beforeEach(() => {
+  single.next = post();
+  single.calls = [];
+  throttleState = "ok";
+  __resetInstagramRefreshQueueWorkerForTest();
+});
+
+describe("instagram per-post refresh lane (#69)", () => {
+  it("enqueueRefreshNow inserts a per-post adapter_refresh_queue row (no boss job)", async () => {
+    const u = await seedUserDirectly({ email: `igrq-enq-${uniq()}@t.io` });
+    const postId = `3001_${uniq()}`;
+    const result = await instagramAdapter.refreshQueue!.enqueue({
+      eventId: `evt-${uniq()}`,
+      userId: u.id,
+      externalId: postId,
+      eventKind: "instagram_post",
+    });
+    expect(result.queue).toBe("adapter_refresh_queue:instagram_account:user_post");
+    const rows = await db
+      .select()
+      .from(adapterRefreshQueue)
+      .where(
+        and(
+          eq(adapterRefreshQueue.adapterKind, "instagram_account"),
+          eq(adapterRefreshQueue.userId, u.id),
+        ),
+      );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.queueName).toBe("user_post");
+    expect(rows[0]!.status).toBe("pending");
+    expect((rows[0]!.payload as { post_id?: string }).post_id).toBe(postId);
+  });
+
+  it("a tick refreshes EXACTLY the queued post (single-post fetch + snapshot), marks the row done", async () => {
+    const u = await seedUserDirectly({ email: `igrq-one-${uniq()}@t.io` });
+    const tgt = await seedIgEvent(u.id, `3101_${uniq()}`);
+    const neighbour = await seedIgEvent(u.id, `3102_${uniq()}`); // same account, NOT queued
+    await enqueue(tgt.eventId, u.id, tgt.postId);
+
+    await instagramRefreshQueueTick();
+
+    expect(single.calls).toHaveLength(1); // ONE single-post fetch — not an account walk
+    expect(await snapshotCount(tgt.postId)).toBe(1);
+    expect(await snapshotCount(neighbour.postId)).toBe(0); // neighbour untouched
+    const [row] = await db
+      .select({ status: adapterRefreshQueue.status })
+      .from(adapterRefreshQueue)
+      .where(eq(adapterRefreshQueue.userId, u.id))
+      .limit(1);
+    expect(row!.status).toBe("done");
+  });
+
+  it("claimGate defers the tick when the operator budget is at 95%", async () => {
+    const u = await seedUserDirectly({ email: `igrq-throttle-${uniq()}@t.io` });
+    const tgt = await seedIgEvent(u.id, `3201_${uniq()}`);
+    await enqueue(tgt.eventId, u.id, tgt.postId);
+    throttleState = "ninetyfive";
+
+    await instagramRefreshQueueTick();
+
+    expect(single.calls).toHaveLength(0); // never fetched — deferred at the gate
+    expect(await snapshotCount(tgt.postId)).toBe(0);
+    const [row] = await db
+      .select({ status: adapterRefreshQueue.status })
+      .from(adapterRefreshQueue)
+      .where(eq(adapterRefreshQueue.userId, u.id))
+      .limit(1);
+    expect(row!.status).toBe("pending"); // still pending, retried later
+  });
+
+  it("is tenant-scoped: a row whose event belongs to another user is skipped (no snapshot)", async () => {
+    const owner = await seedUserDirectly({ email: `igrq-owner-${uniq()}@t.io` });
+    const attacker = await seedUserDirectly({ email: `igrq-atk-${uniq()}@t.io` });
+    const tgt = await seedIgEvent(owner.id, `3301_${uniq()}`);
+    // Enqueue under the ATTACKER's userId but pointing at the owner's event.
+    await enqueue(tgt.eventId, attacker.id, tgt.postId);
+
+    await instagramRefreshQueueTick();
+
+    expect(single.calls).toHaveLength(0); // event not resolvable under attacker → no fetch
+    expect(await snapshotCount(tgt.postId)).toBe(0);
+  });
+
+  it("batchScope global: one tick processes queued posts from DIFFERENT users", async () => {
+    const a = await seedUserDirectly({ email: `igrq-a-${uniq()}@t.io` });
+    const b = await seedUserDirectly({ email: `igrq-b-${uniq()}@t.io` });
+    const pa = await seedIgEvent(a.id, `3401_${uniq()}`);
+    const pb = await seedIgEvent(b.id, `3402_${uniq()}`);
+    await enqueue(pa.eventId, a.id, pa.postId);
+    await enqueue(pb.eventId, b.id, pb.postId);
+
+    await instagramRefreshQueueTick(); // default concurrency 10 ≥ 2 → both in one tick
+
+    expect(single.calls.length).toBe(2);
+    expect(await snapshotCount(pa.postId)).toBe(1);
+    expect(await snapshotCount(pb.postId)).toBe(1);
+  });
+
+  it("deleted/private post (null body) writes a not_found status, no metrics row", async () => {
+    const u = await seedUserDirectly({ email: `igrq-gone-${uniq()}@t.io` });
+    const tgt = await seedIgEvent(u.id, `3501_${uniq()}`);
+    await enqueue(tgt.eventId, u.id, tgt.postId);
+    single.next = null; // provider returns null → deleted/private
+
+    await instagramRefreshQueueTick();
+
+    expect(single.calls).toHaveLength(1);
+    expect(await snapshotCount(tgt.postId)).toBe(0); // not_found → no metrics snapshot
+    const [postRow] = await db
+      .select({ status: instagramPosts.lastPollStatus })
+      .from(instagramPosts)
+      .where(eq(instagramPosts.postId, tgt.postId))
+      .limit(1);
+    expect(postRow!.status).toBe("not_found");
+  });
+});

--- a/tests/integration/instagram-refresh-queue.test.ts
+++ b/tests/integration/instagram-refresh-queue.test.ts
@@ -11,7 +11,7 @@
 // instead of depending on the operator-budget env). NEVER mocks the DB.
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { seedUserDirectly } from "./helpers.js";
 import { AdapterError } from "../../src/lib/sources/errors.js";
 import type { NormalizedSinglePost } from "../../src/lib/sources/social-provider.js";
@@ -66,6 +66,8 @@ const { createEvent } = await import("../../src/lib/server/services/events-mutat
 const { instagramAdapter } = await import("../../src/lib/sources/instagram/server/index.js");
 const { instagramRefreshQueueTick, __resetInstagramRefreshQueueWorkerForTest } =
   await import("../../src/lib/sources/instagram/server/handlers/refresh-queue-tick.js");
+const { enqueueServiceInstagramPostStats } =
+  await import("../../src/lib/sources/instagram/server/handlers/enqueue-service-post-stats.js");
 
 const uniq = (): string => Math.random().toString(36).slice(2, 10);
 
@@ -312,5 +314,47 @@ describe("instagram per-post refresh lane (#69)", () => {
       .where(eq(adapterRefreshQueue.userId, u.id))
       .limit(1);
     expect(row!.status).toBe("done"); // per-row: marked done, not a batch-wide retry
+  });
+
+  it("a service_post (cron warm) row refreshes by post_id with origin=cron — no event, no userId (#70)", async () => {
+    const u = await seedUserDirectly({ email: `igrq-svc-${uniq()}@t.io` });
+    // seedIgEvent populates the public-data instagram_posts cache (the warm lane
+    // needs the permalink) + an event; the service_post row keys off post_id ONLY.
+    const tgt = await seedIgEvent(u.id, `3701_${uniq()}`);
+    const enqueued = await enqueueServiceInstagramPostStats([tgt.postId]);
+    expect(enqueued).toBe(1);
+
+    await instagramRefreshQueueTick();
+
+    expect(single.calls).toHaveLength(1);
+    expect(single.calls[0]!.origin).toBe("cron"); // operator pool, NOT the user's cap
+    expect(await snapshotCount(tgt.postId)).toBe(1);
+    const [row] = await db
+      .select({ status: adapterRefreshQueue.status, userId: adapterRefreshQueue.userId })
+      .from(adapterRefreshQueue)
+      .where(eq(adapterRefreshQueue.queueName, "service_post"))
+      .limit(1);
+    expect(row!.status).toBe("done");
+    expect(row!.userId).toBeNull(); // cross-tenant public-data lane
+  });
+
+  it("enqueueServiceInstagramPostStats DEDUPS against a pending/processing service_post row (#70)", async () => {
+    await seedUserDirectly({ email: `igrq-svcdedup-${uniq()}@t.io` });
+    const postId = `3801_${uniq()}`;
+    const first = await enqueueServiceInstagramPostStats([postId]);
+    const second = await enqueueServiceInstagramPostStats([postId]); // still pending
+    expect(first).toBe(1);
+    expect(second).toBe(0); // skip-if-pending — no duplicate row
+    const rows = await db
+      .select({ id: adapterRefreshQueue.id })
+      .from(adapterRefreshQueue)
+      .where(
+        and(
+          eq(adapterRefreshQueue.adapterKind, "instagram_account"),
+          eq(adapterRefreshQueue.queueName, "service_post"),
+          eq(sql`${adapterRefreshQueue.payload}->>'post_id'`, postId),
+        ),
+      );
+    expect(rows).toHaveLength(1);
   });
 });

--- a/tests/integration/instagram-refresh-queue.test.ts
+++ b/tests/integration/instagram-refresh-queue.test.ts
@@ -22,7 +22,8 @@ interface ScriptedSinglePost {
   calls: Array<{ url: string; origin?: string }>;
 }
 const single: ScriptedSinglePost = { next: null, throwErr: null, calls: [] };
-let throttleState: "ok" | "eighty" | "ninetyfive" = "ok";
+// Controls the claimGate (getSocialSpendToday): default = funded + under cap → run.
+let spend = { creditsUsed: 0, dailyCap: 1000, prepaidBalance: 5000 };
 
 vi.mock("../../src/lib/sources/instagram/server/provider/registry.js", async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
@@ -55,7 +56,7 @@ vi.mock("../../src/lib/sources/instagram/server/provider/registry.js", async (im
 
 vi.mock("../../src/lib/sources/instagram/server/quota.js", async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
-  return { ...actual, getSocialThrottleState: async () => throttleState };
+  return { ...actual, getSocialSpendToday: async () => spend };
 });
 
 const { db } = await import("../../src/lib/server/db/client.js");
@@ -133,7 +134,7 @@ beforeEach(() => {
   single.next = post();
   single.throwErr = null;
   single.calls = [];
-  throttleState = "ok";
+  spend = { creditsUsed: 0, dailyCap: 1000, prepaidBalance: 5000 };
   __resetInstagramRefreshQueueWorkerForTest();
 });
 
@@ -182,11 +183,11 @@ describe("instagram per-post refresh lane (#69)", () => {
     expect(row!.status).toBe("done");
   });
 
-  it("claimGate defers the tick when the operator budget is at 95%", async () => {
+  it("claimGate DEFERS at daily-cap 95% (balance funded → recovers at reset)", async () => {
     const u = await seedUserDirectly({ email: `igrq-throttle-${uniq()}@t.io` });
     const tgt = await seedIgEvent(u.id, `3201_${uniq()}`);
     await enqueue(tgt.eventId, u.id, tgt.postId);
-    throttleState = "ninetyfive";
+    spend = { creditsUsed: 950, dailyCap: 1000, prepaidBalance: 5000 }; // 95% of cap, funded
 
     await instagramRefreshQueueTick();
 
@@ -197,7 +198,50 @@ describe("instagram per-post refresh lane (#69)", () => {
       .from(adapterRefreshQueue)
       .where(eq(adapterRefreshQueue.userId, u.id))
       .limit(1);
-    expect(row!.status).toBe("pending"); // still pending, retried later
+    expect(row!.status).toBe("pending"); // deferred → still pending, retries after reset
+  });
+
+  it("claimGate RUNS at balance-exhausted (no defer-forever; row completes, button settles) (P1-B)", async () => {
+    const u = await seedUserDirectly({ email: `igrq-bal0-${uniq()}@t.io` });
+    const tgt = await seedIgEvent(u.id, `3251_${uniq()}`);
+    await enqueue(tgt.eventId, u.id, tgt.postId);
+    // Prepaid balance is the MONOTONIC hard ceiling — it never resets, so the
+    // claimGate must NOT defer-forever here. It RUNS; in prod the in-fetch reserve
+    // would then fail → non-ok snapshot. (Provider mocked here, so the row simply
+    // completes — the point is it is NOT left pending indefinitely.)
+    spend = { creditsUsed: 0, dailyCap: 1000, prepaidBalance: 0 };
+
+    await instagramRefreshQueueTick();
+
+    expect(single.calls.length).toBeGreaterThan(0); // ran, did not defer
+    const [row] = await db
+      .select({ status: adapterRefreshQueue.status })
+      .from(adapterRefreshQueue)
+      .where(eq(adapterRefreshQueue.userId, u.id))
+      .limit(1);
+    expect(row!.status).toBe("done"); // completed — NOT stuck pending forever
+  });
+
+  it("a failed refresh PRESERVES the prior thumbnail (no blanking) (P1-A)", async () => {
+    const u = await seedUserDirectly({ email: `igrq-thumb-${uniq()}@t.io` });
+    const tgt = await seedIgEvent(u.id, `3271_${uniq()}`);
+    // Give it a known-good thumbnail (simulating a prior successful poll).
+    await db
+      .update(instagramPosts)
+      .set({ thumbnailUrl: "https://scontent.cdninstagram.com/good.jpg" })
+      .where(eq(instagramPosts.postId, tgt.postId));
+    await enqueue(tgt.eventId, u.id, tgt.postId);
+    single.throwErr = new AdapterError("rate limited", { category: "rate-limited" });
+
+    await instagramRefreshQueueTick();
+
+    const [postRow] = await db
+      .select({ thumb: instagramPosts.thumbnailUrl, status: instagramPosts.lastPollStatus })
+      .from(instagramPosts)
+      .where(eq(instagramPosts.postId, tgt.postId))
+      .limit(1);
+    expect(postRow!.status).toBe("rate_limited"); // failure recorded…
+    expect(postRow!.thumb).toBe("https://scontent.cdninstagram.com/good.jpg"); // …but cover preserved
   });
 
   it("is tenant-scoped: a row whose event belongs to another user is skipped (no snapshot)", async () => {

--- a/tests/integration/instagram-refresh-queue.test.ts
+++ b/tests/integration/instagram-refresh-queue.test.ts
@@ -13,13 +13,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { and, eq } from "drizzle-orm";
 import { seedUserDirectly } from "./helpers.js";
+import { AdapterError } from "../../src/lib/sources/errors.js";
 import type { NormalizedSinglePost } from "../../src/lib/sources/social-provider.js";
 
 interface ScriptedSinglePost {
   next: NormalizedSinglePost | null;
+  throwErr: Error | null;
   calls: Array<{ url: string; origin?: string }>;
 }
-const single: ScriptedSinglePost = { next: null, calls: [] };
+const single: ScriptedSinglePost = { next: null, throwErr: null, calls: [] };
 let throttleState: "ok" | "eighty" | "ninetyfive" = "ok";
 
 vi.mock("../../src/lib/sources/instagram/server/provider/registry.js", async (importOriginal) => {
@@ -37,6 +39,7 @@ vi.mock("../../src/lib/sources/instagram/server/provider/registry.js", async (im
           opts: { origin?: string },
         ): Promise<NormalizedSinglePost | null> {
           single.calls.push({ url, origin: opts.origin });
+          if (single.throwErr) throw single.throwErr;
           return single.next;
         },
         async fetchPosts() {
@@ -56,7 +59,7 @@ vi.mock("../../src/lib/sources/instagram/server/quota.js", async (importOriginal
 });
 
 const { db } = await import("../../src/lib/server/db/client.js");
-const { events, instagramPosts, instagramPostSnapshots, adapterRefreshQueue } =
+const { instagramPosts, instagramPostSnapshots, adapterRefreshQueue } =
   await import("../../src/lib/server/db/schema/index.js");
 const { createEvent } = await import("../../src/lib/server/services/events-mutation.js");
 const { instagramAdapter } = await import("../../src/lib/sources/instagram/server/index.js");
@@ -128,6 +131,7 @@ async function enqueue(eventId: string, userId: string, postId: string): Promise
 
 beforeEach(() => {
   single.next = post();
+  single.throwErr = null;
   single.calls = [];
   throttleState = "ok";
   __resetInstagramRefreshQueueWorkerForTest();
@@ -240,5 +244,29 @@ describe("instagram per-post refresh lane (#69)", () => {
       .where(eq(instagramPosts.postId, tgt.postId))
       .limit(1);
     expect(postRow!.status).toBe("not_found");
+  });
+
+  it("provider error writes a VISIBLE non-ok snapshot (no silent drop), row done (P2-A)", async () => {
+    const u = await seedUserDirectly({ email: `igrq-err-${uniq()}@t.io` });
+    const tgt = await seedIgEvent(u.id, `3601_${uniq()}`);
+    await enqueue(tgt.eventId, u.id, tgt.postId);
+    single.throwErr = new AdapterError("rate limited", { category: "rate-limited" });
+
+    await instagramRefreshQueueTick();
+
+    expect(single.calls).toHaveLength(1);
+    expect(await snapshotCount(tgt.postId)).toBe(0); // non-ok → no metrics row…
+    const [postRow] = await db
+      .select({ status: instagramPosts.lastPollStatus })
+      .from(instagramPosts)
+      .where(eq(instagramPosts.postId, tgt.postId))
+      .limit(1);
+    expect(postRow!.status).toBe("rate_limited"); // …but the failure IS recorded (stamps last_polled_at)
+    const [row] = await db
+      .select({ status: adapterRefreshQueue.status })
+      .from(adapterRefreshQueue)
+      .where(eq(adapterRefreshQueue.userId, u.id))
+      .limit(1);
+    expect(row!.status).toBe("done"); // per-row: marked done, not a batch-wide retry
   });
 });

--- a/tests/integration/instagram-thumbnail-proxy.test.ts
+++ b/tests/integration/instagram-thumbnail-proxy.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { db } from "../../src/lib/server/db/client.js";
+import { instagramPosts } from "../../src/lib/server/db/schema/index.js";
+import { resolveInstagramThumbnailUrl } from "../../src/lib/sources/instagram/server/thumbnail-proxy.js";
+
+// The same-origin thumbnail proxy (#69) must only ever fetch URLs we stored
+// ourselves, host-validated against the Instagram/Facebook CDN. resolve*Url is
+// the SSRF guard: it reads instagram_posts.thumbnail_url by post_id and refuses
+// anything that isn't a known CDN host. The route never takes a URL from the
+// request, so this lookup is the whole attack surface.
+
+const uniq = (): string => Math.random().toString(36).slice(2, 10);
+
+describe("instagram thumbnail proxy — resolveInstagramThumbnailUrl (#69)", () => {
+  it("returns the stored URL for a valid Instagram CDN host", async () => {
+    const postId = `proxy-ok-${uniq()}`;
+    const url = "https://scontent-ord5-3.cdninstagram.com/v/t51.82787-15/x.jpg?oe=6A2AB2C0";
+    await db.insert(instagramPosts).values({ postId, thumbnailUrl: url });
+    expect(await resolveInstagramThumbnailUrl(postId)).toBe(url);
+  });
+
+  it("accepts the fbcdn.net CDN host too", async () => {
+    const postId = `proxy-fb-${uniq()}`;
+    const url = "https://scontent.fbcdn.net/v/x.jpg";
+    await db.insert(instagramPosts).values({ postId, thumbnailUrl: url });
+    expect(await resolveInstagramThumbnailUrl(postId)).toBe(url);
+  });
+
+  it("returns null (SSRF guard) for a non-Instagram host", async () => {
+    const postId = `proxy-evil-${uniq()}`;
+    await db
+      .insert(instagramPosts)
+      .values({ postId, thumbnailUrl: "https://evil.example.com/x.jpg" });
+    expect(await resolveInstagramThumbnailUrl(postId)).toBeNull();
+  });
+
+  it("rejects a look-alike host (suffix guard, not substring)", async () => {
+    const postId = `proxy-lookalike-${uniq()}`;
+    // `cdninstagram.com.evil.com` must NOT pass the `.cdninstagram.com` suffix
+    // check — the leading dot is what prevents the substring-spoof.
+    await db
+      .insert(instagramPosts)
+      .values({ postId, thumbnailUrl: "https://cdninstagram.com.evil.com/x.jpg" });
+    expect(await resolveInstagramThumbnailUrl(postId)).toBeNull();
+  });
+
+  it("returns null for an unknown post and for a thumbnail-less row", async () => {
+    expect(await resolveInstagramThumbnailUrl(`missing-${uniq()}`)).toBeNull();
+    const postId = `proxy-nothumb-${uniq()}`;
+    await db.insert(instagramPosts).values({ postId, thumbnailUrl: null });
+    expect(await resolveInstagramThumbnailUrl(postId)).toBeNull();
+  });
+});

--- a/tests/integration/instagram-warm-eligibility.test.ts
+++ b/tests/integration/instagram-warm-eligibility.test.ts
@@ -23,6 +23,18 @@ vi.mock("../../src/lib/sources/instagram/server/quota.js", async (importOriginal
   return { ...actual, getSocialThrottleState: async () => throttle };
 });
 
+// The warm handler gates on getSocialProvider (#70 P1) — control it so the
+// "throttle ok" tests aren't accidentally skipped by the test env's unconfigured IG.
+let providerConfigured = true;
+vi.mock("../../src/lib/sources/instagram/server/provider/registry.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    getSocialProvider: (p: string) =>
+      providerConfigured && p === "instagram" ? ({ name: "scrapecreators" } as never) : null,
+  };
+});
+
 const { db } = await import("../../src/lib/server/db/client.js");
 const { instagramPosts, adapterRefreshQueue, events } =
   await import("../../src/lib/server/db/schema/index.js");
@@ -80,6 +92,7 @@ async function seedCandidate(userId: string, opts: SeedOpts): Promise<string> {
 
 beforeEach(() => {
   throttle = "ok";
+  providerConfigured = true;
 });
 
 describe("selectWarmInstagramPostIds predicate (#70)", () => {
@@ -197,5 +210,20 @@ describe("handleInstagramWarmRefresh producer (#70)", () => {
       .from(adapterRefreshQueue)
       .where(eq(sql`${adapterRefreshQueue.payload}->>'post_id'`, id));
     expect(rows).toHaveLength(0);
+  });
+
+  it("skips when the provider is unconfigured — lane is disabled, no orphan rows (#70 P1)", async () => {
+    const u = await seedUserDirectly({ email: `warm-h-noprov-${uniq()}@t.io` });
+    const id = await seedCandidate(u.id, { publishedAgoDays: 2, lastPolledAgoHours: 30 });
+    throttle = "ok";
+    providerConfigured = false; // getSocialProvider("instagram") === null
+
+    await handleInstagramWarmRefresh({ id: "warm-job-noprov" });
+
+    const rows = await db
+      .select({ id: adapterRefreshQueue.id })
+      .from(adapterRefreshQueue)
+      .where(eq(sql`${adapterRefreshQueue.payload}->>'post_id'`, id));
+    expect(rows).toHaveLength(0); // never enqueued — the lane could never run it
   });
 });

--- a/tests/integration/instagram-warm-eligibility.test.ts
+++ b/tests/integration/instagram-warm-eligibility.test.ts
@@ -1,0 +1,201 @@
+// Instagram warm auto-refresh — eligibility predicate + producer handler (#70).
+//
+// selectWarmInstagramPostIds is the cost-bounded selection: event-attached posts
+// that are YOUNG (< INSTAGRAM_WARM_WINDOW_DAYS, default 7) AND STALE (last_polled_at
+// older than INSTAGRAM_WARM_STALENESS_HOURS, default 22), minus genuinely-terminal
+// (not_found/private) and persistently-failing (poll_failure_count >= max) posts.
+//
+// The crux (#70 P1-A): auth_error is NOT excluded. IG's HTTP seam collapses
+// transient + budget-exhaustion into auth_error, so excluding it (as YouTube's
+// UNAVAILABLE_POLL_STATUSES does) would freeze a post out of auto-refresh on a
+// single blip. Bounded churn via poll_failure_count instead.
+//
+// Real Postgres via ./helpers.js; selection asserts via toContain on the
+// per-test post ids (the predicate is service-wide, so never assert exact arrays).
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { eq, sql } from "drizzle-orm";
+import { seedUserDirectly } from "./helpers.js";
+
+let throttle: "ok" | "eighty" | "ninetyfive" = "ok";
+vi.mock("../../src/lib/sources/instagram/server/quota.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, getSocialThrottleState: async () => throttle };
+});
+
+const { db } = await import("../../src/lib/server/db/client.js");
+const { instagramPosts, adapterRefreshQueue, events } =
+  await import("../../src/lib/server/db/schema/index.js");
+const { createEvent } = await import("../../src/lib/server/services/events-mutation.js");
+const { selectWarmInstagramPostIds } =
+  await import("../../src/lib/sources/instagram/server/warm-eligibility.js");
+const { handleInstagramWarmRefresh } =
+  await import("../../src/lib/sources/instagram/server/handlers/warm-refresh.js");
+
+const uniq = (): string => Math.random().toString(36).slice(2, 10);
+const DAY = 86_400_000;
+const HOUR = 3_600_000;
+
+interface SeedOpts {
+  publishedAgoDays: number;
+  lastPolledAgoHours: number | null;
+  lastPollStatus?: string | null;
+  pollFailureCount?: number;
+  attachEvent?: boolean; // default true
+  deleteEvent?: boolean; // default false
+}
+
+/** Seed a public-data instagram_posts row with precise polling state + (by
+ *  default) one alive event referencing it. Returns the media id. */
+async function seedCandidate(userId: string, opts: SeedOpts): Promise<string> {
+  const postId = `warm_${uniq()}`;
+  const now = Date.now();
+  await db.insert(instagramPosts).values({
+    postId,
+    permalink: `https://www.instagram.com/p/${uniq()}/`,
+    publishedAt: new Date(now - opts.publishedAgoDays * DAY),
+    lastPolledAt:
+      opts.lastPolledAgoHours === null ? null : new Date(now - opts.lastPolledAgoHours * HOUR),
+    lastPollStatus: opts.lastPollStatus ?? null,
+    pollFailureCount: opts.pollFailureCount ?? 0,
+  });
+  if (opts.attachEvent !== false) {
+    const ev = await createEvent(
+      userId,
+      {
+        kind: "instagram_post",
+        title: "warm",
+        externalId: postId, // no url → E re-derivation skipped; externalId kept verbatim
+        occurredAt: new Date().toISOString(),
+        gameIds: [],
+      },
+      "127.0.0.1",
+    );
+    if (opts.deleteEvent === true) {
+      await db.update(events).set({ deletedAt: new Date() }).where(eq(events.id, ev.id));
+    }
+  }
+  return postId;
+}
+
+beforeEach(() => {
+  throttle = "ok";
+});
+
+describe("selectWarmInstagramPostIds predicate (#70)", () => {
+  it("INCLUDES a young + stale event-attached post", async () => {
+    const u = await seedUserDirectly({ email: `warm-inc-${uniq()}@t.io` });
+    const id = await seedCandidate(u.id, { publishedAgoDays: 2, lastPolledAgoHours: 30 });
+    const warm = await selectWarmInstagramPostIds(new Date());
+    expect(warm).toContain(id);
+  });
+
+  it("EXCLUDES a young post that is still FRESH (kept warm by the free account poll)", async () => {
+    const u = await seedUserDirectly({ email: `warm-fresh-${uniq()}@t.io` });
+    const id = await seedCandidate(u.id, { publishedAgoDays: 2, lastPolledAgoHours: 1 });
+    const warm = await selectWarmInstagramPostIds(new Date());
+    expect(warm).not.toContain(id);
+  });
+
+  it("EXCLUDES a post older than the warm window (frozen)", async () => {
+    const u = await seedUserDirectly({ email: `warm-old-${uniq()}@t.io` });
+    const id = await seedCandidate(u.id, { publishedAgoDays: 10, lastPolledAgoHours: 30 });
+    const warm = await selectWarmInstagramPostIds(new Date());
+    expect(warm).not.toContain(id);
+  });
+
+  it("INCLUDES a never-polled young post (bootstrap)", async () => {
+    const u = await seedUserDirectly({ email: `warm-null-${uniq()}@t.io` });
+    const id = await seedCandidate(u.id, { publishedAgoDays: 1, lastPolledAgoHours: null });
+    const warm = await selectWarmInstagramPostIds(new Date());
+    expect(warm).toContain(id);
+  });
+
+  it("EXCLUDES terminal not_found / private posts (stop paying for a gone post)", async () => {
+    const u = await seedUserDirectly({ email: `warm-term-${uniq()}@t.io` });
+    const gone = await seedCandidate(u.id, {
+      publishedAgoDays: 2,
+      lastPolledAgoHours: 30,
+      lastPollStatus: "not_found",
+    });
+    const priv = await seedCandidate(u.id, {
+      publishedAgoDays: 2,
+      lastPolledAgoHours: 30,
+      lastPollStatus: "private",
+    });
+    const warm = await selectWarmInstagramPostIds(new Date());
+    expect(warm).not.toContain(gone);
+    expect(warm).not.toContain(priv);
+  });
+
+  it("INCLUDES an auth_error post under the failure bound (transient — NOT frozen) (#70 P1-A)", async () => {
+    const u = await seedUserDirectly({ email: `warm-auth-${uniq()}@t.io` });
+    const id = await seedCandidate(u.id, {
+      publishedAgoDays: 2,
+      lastPolledAgoHours: 30,
+      lastPollStatus: "auth_error", // IG collapses transient/budget here — must self-heal
+      pollFailureCount: 1,
+    });
+    const warm = await selectWarmInstagramPostIds(new Date());
+    expect(warm).toContain(id);
+  });
+
+  it("EXCLUDES a post at the poll_failure_count bound (persistent failure stops churn)", async () => {
+    const u = await seedUserDirectly({ email: `warm-bound-${uniq()}@t.io` });
+    const id = await seedCandidate(u.id, {
+      publishedAgoDays: 2,
+      lastPolledAgoHours: 30,
+      lastPollStatus: "auth_error",
+      pollFailureCount: 5, // == INSTAGRAM_WARM_MAX_FAILURES default
+    });
+    const warm = await selectWarmInstagramPostIds(new Date());
+    expect(warm).not.toContain(id);
+  });
+
+  it("EXCLUDES a post with NO alive event (warm refresh is event-attached only)", async () => {
+    const u = await seedUserDirectly({ email: `warm-noevt-${uniq()}@t.io` });
+    const orphan = await seedCandidate(u.id, {
+      publishedAgoDays: 2,
+      lastPolledAgoHours: 30,
+      attachEvent: false,
+    });
+    const deleted = await seedCandidate(u.id, {
+      publishedAgoDays: 2,
+      lastPolledAgoHours: 30,
+      deleteEvent: true,
+    });
+    const warm = await selectWarmInstagramPostIds(new Date());
+    expect(warm).not.toContain(orphan);
+    expect(warm).not.toContain(deleted);
+  });
+});
+
+describe("handleInstagramWarmRefresh producer (#70)", () => {
+  it("at throttle 'ok' enqueues a dedup'd service_post row per warm post", async () => {
+    const u = await seedUserDirectly({ email: `warm-h-ok-${uniq()}@t.io` });
+    const id = await seedCandidate(u.id, { publishedAgoDays: 2, lastPolledAgoHours: 30 });
+    throttle = "ok";
+
+    await handleInstagramWarmRefresh({ id: "warm-job" });
+
+    const rows = await db
+      .select({ id: adapterRefreshQueue.id })
+      .from(adapterRefreshQueue)
+      .where(eq(sql`${adapterRefreshQueue.payload}->>'post_id'`, id));
+    expect(rows).toHaveLength(1);
+  });
+
+  it("at throttle 'eighty' skips entirely (warm is non-essential background spend)", async () => {
+    const u = await seedUserDirectly({ email: `warm-h-80-${uniq()}@t.io` });
+    const id = await seedCandidate(u.id, { publishedAgoDays: 2, lastPolledAgoHours: 30 });
+    throttle = "eighty";
+
+    await handleInstagramWarmRefresh({ id: "warm-job-80" });
+
+    const rows = await db
+      .select({ id: adapterRefreshQueue.id })
+      .from(adapterRefreshQueue)
+      .where(eq(sql`${adapterRefreshQueue.payload}->>'post_id'`, id));
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/tests/integration/polling-badge-render.test.ts
+++ b/tests/integration/polling-badge-render.test.ts
@@ -59,6 +59,7 @@ type EventForBadge = {
   lastPolledAt: Date | string | null;
   lastPollStatus: string | null;
   metadata: Record<string, unknown> | null;
+  externalId?: string | null;
 };
 
 function mkEvent(overrides: Partial<EventForBadge> = {}): EventForBadge {
@@ -179,6 +180,41 @@ describe("PollingBadge — live state", () => {
     // rare edge case (only on rate-limit / auth-error swallow), and when
     // it does happen the user needs a way to retry.
     expect(out.body).toMatch(/class="refresh-now/);
+  });
+
+  it("Manual IG paste (instagram_post, externalId=null, no publishedAt) renders Manual — NOT a never-resolving Pending (#69)", () => {
+    // A user pastes an Instagram post and saves WITHOUT clicking the preview
+    // "Fetch" → the event has no media id (externalId null) and no publishedAt.
+    // Without the #69 fix this rendered "Pending · fetching video info" forever
+    // (pending tier from null publishedAt). An explicit-null externalId on a
+    // pollable kind is a manual entry → "Manual", and no refresh button.
+    const ev = mkEvent({
+      kind: "instagram_post",
+      externalId: null,
+      publishedAt: null,
+      lastPolledAt: null,
+    });
+    const out = render(PollingBadge, { props: { event: ev } });
+    expect(out.body).toMatch(/polling-badge--manual/);
+    expect(out.body).toMatch(/Manual entry/);
+    expect(out.body).not.toMatch(/fetching video info/);
+    expect(out.body).not.toMatch(/class="refresh-now/);
+  });
+
+  it("IG backfill in flight (instagram_post, externalId set, no publishedAt) still renders Pending", () => {
+    // The genuine pending case: an enriched paste / source import has a media id
+    // but the cache row's publishedAt hasn't landed yet. externalId is present,
+    // so this stays "Pending" (a poll WILL resolve it) — the #69 manual-entry
+    // carve-out must not swallow this real state.
+    const ev = mkEvent({
+      kind: "instagram_post",
+      externalId: "media-123",
+      publishedAt: null,
+      lastPolledAt: null,
+    });
+    const out = render(PollingBadge, { props: { event: ev } });
+    expect(out.body).toMatch(/fetching video info/);
+    expect(out.body).not.toMatch(/polling-badge--manual/);
   });
 
   it("Non-pollable kind (kind=conference): component renders nothing", () => {

--- a/tests/unit/instagram-normalizer.test.ts
+++ b/tests/unit/instagram-normalizer.test.ts
@@ -199,7 +199,10 @@ describe("instagram normalizer (provider shape -> NormalizedPost)", () => {
 // video_play_count, thumbnail_src, taken_at_timestamp (unix seconds), owner.
 const XDT_IMAGE = {
   __typename: "XDTGraphImage",
-  id: "111_222",
+  // BARE media pk — the single-post GraphQL endpoint returns no owner suffix
+  // (unlike the feed/reels endpoints). The normalizer must reconstruct the
+  // canonical `<pk>_<owner>` key (#69) so a paste matches the source.
+  id: "111",
   shortcode: "DPhotoCode",
   is_video: false,
   taken_at_timestamp: 1780300000,
@@ -209,7 +212,7 @@ const XDT_IMAGE = {
   edge_media_to_caption: {
     edges: [{ node: { text: "First line of the caption\nSecond line dropped" } }],
   },
-  owner: { id: "owner-1", username: "neonicle_dev" },
+  owner: { id: "222", username: "neonicle_dev" },
 };
 
 const XDT_VIDEO = {
@@ -244,6 +247,9 @@ describe("instagram single-post normalizer (xdt_shortcode_media -> NormalizedSin
   it("XDTGraphImage maps to kind 'image' and reads the nested caption/like/comment counts", () => {
     const post = mapSinglePostToNormalized(XDT_IMAGE, false);
     expect(post.kind).toBe("image");
+    // Canonical id = `<pk>_<owner>` reconstructed from the bare-pk `id` (111) +
+    // owner.id (222), matching the feed/reels key so a paste shares the cache
+    // row + polling with the source-imported post (#69).
     expect(post.id).toBe("111_222");
     expect(post.shortcode).toBe("DPhotoCode");
     // Caption is the FULL multi-line text (the first-line split happens at the
@@ -253,10 +259,23 @@ describe("instagram single-post normalizer (xdt_shortcode_media -> NormalizedSin
     expect(post.metrics.comments).toBe(33);
     expect(post.metrics.views).toBeNull(); // photo → no play_count (D-05)
     expect(post.thumbnailUrl).toBe("https://cdn.example/single-photo.jpg");
-    expect(post.ownerId).toBe("owner-1");
+    expect(post.ownerId).toBe("222");
     expect(post.ownerUsername).toBe("neonicle_dev");
     // taken_at_timestamp is unix SECONDS.
     expect(post.publishedAt.toISOString()).toBe(new Date(1780300000 * 1000).toISOString());
+  });
+
+  it("leaves an already-suffixed single-post id unchanged (defensive, no double-suffix) — #69", () => {
+    const post = mapSinglePostToNormalized(
+      { ...XDT_IMAGE, id: "999_888", owner: { id: "888", username: "x" } },
+      false,
+    );
+    expect(post.id).toBe("999_888");
+  });
+
+  it("falls back to the bare pk when the single-post response carries no owner id — #69", () => {
+    const post = mapSinglePostToNormalized({ ...XDT_IMAGE, id: "777", owner: null }, false);
+    expect(post.id).toBe("777");
   });
 
   it("XDTGraphVideo on a /p/ URL (isReelUrl=false) maps to 'video' and reads video_play_count", () => {

--- a/tests/unit/instagram-thumbnail-url.test.ts
+++ b/tests/unit/instagram-thumbnail-url.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveThumbnailUrl,
+  type CardEventLite,
+} from "../../src/lib/components/feed/parts/derive-card-data.js";
+
+// deriveThumbnailUrl for instagram_post must point at the same-origin proxy
+// (IG's CDN sends CORP: same-origin → raw hotlink blocked, #69) and version the
+// URL by the latest poll timestamp so Refresh-Now (or any re-poll) busts the
+// browser cache and the fresh cover appears, while serving from cache between
+// polls.
+
+const base: CardEventLite = {
+  id: "e1",
+  kind: "instagram_post",
+  gameIds: [],
+  externalId: "111_222",
+  metadata: null,
+  occurredAt: new Date("2026-06-03T08:00:00Z"),
+  authorIsMe: false,
+  title: "t",
+  notes: null,
+  url: null,
+  sourceId: null,
+  lastPolledAt: null,
+  lastPollStatus: null,
+};
+
+describe("deriveThumbnailUrl — instagram proxy + cache-buster (#69)", () => {
+  it("returns the same-origin proxy URL versioned by the latest poll timestamp", () => {
+    const polledAt = new Date("2026-06-07T04:41:00Z");
+    const url = deriveThumbnailUrl({
+      ...base,
+      instagramEnrichment: {
+        stats: { viewCount: null, likeCount: 3, commentCount: 0, polledAt },
+        thumbnailUrl: "https://scontent.cdninstagram.com/v/x.jpg",
+        mediaType: "carousel",
+      },
+    });
+    expect(url).toBe(`/api/instagram/thumbnail/111_222?v=${polledAt.getTime()}`);
+  });
+
+  it("omits the ?v cache-buster when there is no snapshot yet", () => {
+    const url = deriveThumbnailUrl({
+      ...base,
+      instagramEnrichment: {
+        stats: null,
+        thumbnailUrl: "https://scontent.cdninstagram.com/v/x.jpg",
+        mediaType: "image",
+      },
+    });
+    expect(url).toBe("/api/instagram/thumbnail/111_222");
+  });
+
+  it("returns null when there is no cached thumbnail", () => {
+    const url = deriveThumbnailUrl({
+      ...base,
+      instagramEnrichment: { stats: null, thumbnailUrl: null, mediaType: null },
+    });
+    expect(url).toBeNull();
+  });
+
+  it("returns null when the event has no externalId (cannot key the proxy)", () => {
+    const url = deriveThumbnailUrl({
+      ...base,
+      externalId: null,
+      instagramEnrichment: {
+        stats: null,
+        thumbnailUrl: "https://scontent.cdninstagram.com/v/x.jpg",
+        mediaType: "image",
+      },
+    });
+    expect(url).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Started as the #69 bug (pasted IG posts stuck on `Pending` with no stats) and grew, through live UAT, into three connected fixes: **paste enrichment**, **thumbnail display**, and a **per-post Refresh** rework. Root cause throughout: Instagram is the only kind where URL identity (shortcode) ≠ media identity (`post.id`), and IG's CDN/refresh behave unlike YouTube/Reddit.

## 1. Paste enrichment (the original #69)
- The preview resolves the media id but the form discarded it → `createEvent` fell back to the URL shortcode, which never matched the snapshot cache. Now the previewed `externalId` round-trips form → schema → `createEvent`.
- IG `external_id` is now ALWAYS the media id or null, never the shortcode: recognition-only / no-fetch paths return null (a bare card, not a never-resolving `Pending`); `createEvent` excludes `instagram_post` from URL-shortcode derivation.
- Single-post media id canonicalized to `<pk>_<owner>` so a paste matches the same post imported from a source (shared cache row + polling).
- No-fetch IG paste shows the **Manual** badge, not a stuck `Pending`.
- Saved URL canonicalized from the preview (strips IG tracking tails / `?img_index`).

## 2. Thumbnails (IG anti-hotlink)
- IG's `cdninstagram.com` serves images with `Cross-Origin-Resource-Policy: same-origin` → the browser blocks a cross-origin `<img>` (confirmed via headless Chromium + response headers). YouTube/Reddit CDNs send CORP `cross-origin`, so only IG broke.
- New same-origin proxy `GET /api/instagram/thumbnail/:postId` (adapter `registerRoutes`): re-serves the bytes from our origin. Auth-gated; NOT an open proxy (URL read from our DB by post_id, host-validated `*.cdninstagram.com`/`*.fbcdn.net`; `redirect:"manual"` + timeout — no SSRF). Cached 1h, versioned by poll timestamp so Refresh busts it. Dropped the pointless `crossorigin` attr on the shared feed-card thumbnail.

## 3. Per-post Refresh (architecture rework)
- IG's manual Refresh did an account-level walk (re-snapshotted neighbours, couldn't reach old posts, no dedup). Now it goes through the shared `adapter_refresh_queue` like YouTube/Reddit: `enqueueRefreshNow` INSERTs one `user_post` row per clicked post (via the tx — fixes a prior `boss.send`-outside-tx violation; cooldown-only dedup, mirroring the other adapters).
- New IG lane worker (`createAdapterBatchLaneWorker`): single-post endpoint can't batch, so scale = **concurrency** — `maxBatchSize = env.SOCIAL_REFRESH_LANE_CONCURRENCY` (default 10), `batchScope:"global"`, `dispatch` = `Promise.allSettled` of N concurrent fetches + per-row ok/non-ok snapshot, never throws (no batch-wide retry). `claimGate` is a throttle gate only — the credit reserve is inside `fetchPostByUrl`, so no double-charge. Tenant-scoped resolve with a null-userId guard. `workQueue` declaration auto-starts via the generic bootstrap; `isEnabled` gates it off when the provider is unconfigured.
- Scheduled hot/cold polling (source-level, batched) is unchanged — only refresh-now moved to per-post.
- Issue 2 (chart "redraws from 0" on each Refresh reload): per-post already cut the poll-loop to ~1-3 iterations; the residual was svelte-echarts applying options with `notMerge:true` (resets + replays the entry animation). `EventHistoryChart` now sets `animation:false` (scoped — not the shared `baseChartOptions`); legend toggle still works.

## Test plan
- New: `events-external-id-derivation`, `add-event-external-id-wiring`, `feed-card-thumbnail-cors`, `instagram-thumbnail-proxy` (incl. look-alike-host SSRF guard), `instagram-thumbnail-url`, `instagram-refresh-queue` (7: enqueue row / targeted-post-only / claimGate defer@95% / tenant-scope skip / global concurrency / null→not_found / error→visible non-ok), `event-history-chart-animation`.
- Updated: `instagram-paste-preview`, `events`, `instagram-normalizer`, `polling-badge-render`, `anonymous-401` (new route allowlisted).
- `pnpm typecheck` 0 errors; `pnpm lint` clean; full `pnpm test:integration` green except the pre-existing Reddit-403 env failures (this dev IP is fenced; they pass in CI via the mock). Browser tests green.

## Self-review
Walked Principles / Tenant scoping (P0) / Don'ts. No new unscoped tenant queries (the lane worker resolves events by userId; IG public-data tables are allowlisted); proxy is auth-gated + SSRF-guarded; no double-charge; no `boss.send` outside a mutating tx (fixed one); no denormalization (snapshot writes the intrinsic `ownerId`, never the renameable handle); comments are why-not-what. YouTube/Reddit refresh + thumbnails are unaffected (IG-scoped branches).

## Self-review (multi-pass, separate agents)
Five fresh-context subagent reviews across the PR + two plan reviews for the refresh rework. Net: no P0/P1. Fixes applied in-branch from review findings — recognition-only null, proxy SSRF hardening (`redirect:"manual"` + timeout), and the refresh dispatch writing a visible non-ok snapshot on unexpected errors (P2-A). Deferred (PR-note): balance-exhausted refresh rows stay `pending` until the operator refills (bounded — `canRun` blocks new enqueues at 95%); a behavioral chart-render test.

The IG-refresh rework follows the project's adapter convention (uniform `adapter_refresh_queue` + per-adapter lane worker) per `src/lib/sources/CHECKLIST.md`.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)