### PR TITLE
fix(sources): show Telegram channel name (not URL) across /sources + /feed

### DIFF
--- a/src/lib/components/SourceRow.svelte
+++ b/src/lib/components/SourceRow.svelte
@@ -43,6 +43,7 @@
   import BackfillPicker from "./BackfillPicker.svelte";
   import RetentionBadge from "./RetentionBadge.svelte";
   import { type SourceKind } from "$lib/util/source-kind-label.js";
+  import { telegramHandleFromUrl } from "$lib/util/telegram-handle.js";
 
   type BackfillWindow = "1d" | "7d" | "30d" | "90d" | "1y" | "everything";
 
@@ -359,8 +360,12 @@
   const handleLabel = $derived.by((): string => {
     if (source.channelTitle) return source.channelTitle;
     if (source.displayName) return source.displayName;
-    const derived = deriveRedditHandle(source.kind, source.handleUrl);
-    if (derived) return derived;
+    const reddit = deriveRedditHandle(source.kind, source.handleUrl);
+    if (reddit) return reddit;
+    if (source.kind === "telegram_channel") {
+      const telegram = telegramHandleFromUrl(source.handleUrl);
+      if (telegram) return telegram;
+    }
     return source.handleUrl;
   });
 

--- a/src/lib/components/feed/parts/derive-card-data.ts
+++ b/src/lib/components/feed/parts/derive-card-data.ts
@@ -24,6 +24,8 @@
 //     reflects everywhere immediately; event.channelTitle is the
 //     fallback for unregistered channels.
 
+import { telegramHandleFromUrl } from "$lib/util/telegram-handle.js";
+
 export type CardEventKind =
   | "youtube_video"
   | "reddit_post"
@@ -177,7 +179,12 @@ export function instagramHandleLabel(source: CardSourceLite | null): string {
  *  telegramChannelLabel below is the URL-intrinsic numeric/slug key, a
  *  different concern — this is the renameable display surface.) */
 export function telegramChannelHandleLabel(source: CardSourceLite | null): string {
-  return source?.channelTitle ?? source?.displayName ?? source?.handleUrl ?? "";
+  if (source?.channelTitle) return source.channelTitle;
+  if (source?.displayName) return source.displayName;
+  // Fallback for a not-yet-polled channel (no telegram_channels entity title
+  // resolved yet): show the @handle from the t.me URL, never the raw URL.
+  // Shared with SourceRow + the /sources/[id] heading via telegramHandleFromUrl.
+  return telegramHandleFromUrl(source?.handleUrl) ?? source?.handleUrl ?? "";
 }
 
 /** Read the Twitter @handle from event metadata. The handle is part of

--- a/src/lib/server/services/sources-page-read.ts
+++ b/src/lib/server/services/sources-page-read.ts
@@ -13,7 +13,7 @@
 
 import { and, eq, isNull, inArray, sql, gte, max, count } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { youtubeChannels } from "../db/schema/index.js";
+import { youtubeChannels, telegramChannels } from "../db/schema/index.js";
 import { dataSourceChannelState } from "../db/schema/data-source-channel-state.js";
 import {
   redditSubredditsCache,
@@ -63,6 +63,7 @@ export async function loadSourcesPage(userId: string): Promise<SourcesPageData> 
   const sourceIds = dtos.map((s) => s.id);
 
   await enrichDataSourceDtosWithYoutubeChannelTitles(dtos);
+  await enrichTelegramSourcesWithChannelTitle(dtos);
   await enrichWithChannelState(dtos);
   await enrichWithChannelState(dtos, telegramChannelKey);
   await enrichRedditSourcesWithLastPolled(dtos);
@@ -95,6 +96,7 @@ export async function loadSourceDetailPage(
   const channelIds = dto.channelId === null ? [] : [dto.channelId];
 
   await enrichDataSourceDtosWithYoutubeChannelTitles([dto]);
+  await enrichTelegramSourcesWithChannelTitle([dto]);
   await enrichWithChannelState([dto]);
   await enrichWithChannelState([dto], telegramChannelKey);
   await enrichRedditSourcesWithLastPolled([dto]);
@@ -129,6 +131,44 @@ export async function enrichDataSourceDtosWithYoutubeChannelTitles(
   for (const r of cache) titleByChannel.set(r.channelId, r.channelTitle);
   for (const s of dtos) {
     if (s.channelId) s.channelTitle = titleByChannel.get(s.channelId) ?? null;
+  }
+}
+
+/**
+ * Telegram sources have no channelId — the channel title lives on the
+ * telegram_channels ENTITY (keyed by channel_key, upserted from the listing
+ * header on every poll), deliberately NOT denormalized onto data_sources (the
+ * no-denorm rule). So /sources would fall back to the raw t.me URL. Read the
+ * entity title by slug (data_sources.metadata.channel) and stamp it onto
+ * dto.channelTitle — the SAME field YouTube uses — so SourceRow's
+ * channelTitle-first precedence renders the channel name (e.g. "d954mas | …")
+ * instead of the URL. Mirrors enrichDataSourceDtosWithYoutubeChannelTitles.
+ *
+ * A never-polled channel has no entity row yet → channelTitle stays null and
+ * SourceRow falls back to the @handle (deriveTelegramHandle), never the bare URL.
+ * Joining on the slug (the user-registered handle === the current entity slug in
+ * the common case) is consistent with how the walker keys telegram channel-state.
+ */
+export async function enrichTelegramSourcesWithChannelTitle(dtos: DataSourceDto[]): Promise<void> {
+  const slugs: string[] = [];
+  for (const s of dtos) {
+    if (s.kind !== "telegram_channel") continue;
+    const md = (s.metadata ?? {}) as { channel?: unknown };
+    if (typeof md.channel === "string" && md.channel) slugs.push(md.channel);
+  }
+  if (slugs.length === 0) return;
+  const rows = await db
+    .select({ slug: telegramChannels.slug, title: telegramChannels.title })
+    .from(telegramChannels)
+    .where(inArray(telegramChannels.slug, slugs));
+  const titleBySlug = new Map<string, string | null>();
+  for (const r of rows) if (r.slug !== null) titleBySlug.set(r.slug, r.title);
+  for (const s of dtos) {
+    if (s.kind !== "telegram_channel") continue;
+    const md = (s.metadata ?? {}) as { channel?: unknown };
+    if (typeof md.channel === "string" && md.channel) {
+      s.channelTitle = titleBySlug.get(md.channel) ?? null;
+    }
   }
 }
 

