### PR TITLE
fix(11): log the actual QPS pacing interval, not a hardcoded 5s

### DIFF
--- a/src/lib/sources/twitter/server/index.ts
+++ b/src/lib/sources/twitter/server/index.ts
@@ -621,20 +621,17 @@ export const twitterAdapter: SourceAdapter & typeof twitterAccountAdapterCore = 
   // scheduledWorker; isEnabled gates it off when the provider is unconfigured
   // (self-host without Twitter) so the lane never ticks/throws.
   //
-  // QPS PACING (the operator's per-account rate-limit requirement, inherited from
-  // Plan 02): intervalMs = TWITTERAPIIO_MIN_REQUEST_INTERVAL_MS (5000ms) + the lane's
-  // maxBatchSize=1 (refresh-queue-tick.ts) serialize twitterapi.io calls to ≤1 every
-  // 5s — the 0.2-QPS floor a never-paid account must respect (the Reddit-lane pacing
-  // pattern: a rate-limited scrape paces via the worker interval). After the
-  // operator's first top-up the ceiling rises to 3 QPS and the constant can be
-  // revisited in ONE home (http.ts).
+  // QPS PACING: intervalMs = TWITTERAPIIO_MIN_REQUEST_INTERVAL_MS (env-tunable, default
+  // 5000ms = 0.2-QPS never-paid floor) + the lane's maxBatchSize=1 serialize twitterapi.io
+  // calls to ≤1 per interval (the Reddit-lane pacing pattern). A paid operator on 3 QPS
+  // lowers the env var (e.g. 400ms ≈ 2.5 QPS).
   workQueue: {
     scheduledWorkers: [
       {
         name: "twitter.refresh",
         intervalMs: TWITTERAPIIO_MIN_REQUEST_INTERVAL_MS,
         replicaPolicy: "parallel",
-        readyMessage: "twitter refresh queue worker ready (5s QPS pacing)",
+        readyMessage: `twitter refresh queue worker ready (${TWITTERAPIIO_MIN_REQUEST_INTERVAL_MS}ms QPS pacing)`,
         disabledMessage: "twitter refresh queue worker disabled (provider unconfigured)",
         laneQueue: {
           strategy: "fixed-slot-round-robin",


### PR DESCRIPTION
## Summary
The twitter refresh worker boot log printed `twitter refresh queue worker ready (5s QPS pacing)` — a hardcoded literal that ignores `TWITTERAPIIO_MIN_REQUEST_INTERVAL_MS`. On prod (now 400ms) the log misleadingly said 5s. Interpolate the real interval; tighten the adjacent stale '(5000ms)/http.ts constant' comment (it's env-tunable now).

Log-only change; no behavior change.

## Test plan
- typecheck 0 errors, eslint clean, prettier clean; no test asserts the old literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)