### PR TITLE
fix(sources): accept scheme-less handle URLs in Add-Source

### DIFF
--- a/src/lib/components/sources/AddSourceModal.svelte
+++ b/src/lib/components/sources/AddSourceModal.svelte
@@ -28,7 +28,10 @@
   import { m } from "$lib/paraglide/messages.js";
   import InlineError from "$lib/components/InlineError.svelte";
   import BackfillPicker from "$lib/components/BackfillPicker.svelte";
-  import { inferSourceKindFromUrl } from "$lib/components/sources/infer-source-kind.js";
+  import {
+    inferSourceKindFromUrl,
+    normalizeHandleUrl,
+  } from "$lib/components/sources/infer-source-kind.js";
 
   // Mirror the synthetic UI kind picker from /sources/new — "reddit" is
   // resolved server-side to reddit_account / reddit_subreddit by URL
@@ -238,14 +241,14 @@
     e.preventDefault();
     if (submitting) return;
     if (handleUrl.trim().length === 0) return;
-    if (!handleUrl.trim().startsWith("https://")) {
-      formError = m.ingest_error_malformed_url();
-      return;
-    }
     if (submitKind === null) {
       formError = m.add_source_link_unrecognized();
       return;
     }
+    // URL-first: accept scheme-less host/paths ("t.me/durov") and raw handles —
+    // normalize to an absolute URL the server's parseSourceUrl can read. The
+    // detector already matched a kind above, so this is a recognized link.
+    const normalizedUrl = normalizeHandleUrl(handleUrl);
     submitting = true;
     formError = null;
     try {
@@ -254,7 +257,7 @@
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
           kind: submitKind,
-          handleUrl: handleUrl.trim(),
+          handleUrl: normalizedUrl,
           metadata: description.trim() ? { description: description.trim() } : undefined,
           isOwnedByMe,
           autoImport,
@@ -375,9 +378,13 @@
 
       <label class="field">
         <span class="label">Handle URL *</span>
+        <!-- type="text" (not "url"): the field accepts scheme-less host/paths and
+             raw @handles per the placeholder; type="url" would natively reject
+             "t.me/durov" before submit (the normalize step adds the scheme). -->
         <input
           class="input"
-          type="url"
+          type="text"
+          inputmode="url"
           bind:value={handleUrl}
           required
           placeholder="https://t.me/channel · youtube.com/@handle · reddit.com/r/sub"

--- a/src/lib/components/sources/infer-source-kind.ts
+++ b/src/lib/components/sources/infer-source-kind.ts
@@ -95,3 +95,38 @@ export function inferSourceKindFromUrl(input: string): InferredSourceKind | null
   }
   return matchSubstring(input.toLowerCase());
 }
+
+/**
+ * Normalize a pasted Handle URL into a submittable form for POST /api/sources.
+ *
+ * The Add-Source surfaces are URL-first and the placeholder advertises
+ * SCHEME-LESS input ("youtube.com/@handle", "reddit.com/r/sub", "t.me/channel").
+ * The server's parseSourceUrl iterator needs a parseable ABSOLUTE URL for a
+ * host/path input (`new URL()` rejects a missing scheme), so prepend `https://`
+ * when the input looks like a host/path with no scheme — otherwise a perfectly
+ * valid paste like `t.me/durov` dead-ends at "enter a URL" (the input was
+ * `type="url"`, which natively rejects a scheme-less value too).
+ *
+ * A raw `@handle` / bare handle (no `/`, `.`, or `:`) is left UNTOUCHED — the
+ * per-kind server parser resolves those directly (e.g. telegram `@durov`), and
+ * prepending a scheme would make `https://@durov` (invalid). Already-schemed
+ * input is returned as-is, with `http://` upgraded to `https://` (the app is
+ * https-only). Empty input returns "".
+ *
+ * Pure + client-safe (no server imports), same as inferSourceKindFromUrl — the
+ * server's parseSourceUrl iterator remains the validation source of truth.
+ */
+export function normalizeHandleUrl(input: string): string {
+  const trimmed = input.trim();
+  if (trimmed === "") return "";
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed.replace(/^http:\/\//i, "https://");
+  }
+  // Raw `@handle` / bare handle — no path/host/scheme separators. The per-kind
+  // server parser handles these; a scheme prefix would corrupt them.
+  if (!trimmed.includes("/") && !trimmed.includes(".") && !trimmed.includes(":")) {
+    return trimmed;
+  }
+  // Scheme-less host/path (e.g. "t.me/channel", "youtube.com/@h") → absolute.
+  return `https://${trimmed}`;
+}