--- a/src/lib/sources/telegram/server/parse.ts
+++ b/src/lib/sources/telegram/server/parse.ts
@@ -160,7 +160,11 @@ function parseBlock(el: HTMLElement): ParsedTelegramPost | null {
   if (!dataPost) return null;
   const slash = dataPost.indexOf("/");
   if (slash <= 0 || slash === dataPost.length - 1) return null;
-  const slug = dataPost.slice(0, slash);
+  // Lowercase per the "slugs are lowercase everywhere" invariant (url.ts:44-49):
+  // url.ts lowercases the URL-parsed handle, so the slug we store on external_url
+  // must match — else resolveCachedExternalId's external_url lookup misses for an
+  // uppercase @Username channel.
+  const slug = dataPost.slice(0, slash).toLowerCase();
   const messageId = dataPost.slice(slash + 1);
 
   // channelKey is the rename-proof prefix of the stable post id. When it cannot
@@ -260,7 +264,12 @@ function parseChannelHeaderFromRoot(
   // leading '@' for the stored slug.
   const usernameEl = root.querySelector(".tgme_channel_info_header_username a");
   const usernameRaw = usernameEl?.text?.trim() ?? "";
-  const slug = usernameRaw.replace(/^@/, "") || null;
+  // Lowercase per the "slugs are lowercase everywhere" invariant (url.ts:44-49):
+  // data_sources.metadata.channel is lowercased at parse, so the stored
+  // telegram_channels.slug must match — else the channel-name JOIN
+  // (enrichTelegramSourcesWithChannelTitle) silently misses for an uppercase
+  // @Username and the source/feed cards degrade to the @handle forever.
+  const slug = usernameRaw.replace(/^@/, "").toLowerCase() || null;
 
   // og:image is the channel avatar on the listing page (a stable hotlink).
   const ogImage = root.querySelector('meta[property="og:image"]')?.getAttribute("content")?.trim();

--- a/src/lib/util/telegram-handle.ts
+++ b/src/lib/util/telegram-handle.ts
@@ -1,0 +1,18 @@
+// Client-safe pure helper: derive the "@handle" from a t.me channel/post URL.
+//
+// ONE home for the t.me-URL slug shape, used by all three name-rendering
+// surfaces so they agree on the "@durov" fallback shown when no channel title
+// is resolved yet (a just-added, not-yet-polled channel):
+//   - SourceRow (the /sources list)
+//   - the /sources/[id] detail-page heading
+//   - telegramChannelHandleLabel (the /feed card)
+//
+// The server has a richer parser (telegram/server/url.ts) but it can't be
+// imported into the client bundle (it pulls in adapter/DB types), so this
+// mirrors the minimal slug shape — exactly as infer-source-kind.ts mirrors the
+// host table for the same client-can't-import-server reason.
+export function telegramHandleFromUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  const m = url.match(/t\.me\/(?:s\/)?([^/?#]+)/i);
+  return m ? `@${m[1]}` : null;
+}

--- a/src/routes/feed/+page.server.ts
+++ b/src/routes/feed/+page.server.ts
@@ -11,7 +11,10 @@ import { listGames, deriveReleaseInfoForGames } from "$lib/server/services/games
 import { listSources } from "$lib/server/services/data-sources.js";
 import { mapEventsToDtos, toGameDto, toDataSourceDto } from "$lib/server/dto.js";
 import { allAdapters } from "$lib/sources/registry.js";
-import { enrichDataSourceDtosWithYoutubeChannelTitles } from "$lib/server/services/sources-page-read.js";
+import {
+  enrichDataSourceDtosWithYoutubeChannelTitles,
+  enrichTelegramSourcesWithChannelTitle,
+} from "$lib/server/services/sources-page-read.js";
 import { NotFoundError } from "$lib/server/services/errors.js";
 import { parseSearchParams } from "$lib/feed/url-state.js";
 import { dateRangeWindow, parseEventDate } from "$lib/feed/date-range.js";
@@ -215,9 +218,13 @@ export const load: PageServerLoad = async ({ locals, url }) => {
     }
   }
 
-  // Enrich source DTOs with the YouTube channel_title from cache.
+  // Enrich source DTOs with the channel display name the feed cards read:
+  // YouTube channel_title + Telegram entity title (both via FK at read time, the
+  // no-denorm path). Instagram needs no enrichment — its account name is stored
+  // on data_sources.display_name at create, which the card reads directly.
   const sourceDtos = sourceRows.map(toDataSourceDto);
   await enrichDataSourceDtosWithYoutubeChannelTitles(sourceDtos);
+  await enrichTelegramSourcesWithChannelTitle(sourceDtos);
 
   // GameDto.releaseDate / .releaseTba derived via JOIN with
   // game_steam_listings — the games row no longer carries the columns

--- a/src/routes/sources/[id]/+page.svelte
+++ b/src/routes/sources/[id]/+page.svelte
@@ -9,6 +9,7 @@
   import SourceCoverageBadge from "$lib/components/SourceCoverageBadge.svelte";
   import { invalidateAll } from "$app/navigation";
   import { m } from "$lib/paraglide/messages.js";
+  import { telegramHandleFromUrl } from "$lib/util/telegram-handle.js";
   import type { PageData } from "./$types";
 
   let { data }: { data: PageData } = $props();
@@ -36,10 +37,17 @@
       }
     };
   });
