### PR TITLE
feat(social): env-configurable twitterapi.io QPS pacer interval

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -394,3 +394,8 @@ TWITTER_WARM_MAX_FAILURES=5
 
 # (POSTGRES_PASSWORD is defined at the top of this file — it must come
 # before any line that interpolates ${POSTGRES_PASSWORD}. See top of file.)
+
+# twitterapi.io QPS pacer floor (ms between any two twitterapi.io calls, one slot
+# across all paths + replicas). 5000 = 0.2 QPS (never-paid floor, safe default for
+# self-host). A paid operator on 3 QPS lowers this to ~400 (2.5 QPS, margin under 3).
+TWITTERAPIIO_MIN_REQUEST_INTERVAL_MS=5000

--- a/src/lib/server/config/env.ts
+++ b/src/lib/server/config/env.ts
@@ -385,6 +385,11 @@ const RawSchema = z.object({
   TWITTER_WARM_WINDOW_DAYS: z.coerce.number().int().positive().default(7),
   TWITTER_WARM_STALENESS_HOURS: z.coerce.number().int().positive().default(26),
   TWITTER_WARM_MAX_FAILURES: z.coerce.number().int().positive().default(5),
+  // Global twitterapi.io QPS pacer floor — min ms between any two twitterapi.io calls
+  // (one DB slot across all paths + replicas). Default 5000 = 0.2 QPS (the never-paid
+  // floor, safe for a free-tier self-host). A paid operator on 3 QPS lowers it to ~400
+  // (≈2.5 QPS, margin under the ceiling). Read by twitter/server/pacer.ts.
+  TWITTERAPIIO_MIN_REQUEST_INTERVAL_MS: z.coerce.number().int().positive().default(5000),
 });
 
 const raw = RawSchema.parse(process.env);
@@ -527,6 +532,7 @@ export const env = {
   TWITTER_WARM_WINDOW_DAYS: raw.TWITTER_WARM_WINDOW_DAYS,
   TWITTER_WARM_STALENESS_HOURS: raw.TWITTER_WARM_STALENESS_HOURS,
   TWITTER_WARM_MAX_FAILURES: raw.TWITTER_WARM_MAX_FAILURES,
+  TWITTERAPIIO_MIN_REQUEST_INTERVAL_MS: raw.TWITTERAPIIO_MIN_REQUEST_INTERVAL_MS,
 } as const;
 
 export type Env = typeof env;

--- a/src/lib/sources/twitter/server/pacer.ts
+++ b/src/lib/sources/twitter/server/pacer.ts
@@ -15,11 +15,11 @@ import { sql } from "drizzle-orm";
 import { db, type DbOrTx } from "$lib/server/db/client.js";
 import { env } from "$lib/server/config/env.js";
 
-/** The per-account QPS floor twitterapi.io enforces for a NEVER-PAID account: 0.2 QPS
- *  = 1 request every 5000ms. THE single home for the QPS knob — http.ts re-exports it
- *  so the seam + walker lane read ONE constant. After the operator's first top-up the
- *  ceiling rises to 3 QPS (~334ms); a 3-QPS operator can lower this. */
-export const TWITTERAPIIO_MIN_REQUEST_INTERVAL_MS = 5000;
+/** The twitterapi.io QPS pacer floor — min ms between any two calls. THE single home
+ *  for the QPS knob (http.ts re-exports it so the seam + walker lane read ONE value).
+ *  Env-tunable: default 5000 = 0.2 QPS (never-paid floor, safe for free-tier self-host);
+ *  a paid operator on 3 QPS lowers TWITTERAPIIO_MIN_REQUEST_INTERVAL_MS to ~400. */
+export const TWITTERAPIIO_MIN_REQUEST_INTERVAL_MS = env.TWITTERAPIIO_MIN_REQUEST_INTERVAL_MS;
 
 /** Pacer slot interval. Tests disable the slot (0ms) so the atomic UPDATE always
  *  acquires — suites never wait seconds between mocked twitterapi.io calls. */


### PR DESCRIPTION
## Summary

`TWITTERAPIIO_MIN_REQUEST_INTERVAL_MS` (the twitterapi.io QPS pacer floor) was a hardcoded `5000`ms const = the 0.2-QPS never-paid floor. Make it an **env var** so a paid operator on 3 QPS can lower it (e.g. `400` ≈ 2.5 QPS, margin under the ceiling) without a code change.

- `env.ts`: schema (`z.coerce.number().int().positive().default(5000)`) + raw→parsed mapping.
- `.env.example`: documented, default 5000.
- `pacer.ts`: const now reads `env.TWITTERAPIIO_MIN_REQUEST_INTERVAL_MS`; keeps the same exported name → all consumers (http seam re-export, backfill `startAfter`, `TWITTER_PACER_SLOT_MS` test-disable) unchanged.

**SaaS == self-host:** default 5000 stays safe for a free-tier (0.2 QPS) self-host operator; a paid operator overrides via `.env`. No `APP_MODE` branch; behavior at the default is identical to before.

## Test plan
- `pnpm typecheck` (0 errors), `pnpm exec eslint` (changed files), `pnpm test:unit` (965, incl. env-drift + env tests), drift test green.
- A fresh-eyes review of the diff: APPROVE (two-part env pattern, .env.example parity, no missed 5000 reader, not secret-shaped).
- Prod: after merge + image rebuild, set `TWITTERAPIIO_MIN_REQUEST_INTERVAL_MS=400` in prod `.env` for 3 QPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)