--- a/src/routes/sources/new/+page.svelte
+++ b/src/routes/sources/new/+page.svelte
@@ -24,7 +24,10 @@
   import { m } from "$lib/paraglide/messages.js";
   import InlineError from "$lib/components/InlineError.svelte";
   import BackfillPicker from "$lib/components/BackfillPicker.svelte";
-  import { inferSourceKindFromUrl } from "$lib/components/sources/infer-source-kind.js";
+  import {
+    inferSourceKindFromUrl,
+    normalizeHandleUrl,
+  } from "$lib/components/sources/infer-source-kind.js";
   import type {
     AddSourceUiKind,
     KindLabelKey,
@@ -162,14 +165,14 @@
     e.preventDefault();
     if (submitting) return;
     if (handleUrl.trim().length === 0) return;
-    if (!handleUrl.trim().startsWith("https://")) {
-      formError = m.ingest_error_malformed_url();
-      return;
-    }
     if (submitKind === null) {
       formError = m.add_source_link_unrecognized();
       return;
     }
+    // URL-first: accept scheme-less host/paths ("t.me/durov") and raw handles —
+    // normalize to an absolute URL the server's parseSourceUrl can read. The
+    // detector already matched a kind above, so this is a recognized link.
+    const normalizedUrl = normalizeHandleUrl(handleUrl);
     submitting = true;
     formError = null;
     try {
@@ -178,7 +181,7 @@
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
           kind: submitKind,
-          handleUrl: handleUrl.trim(),
+          handleUrl: normalizedUrl,
           // Description stored in metadata.description (no schema change
           // — jsonb column accepts arbitrary keys).
           metadata: description.trim() ? { description: description.trim() } : undefined,
@@ -289,9 +292,13 @@
 
     <label class="field">
       <span class="label">Handle URL *</span>
+      <!-- type="text" (not "url"): the field accepts scheme-less host/paths and
+           raw @handles per the placeholder; type="url" would natively reject
+           "t.me/durov" before submit (the normalize step adds the scheme). -->
       <input
         class="input"
-        type="url"
+        type="text"
+        inputmode="url"
         bind:value={handleUrl}
         required
         placeholder="https://t.me/channel · youtube.com/@handle · reddit.com/r/sub"

--- a/tests/unit/infer-source-kind.test.ts
+++ b/tests/unit/infer-source-kind.test.ts
@@ -4,7 +4,10 @@
 // validation gate (the server's parseSourceUrl iterator is the source of
 // truth on submit).
 import { describe, it, expect } from "vitest";
-import { inferSourceKindFromUrl } from "../../src/lib/components/sources/infer-source-kind.js";
+import {
+  inferSourceKindFromUrl,
+  normalizeHandleUrl,
+} from "../../src/lib/components/sources/infer-source-kind.js";
 
 describe("inferSourceKindFromUrl", () => {
   it("maps youtube.com and youtu.be to youtube_channel", () => {
@@ -60,5 +63,42 @@ describe("inferSourceKindFromUrl", () => {
     expect(inferSourceKindFromUrl("not a url at all")).toBeNull();
     expect(inferSourceKindFromUrl("https://example.com/")).toBeNull();
     expect(inferSourceKindFromUrl("ftp://files.local/x")).toBeNull();
+  });
+});
+
+describe("normalizeHandleUrl", () => {
+  it("prepends https:// to a scheme-less host/path (the t.me/durov regression)", () => {
+    // The exact paste that dead-ended at the browser's type=url "enter a URL"
+    // popup: a scheme-less channel link. After normalization the server's
+    // telegramParseSourceUrl (which `new URL()`-parses) accepts it.
+    expect(normalizeHandleUrl("t.me/durov")).toBe("https://t.me/durov");
+    expect(normalizeHandleUrl("youtube.com/@handle")).toBe("https://youtube.com/@handle");
+    expect(normalizeHandleUrl("reddit.com/r/IndieDev")).toBe("https://reddit.com/r/IndieDev");
+    expect(normalizeHandleUrl("t.me/d954mas_make_games")).toBe("https://t.me/d954mas_make_games");
+  });
+
+  it("leaves an already-https URL unchanged", () => {
+    expect(normalizeHandleUrl("https://t.me/durov")).toBe("https://t.me/durov");
+    expect(normalizeHandleUrl("https://www.youtube.com/@handle")).toBe(
+      "https://www.youtube.com/@handle",
+    );
+  });
+
+  it("upgrades http:// to https:// (the app is https-only)", () => {
+    expect(normalizeHandleUrl("http://t.me/durov")).toBe("https://t.me/durov");
+    expect(normalizeHandleUrl("HTTP://t.me/durov")).toBe("https://t.me/durov");
+  });
+
+  it("leaves a raw @handle / bare handle untouched (no scheme to prepend onto)", () => {
+    // Prepending https:// would corrupt these into https://@durov; the per-kind
+    // server parser resolves a raw handle directly (telegram @durov).
+    expect(normalizeHandleUrl("@durov")).toBe("@durov");
+    expect(normalizeHandleUrl("durov")).toBe("durov");
+  });
+
+  it("trims surrounding whitespace and returns '' for empty/whitespace input", () => {
+    expect(normalizeHandleUrl("  t.me/durov  ")).toBe("https://t.me/durov");
+    expect(normalizeHandleUrl("")).toBe("");
+    expect(normalizeHandleUrl("   ")).toBe("");
   });
 });


### PR DESCRIPTION
## Summary

- The URL-first Add-Source surfaces (modal + `/sources/new`) advertise **scheme-less** input in the placeholder (`youtube.com/@handle`, `reddit.com/r/sub`, `t.me/channel`) and the kind detector matches it — but the URL field was `type="url"` (the browser natively rejects a scheme-less value with an "enter a URL" popup) and submit hard-required `startsWith("https://")`. So pasting `t.me/durov` lit the "✓ detected Telegram" chip yet dead-ended at validation, never reaching the server. Found in Phase 9 Telegram UAT.
- Fix: a pure, client-safe `normalizeHandleUrl` — prepend `https://` to a scheme-less host/path, leave a raw `@handle`/bare handle for the per-kind server parser, upgrade `http`→`https`. Switch the input to `type="text"` + `inputmode="url"`, and POST the normalized URL. The server's `parseSourceUrl` iterator stays the validation source of truth.
- Applied identically to `AddSourceModal.svelte` + `/sources/new/+page.svelte` (the two surfaces must not diverge).

## Test plan

- New unit tests for `normalizeHandleUrl` (scheme-less host/path incl. the `t.me/...` regression, already-https unchanged, `http`→`https` upgrade, raw `@handle`/bare handle untouched, whitespace/empty).
- Full local gate: typecheck **0 errors**, eslint + prettier clean, unit **767/767**.
- Client-only change (no server / DB / adapter code) — integration suite unaffected; CI runs it regardless.
- Manual: pasting `t.me/<channel>` (no scheme) now both detects Telegram **and** submits successfully.