-  // Heading prefers canonical channel title from cache (always more
-  // identifiable than the user-typed displayName). displayName is legacy
-  // — UI doesn't surface it anymore.
-  const heading = $derived(source.channelTitle ?? source.handleUrl);
+  // Heading precedence mirrors the /sources list row (SourceRow.handleLabel) so
+  // the list and this detail heading never disagree: canonical channel title
+  // (FK-resolved, most identifiable) → legacy displayName → Telegram @handle
+  // (so a not-yet-polled telegram channel shows "@durov", not the raw URL) →
+  // the raw handle URL as last resort.
+  const heading = $derived(
+    source.channelTitle ??
+      source.displayName ??
+      telegramHandleFromUrl(source.handleUrl) ??
+      source.handleUrl,
+  );
 
   // ---- date picker (target_since) ----
   const SENTINEL_ISO = "1970-01-01";

--- a/tests/unit/sources/telegram/parse.test.ts
+++ b/tests/unit/sources/telegram/parse.test.ts
@@ -384,3 +384,30 @@ describe("parseTelegramChannelHeader — the channel subject entity (Phase 9)", 
     expect(h.subscriberCount).toBeNull();
   });
 });
+
+describe("slug lowercasing (the slugs-are-lowercase invariant, url.ts:44-49)", () => {
+  // url.ts lowercases the URL-parsed handle, so parse.ts MUST lowercase the
+  // scraped slug too — else data_sources.metadata.channel (always lowercase)
+  // won't match telegram_channels.slug (the channel-name JOIN), and external_url
+  // won't match resolveCachedExternalId's lowercased lookup. Every other fixture
+  // here is already lowercase, so without these cases a revert of the
+  // .toLowerCase() calls would pass green (the regression-guard gap the review
+  // flagged).
+  it("parseTelegramChannelHeader lowercases an uppercase @Username slug (NOT the title)", () => {
+    const html =
+      '<div class="tgme_channel_info_header_title">Durov Channel</div>' +
+      '<div class="tgme_channel_info_header_username"><a href="https://t.me/Durov">@Durov</a></div>';
+    const h = parseTelegramChannelHeader(html);
+    expect(h.slug).toBe("durov");
+    expect(h.title).toBe("Durov Channel"); // display title keeps its original case
+  });
+
+  it("parseTelegramPost lowercases the data-post slug", () => {
+    const html =
+      '<div class="tgme_widget_message" data-post="Durov/503">' +
+      '<div class="tgme_widget_message_text">hello</div></div>';
+    const post = parseTelegramPost(html);
+    expect(post?.slug).toBe("durov");
+    expect(post?.messageId).toBe("503");
+  });
+});

