### PR TITLE
fix(10): log tiktokcdn response status on thumbnail-proxy 502

### DIFF
--- a/src/lib/sources/tiktok/server/thumbnail-proxy.ts
+++ b/src/lib/sources/tiktok/server/thumbnail-proxy.ts
@@ -92,6 +92,16 @@ tiktokThumbnailRoutes.get("/tiktok/thumbnail/:postId", async (c) => {
     return null;
   });
   if (upstream === null || !upstream.ok || upstream.body === null) {
+    // Diagnostic for the steady prod 502 rate on this route: a network error is
+    // already logged above; this captures the HTTP-level failure so we can tell a
+    // signed-URL expiry (403/404 — the next poll refreshes thumbnail_url) from a
+    // CDN block / opaque-redirect (3xx) without guessing.
+    if (upstream !== null) {
+      logger.warn(
+        { postId: c.req.param("postId"), status: upstream.status, hadBody: upstream.body !== null },
+        "tiktok thumbnail proxy: upstream non-ok",
+      );
+    }
     return c.body(null, 502);
   }
 


### PR DESCRIPTION
## Summary
`/api/tiktok/thumbnail/:postId` shows a steady low 502 rate on prod (the only 5xx route, surfaced in the 2026-06-14 audit). The proxy logs network errors but returns 502 SILENTLY on an HTTP non-ok from tiktokcdn — so the cause is undiagnosable in Loki. Add a WARN capturing the upstream status + postId.

This lets the next audit distinguish a **signed-URL expiry** (403/404 — the cached `thumbnail_url` aged out; next account poll refreshes it) from a **CDN block / opaque-redirect** (3xx), so the eventual fix (re-resolve on miss / cache bytes / warm-refresh) targets the real cause.

Diagnostic only — no behavior change (still 502 → `<img>` onerror → KindIcon placeholder). Pre-existing TikTok (Phase 10), unrelated to Phase 11.

## Test plan
- typecheck 0, eslint clean, prettier clean. Log-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)