--- a/tests/unit/telegram-channel-handle-label.test.ts
+++ b/tests/unit/telegram-channel-handle-label.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import {
+  telegramChannelHandleLabel,
+  type CardSourceLite,
+} from "../../src/lib/components/feed/parts/derive-card-data.js";
+
+// telegramChannelHandleLabel is the Telegram feed card's source label. Precedence
+// (mirrors SourceRow.handleLabel so /feed and /sources agree):
+//   channelTitle (telegram_channels entity, FK at read) → displayName (legacy
+//   user label) → @handle from the t.me URL → raw URL (last resort). The @handle
+//   fallback keeps a not-yet-polled channel (no entity title) from showing the
+//   bare URL.
+
+const base: CardSourceLite = {
+  id: "s1",
+  displayName: null,
+  handleUrl: "https://t.me/d954mas_make_games",
+  channelTitle: null,
+};
+
+describe("telegramChannelHandleLabel", () => {
+  it("prefers the entity channelTitle over everything", () => {
+    expect(
+      telegramChannelHandleLabel({
+        ...base,
+        channelTitle: "d954mas | весело и просто делаю игры",
+        displayName: "ignored",
+      }),
+    ).toBe("d954mas | весело и просто делаю игры");
+  });
+
+  it("falls back to displayName when channelTitle is null", () => {
+    expect(telegramChannelHandleLabel({ ...base, displayName: "My label" })).toBe("My label");
+  });
+
+  it("falls back to @handle (not the raw URL) for a not-yet-polled channel", () => {
+    // The @handle URL-parsing edge cases live in telegram-handle.test.ts; here we
+    // only assert this label COMPOSES that fallback after the title/displayName
+    // precedence.
+    expect(telegramChannelHandleLabel(base)).toBe("@d954mas_make_games");
+  });
+
+  it("returns the raw value when the URL is not a t.me link (defensive last resort)", () => {
+    expect(telegramChannelHandleLabel({ ...base, handleUrl: "https://example.com/x" })).toBe(
+      "https://example.com/x",
+    );
+  });
+
+  it("returns '' for a null source", () => {
+    expect(telegramChannelHandleLabel(null)).toBe("");
+  });
+});

--- a/tests/unit/telegram-handle.test.ts
+++ b/tests/unit/telegram-handle.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { telegramHandleFromUrl } from "../../src/lib/util/telegram-handle.js";
+
+// telegramHandleFromUrl is the ONE home for the t.me-URL "@handle" shape, shared
+// by SourceRow (/sources list), the /sources/[id] heading, and the /feed card
+// label so all three show the same "@durov" fallback when no channel title is
+// resolved yet. Stored source handle URLs are always canonical https://t.me/<slug>
+// (telegram/server/url.ts canonicalizes to t.me), so matching only t.me is enough.
+
+describe("telegramHandleFromUrl", () => {
+  it("derives @handle from a canonical t.me channel URL", () => {
+    expect(telegramHandleFromUrl("https://t.me/durov")).toBe("@durov");
+    expect(telegramHandleFromUrl("https://t.me/d954mas_make_games")).toBe("@d954mas_make_games");
+  });
+
+  it("handles the /s/ preview URL variant", () => {
+    expect(telegramHandleFromUrl("https://t.me/s/durov")).toBe("@durov");
+  });
+
+  it("stops at a query string or fragment", () => {
+    expect(telegramHandleFromUrl("https://t.me/durov?utm=x")).toBe("@durov");
+    expect(telegramHandleFromUrl("https://t.me/durov#frag")).toBe("@durov");
+  });
+
+  it("returns null for a non-t.me URL (caller falls back to the raw value)", () => {
+    expect(telegramHandleFromUrl("https://example.com/durov")).toBeNull();
+    expect(telegramHandleFromUrl("https://youtube.com/@durov")).toBeNull();
+  });
+
+  it("returns null for empty / null / undefined input", () => {
+    expect(telegramHandleFromUrl("")).toBeNull();
+    expect(telegramHandleFromUrl(null)).toBeNull();
+    expect(telegramHandleFromUrl(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Telegram sources/posts displayed the raw `https://t.me/<slug>` URL while YouTube/Instagram showed the channel name. The Telegram title lives only on the `telegram_channels` entity (no-denorm), so neither `data_sources.channelTitle` (never enriched) nor `display_name` (unset) was populated → the UI fell back to the URL. Found in Phase 9 Telegram UAT.
- Enrich `dto.channelTitle` from `telegram_channels.title` (JOIN by slug, at **read** time — no denormalization) in **both** the `/sources` read model and the `/feed` loader, mirroring `enrichDataSourceDtosWithYoutubeChannelTitles`. Add a shared client-safe `telegramHandleFromUrl` helper for the `@handle` fallback (a not-yet-polled channel shows `@slug`, never the URL), used by `SourceRow`, the `/sources/[id]` heading, and the feed card label.
- **Root P1 fix (from review):** `parse.ts` stored the scraped slug **verbatim**, but `url.ts` lowercases the URL-parsed handle, so the slug JOIN missed (and `resolveCachedExternalId`'s `external_url` lookup missed) for any uppercase `@Username` channel. Both `parse.ts` slug extractions now `.toLowerCase()`, honoring the documented slugs-are-lowercase invariant (`url.ts:44-49`).

## Behavior-change note (intentional)

The `/sources/[id]` detail heading now falls back through `displayName` (parity with the list row `SourceRow.handleLabel`), so a **non-Telegram** source with a legacy `displayName` and no `channelTitle` shows the name instead of the raw URL. This is a parity improvement, not a regression — flagged here so it's intentional.

## How the three platforms resolve the name (after this change)

| | source of the name | path |
|---|---|---|
| YouTube | `youtube_channels` entity | `channelTitle` enriched at read |
| Telegram | `telegram_channels` entity | `channelTitle` enriched at read (**new, matches YouTube**) |
| Instagram | `data_sources.display_name` (set at create) | read directly |

## Test plan

- `tests/unit/telegram-handle.test.ts` — `telegramHandleFromUrl` URL edges (`t.me/x`, `/s/x`, query/fragment, non-t.me → null, null/empty → null).
- `tests/unit/telegram-channel-handle-label.test.ts` — label precedence (channelTitle → displayName → @handle → URL → "").
- `tests/unit/sources/telegram/parse.test.ts` — uppercase-slug regression (`@Durov`/`Durov/503` → `durov`), guarding the P1 fix (other fixtures are all lowercase).
- Full local gate: typecheck **0 errors**, eslint + prettier clean, unit **774/774**, telegram integration **67/67**. Full integration: only the known local flakes (4 reddit live-403 + 1 `events-attach` clock-drift) — zero telegram/sources/feed failures.

## Self-review

Two fresh-context review passes. P1 (slug casing) + P2 (detail-heading parity, DRY helper) resolved; final verdict SHIP-READY. No-denorm honored (title read from owning entity at read, never copied to `data_sources`); tenant-safe (`telegram_channels` is allowlisted public-data; only the user's own DTOs are enriched).
