### PR TITLE
fix(10): cache tiktok cover bytes (expiry-proof thumbnail proxy)

### DIFF
--- a/drizzle/0069_secret_firestar.sql
+++ b/drizzle/0069_secret_firestar.sql
@@ -1,0 +1,6 @@
+-- Cache TikTok cover image bytes at poll time so the thumbnail proxy serves
+-- expiry-proof bytes instead of re-fetching the (hours-short) signed CDN URL,
+-- which caused the steady prod 502 rate on /api/tiktok/thumbnail.
+-- Rollback: ALTER TABLE "tiktok_posts" DROP COLUMN "thumbnail_bytes", DROP COLUMN "thumbnail_content_type";
+ALTER TABLE "tiktok_posts" ADD COLUMN "thumbnail_bytes" "bytea";--> statement-breakpoint
+ALTER TABLE "tiktok_posts" ADD COLUMN "thumbnail_content_type" text;

--- a/drizzle/meta/0069_snapshot.json
+++ b/drizzle/meta/0069_snapshot.json
@@ -1,0 +1,4894 @@
+{
+  "id": "b5c03045-2945-4d7a-8438-df903ba3d60d",
+  "prevId": "c7e5430f-077c-4ffb-9932-a3222cce20a1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_session_updated_at": {
+          "name": "idx_session_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference": {
+          "name": "theme_preference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "audit_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_user_id_idx": {
+          "name": "audit_log_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_user_id_created_at_idx": {
+          "name": "audit_log_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_user_id_action_created_at_idx": {
+          "name": "audit_log_user_id_action_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.adapter_refresh_queue": {
+      "name": "adapter_refresh_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "adapter_kind": {
+          "name": "adapter_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queue_name": {
+          "name": "queue_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enqueued_at": {
+          "name": "enqueued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "idx_adapter_refresh_queue_pending": {
+          "name": "idx_adapter_refresh_queue_pending",
+          "columns": [
+            {
+              "expression": "adapter_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queue_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enqueued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"adapter_refresh_queue\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_adapter_refresh_queue_processing_last_attempt": {
+          "name": "idx_adapter_refresh_queue_processing_last_attempt",
+          "columns": [
+            {
+              "expression": "adapter_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"adapter_refresh_queue\".\"status\" = 'processing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_adapter_refresh_queue_user_window": {
+          "name": "idx_adapter_refresh_queue_user_window",
+          "columns": [
+            {
+              "expression": "adapter_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queue_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enqueued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "adapter_refresh_queue_user_id_user_id_fk": {
+          "name": "adapter_refresh_queue_user_id_user_id_fk",
+          "tableFrom": "adapter_refresh_queue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "adapter_refresh_queue_status_check": {
+          "name": "adapter_refresh_queue_status_check",
+          "value": "\"adapter_refresh_queue\".\"status\" IN ('pending', 'processing', 'done', 'dead_letter')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_keys_steam": {
+      "name": "api_keys_steam",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last4": {
+          "name": "last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_ct": {
+          "name": "secret_ct",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_iv": {
+          "name": "secret_iv",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_tag": {
+          "name": "secret_tag",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_dek": {
+          "name": "wrapped_dek",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dek_iv": {
+          "name": "dek_iv",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dek_tag": {
+          "name": "dek_tag",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kek_version": {
+          "name": "kek_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_steam_user_id_idx": {
+          "name": "api_keys_steam_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_steam_user_label_unq": {
+          "name": "api_keys_steam_user_label_unq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_steam_user_id_user_id_fk": {
+          "name": "api_keys_steam_user_id_user_id_fk",
+          "tableFrom": "api_keys_steam",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_source_channel_state": {
+      "name": "data_source_channel_state",
+      "schema": "",
+      "columns": {
+        "kind": {
+          "name": "kind",
+          "type": "source_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_key": {
+          "name": "channel_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_oldest_at": {
+          "name": "backfill_oldest_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_complete": {
+          "name": "backfill_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_source_channel_state_picker_idx": {
+          "name": "data_source_channel_state_picker_idx",
+          "columns": [
+            {
+              "expression": "last_polled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"data_source_channel_state\".\"backfill_complete\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "data_source_channel_state_kind_channel_key_pk": {
+          "name": "data_source_channel_state_kind_channel_key_pk",
+          "columns": [
+            "kind",
+            "channel_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_sources": {
+      "name": "data_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "source_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle_url": {
+          "name": "handle_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_owned_by_me": {
+          "name": "is_owned_by_me",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_import": {
+          "name": "auto_import",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_reconnect": {
+          "name": "needs_reconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_kind": {
+          "name": "last_error_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_target_since": {
+          "name": "backfill_target_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "data_sources_user_id_idx": {
+          "name": "data_sources_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "data_sources_user_kind_idx": {
+          "name": "data_sources_user_kind_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "data_sources_user_deleted_at_idx": {
+          "name": "data_sources_user_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "data_sources_user_handle_active_unq": {
+          "name": "data_sources_user_handle_active_unq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "handle_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"data_sources\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_sources_user_id_user_id_fk": {
+          "name": "data_sources_user_id_user_id_fk",
+          "tableFrom": "data_sources",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_games": {
+      "name": "event_games",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_games_user_id_idx": {
+          "name": "event_games_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_games_game_id_idx": {
+          "name": "event_games_game_id_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_games_user_game_idx": {
+          "name": "event_games_user_game_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_games_event_id_events_id_fk": {
+          "name": "event_games_event_id_events_id_fk",
+          "tableFrom": "event_games",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_games_game_id_games_id_fk": {
+          "name": "event_games_game_id_games_id_fk",
+          "tableFrom": "event_games",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_games_user_id_user_id_fk": {
+          "name": "event_games_user_id_user_id_fk",
+          "tableFrom": "event_games",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_games_event_id_game_id_pk": {
+          "name": "event_games_event_id_game_id_pk",
+          "columns": [
+            "event_id",
+            "game_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_is_me": {
+          "name": "author_is_me",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_handle": {
+          "name": "author_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vec": {
+          "name": "search_vec",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(title, '') || ' ' || coalesce(notes, ''))",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "events_user_id_idx": {
+          "name": "events_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_user_occurred_at_idx": {
+          "name": "events_user_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"occurred_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_user_created_at_idx": {
+          "name": "events_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_user_source_idx": {
+          "name": "events_user_source_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_user_kind_source_ext_unq": {
+          "name": "events_user_kind_source_ext_unq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"events\".\"source_id\" IS NOT NULL AND \"events\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_search_vec": {
+          "name": "idx_events_search_vec",
+          "columns": [
+            {
+              "expression": "search_vec",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_events_title_trgm": {
+          "name": "idx_events_title_trgm",
+          "columns": [
+            {
+              "expression": "\"title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_events_notes_trgm": {
+          "name": "idx_events_notes_trgm",
+          "columns": [
+            {
+              "expression": "\"notes\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_user_id_user_id_fk": {
+          "name": "events_user_id_user_id_fk",
+          "tableFrom": "events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_source_id_data_sources_id_fk": {
+          "name": "events_source_id_data_sources_id_fk",
+          "tableFrom": "events",
+          "tableTo": "data_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_steam_listings": {
+      "name": "game_steam_listings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coming_soon": {
+          "name": "coming_soon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_genres": {
+          "name": "steam_genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "steam_categories": {
+          "name": "steam_categories",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "raw_appdetails": {
+          "name": "raw_appdetails",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "game_steam_listings_user_id_idx": {
+          "name": "game_steam_listings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "game_steam_listings_game_id_idx": {
+          "name": "game_steam_listings_game_id_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_steam_listings_user_id_user_id_fk": {
+          "name": "game_steam_listings_user_id_user_id_fk",
+          "tableFrom": "game_steam_listings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_steam_listings_game_id_games_id_fk": {
+          "name": "game_steam_listings_game_id_games_id_fk",
+          "tableFrom": "game_steam_listings",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_steam_listings_api_key_id_api_keys_steam_id_fk": {
+          "name": "game_steam_listings_api_key_id_api_keys_steam_id_fk",
+          "tableFrom": "game_steam_listings",
+          "tableTo": "api_keys_steam",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "game_steam_listings_game_app_id_unq": {
+          "name": "game_steam_listings_game_app_id_unq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "game_id",
+            "app_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "games_user_id_idx": {
+          "name": "games_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_user_id_created_at_idx": {
+          "name": "games_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_user_id_deleted_at_idx": {
+          "name": "games_user_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "games_user_id_user_id_fk": {
+          "name": "games_user_id_user_id_fk",
+          "tableFrom": "games",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wishlist_snapshots": {
+      "name": "wishlist_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "listing_id": {
+          "name": "listing_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adds": {
+          "name": "adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletes": {
+          "name": "deletes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchases_and_activations": {
+          "name": "purchases_and_activations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gifts": {
+          "name": "gifts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'csv'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wishlist_snapshots_user_id_idx": {
+          "name": "wishlist_snapshots_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wishlist_snapshots_listing_date_unq": {
+          "name": "wishlist_snapshots_listing_date_unq",
+          "columns": [
+            {
+              "expression": "listing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wishlist_snapshots_user_id_user_id_fk": {
+          "name": "wishlist_snapshots_user_id_user_id_fk",
+          "tableFrom": "wishlist_snapshots",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wishlist_snapshots_listing_id_game_steam_listings_id_fk": {
+          "name": "wishlist_snapshots_listing_id_game_steam_listings_id_fk",
+          "tableFrom": "wishlist_snapshots",
+          "tableTo": "game_steam_listings",
+          "columnsFrom": [
+            "listing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outbox": {
+      "name": "outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "queue": {
+          "name": "queue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "forwarded_at": {
+          "name": "forwarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forwarder_attempt": {
+          "name": "forwarder_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "outbox_pending_idx": {
+          "name": "outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "forwarded_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.youtube_channels": {
+      "name": "youtube_channels",
+      "schema": "",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uploads_playlist_id": {
+          "name": "uploads_playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_title": {
+          "name": "channel_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_backfill_at": {
+          "name": "last_backfill_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle_aliases": {
+          "name": "handle_aliases",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_youtube_channels_handle_aliases": {
+          "name": "idx_youtube_channels_handle_aliases",
+          "columns": [
+            {
+              "expression": "handle_aliases",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.youtube_metadata_fetch_log": {
+      "name": "youtube_metadata_fetch_log",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_youtube_metadata_fetch_log_user_at": {
+          "name": "idx_youtube_metadata_fetch_log_user_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"fetched_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "youtube_metadata_fetch_log_user_id_user_id_fk": {
+          "name": "youtube_metadata_fetch_log_user_id_user_id_fk",
+          "tableFrom": "youtube_metadata_fetch_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.youtube_service_quota_usage": {
+      "name": "youtube_service_quota_usage",
+      "schema": "",
+      "columns": {
+        "date_pacific": {
+          "name": "date_pacific",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pool_kind": {
+          "name": "pool_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_units": {
+          "name": "estimated_units",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "youtube_service_quota_usage_date_pacific_api_key_id_pool_kind_pk": {
+          "name": "youtube_service_quota_usage_date_pacific_api_key_id_pool_kind_pk",
+          "columns": [
+            "date_pacific",
+            "api_key_id",
+            "pool_kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.youtube_video_snapshots": {
+      "name": "youtube_video_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "video_id": {
+          "name": "video_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polled_at": {
+          "name": "polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "youtube_video_snapshots_video_polled_unq": {
+          "name": "youtube_video_snapshots_video_polled_unq",
+          "columns": [
+            {
+              "expression": "video_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "polled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.youtube_videos": {
+      "name": "youtube_videos",
+      "schema": "",
+      "columns": {
+        "video_id": {
+          "name": "video_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_poll_status": {
+          "name": "last_poll_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_failure_count": {
+          "name": "poll_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_youtube_videos_published_at": {
+          "name": "idx_youtube_videos_published_at",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"youtube_videos\".\"published_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_youtube_videos_rehab": {
+          "name": "idx_youtube_videos_rehab",
+          "columns": [
+            {
+              "expression": "last_polled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"youtube_videos\".\"last_poll_status\" IN ('not_found', 'private') AND \"youtube_videos\".\"poll_failure_count\" < 5",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reddit_posts": {
+      "name": "reddit_posts",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subreddit": {
+          "name": "subreddit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_fullname": {
+          "name": "author_fullname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permalink": {
+          "name": "permalink",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_snapshot_at": {
+          "name": "last_snapshot_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletion_detected_at": {
+          "name": "deletion_detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_reddit_posts_subreddit_submitted": {
+          "name": "idx_reddit_posts_subreddit_submitted",
+          "columns": [
+            {
+              "expression": "subreddit",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reddit_posts_author_submitted": {
+          "name": "idx_reddit_posts_author_submitted",
+          "columns": [
+            {
+              "expression": "author",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reddit_posts\".\"author\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reddit_posts_last_snapshot": {
+          "name": "idx_reddit_posts_last_snapshot",
+          "columns": [
+            {
+              "expression": "last_snapshot_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reddit_posts\".\"deletion_detected_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reddit_users_cache": {
+      "name": "reddit_users_cache",
+      "schema": "",
+      "columns": {
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reddit_id": {
+          "name": "reddit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_age_days": {
+          "name": "account_age_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_karma": {
+          "name": "link_karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_karma": {
+          "name": "comment_karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_karma": {
+          "name": "total_karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_suspended": {
+          "name": "is_suspended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_metadata_refresh_at": {
+          "name": "last_metadata_refresh_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "backfill_after_cursor": {
+          "name": "backfill_after_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_complete": {
+          "name": "backfill_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backfill_deepest_at": {
+          "name": "backfill_deepest_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "not_found_count": {
+          "name": "not_found_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_not_found_at": {
+          "name": "last_not_found_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_reddit_users_cache_last_refresh": {
+          "name": "idx_reddit_users_cache_last_refresh",
+          "columns": [
+            {
+              "expression": "last_metadata_refresh_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reddit_subreddits_cache": {
+      "name": "reddit_subreddits_cache",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subreddit_id": {
+          "name": "subreddit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribers": {
+          "name": "subscribers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounts_active": {
+          "name": "accounts_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_description": {
+          "name": "public_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_metadata": {
+          "name": "submission_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "rules_raw_json": {
+          "name": "rules_raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rules_fetched_at": {
+          "name": "rules_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "over18": {
+          "name": "over18",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "subreddit_type": {
+          "name": "subreddit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_metadata_refresh_at": {
+          "name": "last_metadata_refresh_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "backfill_after_cursor": {
+          "name": "backfill_after_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_complete": {
+          "name": "backfill_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backfill_deepest_at": {
+          "name": "backfill_deepest_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "not_found_count": {
+          "name": "not_found_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_not_found_at": {
+          "name": "last_not_found_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_reddit_subreddits_cache_last_refresh": {
+          "name": "idx_reddit_subreddits_cache_last_refresh",
+          "columns": [
+            {
+              "expression": "last_metadata_refresh_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reddit_post_snapshots": {
+      "name": "reddit_post_snapshots",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polled_at": {
+          "name": "polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_comments": {
+          "name": "num_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awards_total": {
+          "name": "awards_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upvote_ratio": {
+          "name": "upvote_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_by_category": {
+          "name": "removed_by_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reddit_post_snapshots_post_id_reddit_posts_post_id_fk": {
+          "name": "reddit_post_snapshots_post_id_reddit_posts_post_id_fk",
+          "tableFrom": "reddit_post_snapshots",
+          "tableTo": "reddit_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "reddit_post_snapshots_post_id_polled_at_pk": {
+          "name": "reddit_post_snapshots_post_id_polled_at_pk",
+          "columns": [
+            "post_id",
+            "polled_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reddit_user_snapshots": {
+      "name": "reddit_user_snapshots",
+      "schema": "",
+      "columns": {
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polled_at": {
+          "name": "polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_karma": {
+          "name": "link_karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_karma": {
+          "name": "comment_karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_karma": {
+          "name": "total_karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reddit_user_snapshots_username_reddit_users_cache_username_fk": {
+          "name": "reddit_user_snapshots_username_reddit_users_cache_username_fk",
+          "tableFrom": "reddit_user_snapshots",
+          "tableTo": "reddit_users_cache",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "reddit_user_snapshots_username_polled_at_pk": {
+          "name": "reddit_user_snapshots_username_polled_at_pk",
+          "columns": [
+            "username",
+            "polled_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reddit_subreddit_snapshots": {
+      "name": "reddit_subreddit_snapshots",
+      "schema": "",
+      "columns": {
+        "subreddit": {
+          "name": "subreddit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polled_at": {
+          "name": "polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscribers": {
+          "name": "subscribers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounts_active": {
+          "name": "accounts_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reddit_subreddit_snapshots_subreddit_reddit_subreddits_cache_name_fk": {
+          "name": "reddit_subreddit_snapshots_subreddit_reddit_subreddits_cache_name_fk",
+          "tableFrom": "reddit_subreddit_snapshots",
+          "tableTo": "reddit_subreddits_cache",
+          "columnsFrom": [
+            "subreddit"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "reddit_subreddit_snapshots_subreddit_polled_at_pk": {
+          "name": "reddit_subreddit_snapshots_subreddit_polled_at_pk",
+          "columns": [
+            "subreddit",
+            "polled_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reddit_subreddit_baselines": {
+      "name": "reddit_subreddit_baselines",
+      "schema": "",
+      "columns": {
+        "subreddit": {
+          "name": "subreddit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_label": {
+          "name": "window_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_size": {
+          "name": "sample_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "median_score_24h": {
+          "name": "median_score_24h",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "p75_score_24h": {
+          "name": "p75_score_24h",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "median_comments_24h": {
+          "name": "median_comments_24h",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "p75_comments_24h": {
+          "name": "p75_comments_24h",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "median_upvote_ratio_24h": {
+          "name": "median_upvote_ratio_24h",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reddit_subreddit_baselines_subreddit_reddit_subreddits_cache_name_fk": {
+          "name": "reddit_subreddit_baselines_subreddit_reddit_subreddits_cache_name_fk",
+          "tableFrom": "reddit_subreddit_baselines",
+          "tableTo": "reddit_subreddits_cache",
+          "columnsFrom": [
+            "subreddit"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "reddit_subreddit_baselines_subreddit_window_label_pk": {
+          "name": "reddit_subreddit_baselines_subreddit_window_label_pk",
+          "columns": [
+            "subreddit",
+            "window_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reddit_pacer": {
+      "name": "reddit_pacer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "smallint",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "next_allowed_at": {
+          "name": "next_allowed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "paused_until": {
+          "name": "paused_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pause_level": {
+          "name": "pause_level",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_pause_reason": {
+          "name": "last_pause_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_paused_at": {
+          "name": "last_paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reddit_pacer_last_pause_reason_check": {
+          "name": "reddit_pacer_last_pause_reason_check",
+          "value": "\"reddit_pacer\".\"last_pause_reason\" IS NULL OR \"reddit_pacer\".\"last_pause_reason\" IN ('http_403', 'http_429')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.instagram_accounts": {
+      "name": "instagram_accounts",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follower_count": {
+          "name": "follower_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle_aliases": {
+          "name": "handle_aliases",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_refreshed_at": {
+          "name": "last_refreshed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_instagram_accounts_handle_aliases": {
+          "name": "idx_instagram_accounts_handle_aliases",
+          "columns": [
+            {
+              "expression": "handle_aliases",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instagram_posts": {
+      "name": "instagram_posts",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permalink": {
+          "name": "permalink",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_poll_status": {
+          "name": "last_poll_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_failure_count": {
+          "name": "poll_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_instagram_posts_published_at": {
+          "name": "idx_instagram_posts_published_at",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instagram_posts\".\"published_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instagram_posts_account_published_at": {
+          "name": "idx_instagram_posts_account_published_at",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instagram_posts_permalink": {
+          "name": "idx_instagram_posts_permalink",
+          "columns": [
+            {
+              "expression": "permalink",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instagram_post_snapshots": {
+      "name": "instagram_post_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polled_at": {
+          "name": "polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "instagram_post_snapshots_post_polled_unq": {
+          "name": "instagram_post_snapshots_post_polled_unq",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "polled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_provider_balance": {
+      "name": "social_provider_balance",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prepaid_balance_credits": {
+          "name": "prepaid_balance_credits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "social_provider_balance_provider_pk": {
+          "name": "social_provider_balance_provider_pk",
+          "columns": [
+            "provider"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_provider_spend": {
+      "name": "social_provider_spend",
+      "schema": "",
+      "columns": {
+        "date_pacific": {
+          "name": "date_pacific",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pool_kind": {
+          "name": "pool_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits_used": {
+          "name": "credits_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "social_provider_spend_date_pacific_platform_provider_pool_kind_pk": {
+          "name": "social_provider_spend_date_pacific_platform_provider_pool_kind_pk",
+          "columns": [
+            "date_pacific",
+            "platform",
+            "provider",
+            "pool_kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_channels": {
+      "name": "telegram_channels",
+      "schema": "",
+      "columns": {
+        "channel_key": {
+          "name": "channel_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle_aliases": {
+          "name": "handle_aliases",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_refreshed_at": {
+          "name": "last_refreshed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_channels_handle_aliases": {
+          "name": "idx_telegram_channels_handle_aliases",
+          "columns": [
+            {
+              "expression": "handle_aliases",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_posts": {
+      "name": "telegram_posts",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_key": {
+          "name": "channel_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_snippet": {
+          "name": "text_snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_kind": {
+          "name": "media_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reactions_top": {
+          "name": "reactions_top",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_poll_status": {
+          "name": "last_poll_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_failure_count": {
+          "name": "poll_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_posts_published_at": {
+          "name": "idx_telegram_posts_published_at",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"telegram_posts\".\"published_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_post_snapshots": {
+      "name": "telegram_post_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polled_at": {
+          "name": "polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reactions_total": {
+          "name": "reactions_total",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "telegram_post_snapshots_post_polled_unq": {
+          "name": "telegram_post_snapshots_post_polled_unq",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "polled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_pacer": {
+      "name": "telegram_pacer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "smallint",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "next_allowed_at": {
+          "name": "next_allowed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "paused_until": {
+          "name": "paused_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pause_level": {
+          "name": "pause_level",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_pause_reason": {
+          "name": "last_pause_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_paused_at": {
+          "name": "last_paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "telegram_pacer_last_pause_reason_check": {
+          "name": "telegram_pacer_last_pause_reason_check",
+          "value": "\"telegram_pacer\".\"last_pause_reason\" IS NULL OR \"telegram_pacer\".\"last_pause_reason\" IN ('http_403', 'http_429')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tiktok_accounts": {
+      "name": "tiktok_accounts",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follower_count": {
+          "name": "follower_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sec_uid": {
+          "name": "sec_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle_aliases": {
+          "name": "handle_aliases",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_refreshed_at": {
+          "name": "last_refreshed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tiktok_accounts_handle_aliases": {
+          "name": "idx_tiktok_accounts_handle_aliases",
+          "columns": [
+            {
+              "expression": "handle_aliases",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tiktok_posts": {
+      "name": "tiktok_posts",
+      "schema": "",
+      "columns": {
+        "aweme_id": {
+          "name": "aweme_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permalink": {
+          "name": "permalink",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_bytes": {
+          "name": "thumbnail_bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_content_type": {
+          "name": "thumbnail_content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_poll_status": {
+          "name": "last_poll_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_failure_count": {
+          "name": "poll_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tiktok_posts_published_at": {
+          "name": "idx_tiktok_posts_published_at",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tiktok_posts\".\"published_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tiktok_posts_account_published_at": {
+          "name": "idx_tiktok_posts_account_published_at",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tiktok_posts_permalink": {
+          "name": "idx_tiktok_posts_permalink",
+          "columns": [
+            {
+              "expression": "permalink",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tiktok_post_snapshots": {
+      "name": "tiktok_post_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "aweme_id": {
+          "name": "aweme_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polled_at": {
+          "name": "polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_count": {
+          "name": "share_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tiktok_post_snapshots_aweme_polled_unq": {
+          "name": "tiktok_post_snapshots_aweme_polled_unq",
+          "columns": [
+            {
+              "expression": "aweme_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "polled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.twitter_accounts": {
+      "name": "twitter_accounts",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follower_count": {
+          "name": "follower_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle_aliases": {
+          "name": "handle_aliases",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_refreshed_at": {
+          "name": "last_refreshed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_twitter_accounts_handle_aliases": {
+          "name": "idx_twitter_accounts_handle_aliases",
+          "columns": [
+            {
+              "expression": "handle_aliases",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.twitter_posts": {
+      "name": "twitter_posts",
+      "schema": "",
+      "columns": {
+        "tweet_id": {
+          "name": "tweet_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permalink": {
+          "name": "permalink",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_poll_status": {
+          "name": "last_poll_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_failure_count": {
+          "name": "poll_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_twitter_posts_published_at": {
+          "name": "idx_twitter_posts_published_at",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"twitter_posts\".\"published_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_twitter_posts_account_published_at": {
+          "name": "idx_twitter_posts_account_published_at",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_twitter_posts_permalink": {
+          "name": "idx_twitter_posts_permalink",
+          "columns": [
+            {
+              "expression": "permalink",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.twitter_post_snapshots": {
+      "name": "twitter_post_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tweet_id": {
+          "name": "tweet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polled_at": {
+          "name": "polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_count": {
+          "name": "share_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retweet_count": {
+          "name": "retweet_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quote_count": {
+          "name": "quote_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bookmark_count": {
+          "name": "bookmark_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "twitter_post_snapshots_tweet_polled_unq": {
+          "name": "twitter_post_snapshots_tweet_polled_unq",
+          "columns": [
+            {
+              "expression": "tweet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "polled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.twitter_pacer": {
+      "name": "twitter_pacer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "smallint",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "next_allowed_at": {
+          "name": "next_allowed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "twitter_pacer_id_check": {
+          "name": "twitter_pacer_id_check",
+          "value": "\"twitter_pacer\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.audit_action": {
+      "name": "audit_action",
+      "schema": "public",
+      "values": [
+        "session.signin",
+        "session.signout",
+        "session.signout_all",
+        "user.signup",
+        "key.add",
+        "key.rotate",
+        "key.remove",
+        "game.created",
+        "game.deleted",
+        "game.restored",
+        "event.created",
+        "event.edited",
+        "event.deleted",
+        "event.attached_to_game",
+        "event.detached_from_game",
+        "event.dismissed_from_inbox",
+        "event.restored",
+        "event.marked_standalone",
+        "event.unmarked_standalone",
+        "source.added",
+        "source.removed",
+        "source.toggled_auto_import",
+        "theme.changed",
+        "account.deleted",
+        "account.restored",
+        "account.exported",
+        "quota.limit_hit",
+        "quota.service_throttled",
+        "purge.completed",
+        "auto_import.deferred",
+        "poll.failed",
+        "event.poll_refreshed",
+        "source.refresh_content_requested",
+        "reddit.queue_drained",
+        "reddit.deletion_propagated",
+        "reddit.cap_exhausted",
+        "reddit.adapter_degraded",
+        "events.bulk_edit",
+        "events.bulk_delete",
+        "events.delete_forever",
+        "events.purge_stale",
+        "source.delete_forever",
+        "game.delete_forever",
+        "listing.delete_forever",
+        "wishlist.imported",
+        "social.provider_throttled",
+        "social.budget_exhausted",
+        "telegram.queue_drained"
+      ]
+    },
+    "public.source_kind": {
+      "name": "source_kind",
+      "schema": "public",
+      "values": [
+        "youtube_channel",
+        "reddit_account",
+        "reddit_subreddit",
+        "twitter_account",
+        "telegram_channel",
+        "discord_server",
+        "instagram_account",
+        "tiktok_account"
+      ]
+    },
+    "public.event_kind": {
+      "name": "event_kind",
+      "schema": "public",
+      "values": [
+        "youtube_video",
+        "reddit_post",
+        "twitter_post",
+        "telegram_post",
+        "discord_drop",
+        "conference",
+        "talk",
+        "press",
+        "other",
+        "post",
+        "instagram_post",
+        "tiktok_post"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -484,6 +484,13 @@
       "when": 1781363235555,
       "tag": "0068_perpetual_psylocke",
       "breakpoints": true
+    },
+    {
+      "idx": 69,
+      "version": "7",
+      "when": 1781437055971,
+      "tag": "0069_secret_firestar",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/sources/tiktok/server/schema/posts.ts
+++ b/src/lib/sources/tiktok/server/schema/posts.ts
@@ -32,8 +32,14 @@
 // deleted. The row IS the historical record for that account's per-post stats;
 // future account-level analytics require the full historical record.
 
-import { pgTable, text, timestamp, integer, index } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, integer, index, customType } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
+
+// Postgres bytea ↔ Node Buffer. Drizzle has no first-class bytea column type;
+// this is the documented customType bridge (driver returns/accepts Buffer).
+const bytea = customType<{ data: Buffer; default: false }>({
+  dataType: () => "bytea",
+});
 
 export const tiktokPosts = pgTable(
   "tiktok_posts",
@@ -56,6 +62,14 @@ export const tiktokPosts = pgTable(
     // The fresh TikTok CDN thumbnail URL (hotlink). Expires; refreshed on every
     // poll by the snapshot writer.
     thumbnailUrl: text("thumbnail_url"),
+    // Cached cover image bytes, fetched at poll time while thumbnail_url is still
+    // a fresh signed URL. The proxy serves these directly so a load never depends
+    // on the (hours-short) signature — the daily poll signature expiry caused the
+    // steady prod 502 rate on /api/tiktok/thumbnail. NULL on legacy rows not yet
+    // re-polled and when the write-time fetch failed (proxy URL-fallback applies).
+    // Read ONLY by the proxy — never loaded on the feed/DTO read path.
+    thumbnailBytes: bytea("thumbnail_bytes"),
+    thumbnailContentType: text("thumbnail_content_type"),
     // Drives tier classification. NULL on rows freshly inserted by ingest before
     // the account backfill resolves the post's create_time.
     publishedAt: timestamp("published_at", { withTimezone: true }),

--- a/src/lib/sources/tiktok/server/snapshots.ts
+++ b/src/lib/sources/tiktok/server/snapshots.ts
@@ -76,13 +76,18 @@ export async function writeSnapshot(args: WriteSnapshotArgs): Promise<void> {
   let cover: { bytes: Buffer; contentType: string } | null = null;
   const incomingUrl = args.thumbnailUrl ?? null;
   if (incomingUrl !== null) {
+    // Presence-only — never SELECT the bytea itself (the blob stays off this path
+    // too; we only need "is the cache empty?").
     const [prior] = await db
-      .select({ url: tiktokPosts.thumbnailUrl, hasBytes: tiktokPosts.thumbnailBytes })
+      .select({
+        url: tiktokPosts.thumbnailUrl,
+        hasBytes: sql<boolean>`${tiktokPosts.thumbnailBytes} IS NOT NULL`,
+      })
       .from(tiktokPosts)
       .where(eq(tiktokPosts.awemeId, args.awemeId))
       .limit(1);
     const urlChanged = prior === undefined || prior.url !== incomingUrl;
-    const cacheEmpty = prior !== undefined && prior.hasBytes === null;
+    const cacheEmpty = prior !== undefined && !prior.hasBytes;
     if (urlChanged || cacheEmpty) cover = await fetchCoverBytes(incomingUrl);
   }
 

--- a/src/lib/sources/tiktok/server/snapshots.ts
+++ b/src/lib/sources/tiktok/server/snapshots.ts
@@ -25,9 +25,10 @@
 // lock while waiting on a multi-hundred-KB provider payload). This service
 // expects the metrics + status as already-resolved inputs.
 
-import { sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { db } from "$lib/server/db/client.js";
 import { tiktokAccounts, tiktokPosts, tiktokPostSnapshots } from "$lib/server/db/schema/index.js";
+import { fetchCoverBytes } from "./thumbnail-proxy.js";
 
 export type SnapshotStatus = "ok" | "not_found" | "private" | "auth_error" | "rate_limited";
 
@@ -65,6 +66,26 @@ export interface WriteSnapshotArgs {
 }
 
 export async function writeSnapshot(args: WriteSnapshotArgs): Promise<void> {
+  // Cache the cover bytes while the signed URL is fresh (poll time) so the proxy
+  // serves them expiry-proof — the daily-poll/hours-short signature mismatch was
+  // the prod 502 cause. Only fetch when the incoming URL differs from the stored
+  // one OR the cache is empty (skip an unchanged cover every poll → no needless
+  // re-download). Best-effort + OUTSIDE the tx: never hold a row lock on a CDN
+  // fetch, never block/throw the snapshot write on a fetch miss (bytes stay null,
+  // the proxy URL-fallback still applies, exactly as before this cache existed).
+  let cover: { bytes: Buffer; contentType: string } | null = null;
+  const incomingUrl = args.thumbnailUrl ?? null;
+  if (incomingUrl !== null) {
+    const [prior] = await db
+      .select({ url: tiktokPosts.thumbnailUrl, hasBytes: tiktokPosts.thumbnailBytes })
+      .from(tiktokPosts)
+      .where(eq(tiktokPosts.awemeId, args.awemeId))
+      .limit(1);
+    const urlChanged = prior === undefined || prior.url !== incomingUrl;
+    const cacheEmpty = prior !== undefined && prior.hasBytes === null;
+    if (urlChanged || cacheEmpty) cover = await fetchCoverBytes(incomingUrl);
+  }
+
   await db.transaction(async (tx) => {
     // 1. UPSERT tiktok_posts — public-data, single source of truth for the post
     //    snippet + polling state across all tenants who reference it.
@@ -80,6 +101,8 @@ export async function writeSnapshot(args: WriteSnapshotArgs): Promise<void> {
         caption: args.caption ?? null,
         permalink: args.permalink ?? null,
         thumbnailUrl: args.thumbnailUrl ?? null,
+        thumbnailBytes: cover?.bytes ?? null,
+        thumbnailContentType: cover?.contentType ?? null,
         publishedAt: args.publishedAt ?? null,
         fetchedAt: now,
         lastPolledAt: now,
@@ -100,6 +123,11 @@ export async function writeSnapshot(args: WriteSnapshotArgs): Promise<void> {
           caption: args.caption ?? null,
           permalink: sql`COALESCE(${args.permalink ?? null}, ${tiktokPosts.permalink})`,
           thumbnailUrl: sql`COALESCE(${args.thumbnailUrl ?? null}, ${tiktokPosts.thumbnailUrl})`,
+          // Refresh the cached cover when we fetched fresh bytes; COALESCE-preserve
+          // the prior cache on a fetch miss / non-ok poll (never blank a working
+          // cover — the proxy keeps serving the last good bytes).
+          thumbnailBytes: sql`COALESCE(${cover?.bytes ?? null}, ${tiktokPosts.thumbnailBytes})`,
+          thumbnailContentType: sql`COALESCE(${cover?.contentType ?? null}, ${tiktokPosts.thumbnailContentType})`,
           publishedAt: sql`COALESCE(${args.publishedAt ?? null}, ${tiktokPosts.publishedAt})`,
           lastPolledAt: now,
           lastPollStatus: args.status,

--- a/src/lib/sources/tiktok/server/snapshots.ts
+++ b/src/lib/sources/tiktok/server/snapshots.ts
@@ -28,7 +28,7 @@
 import { eq, sql } from "drizzle-orm";
 import { db } from "$lib/server/db/client.js";
 import { tiktokAccounts, tiktokPosts, tiktokPostSnapshots } from "$lib/server/db/schema/index.js";
-import { fetchCoverBytes } from "./thumbnail-proxy.js";
+import { fetchCoverBytes, coverCacheKey } from "./thumbnail-proxy.js";
 
 export type SnapshotStatus = "ok" | "not_found" | "private" | "auth_error" | "rate_limited";
 
@@ -68,11 +68,12 @@ export interface WriteSnapshotArgs {
 export async function writeSnapshot(args: WriteSnapshotArgs): Promise<void> {
   // Cache the cover bytes while the signed URL is fresh (poll time) so the proxy
   // serves them expiry-proof — the daily-poll/hours-short signature mismatch was
-  // the prod 502 cause. Only fetch when the incoming URL differs from the stored
-  // one OR the cache is empty (skip an unchanged cover every poll → no needless
-  // re-download). Best-effort + OUTSIDE the tx: never hold a row lock on a CDN
-  // fetch, never block/throw the snapshot write on a fetch miss (bytes stay null,
-  // the proxy URL-fallback still applies, exactly as before this cache existed).
+  // the prod 502 cause. A post's cover is immutable, so fetch only when the cover
+  // actually CHANGED — compare the URL PATH (coverCacheKey strips the rotating
+  // x-signature/x-expires query; comparing the full URL would re-fetch every poll
+  // since the signature rotates) — OR the cache is empty. Best-effort + OUTSIDE the
+  // tx: never hold a row lock on a CDN fetch, never block/throw the snapshot write
+  // on a fetch miss (bytes stay null, the proxy URL-fallback still applies).
   let cover: { bytes: Buffer; contentType: string } | null = null;
   const incomingUrl = args.thumbnailUrl ?? null;
   if (incomingUrl !== null) {
@@ -86,7 +87,8 @@ export async function writeSnapshot(args: WriteSnapshotArgs): Promise<void> {
       .from(tiktokPosts)
       .where(eq(tiktokPosts.awemeId, args.awemeId))
       .limit(1);
-    const urlChanged = prior === undefined || prior.url !== incomingUrl;
+    const urlChanged =
+      prior === undefined || coverCacheKey(prior.url) !== coverCacheKey(incomingUrl);
     const cacheEmpty = prior !== undefined && !prior.hasBytes;
     if (urlChanged || cacheEmpty) cover = await fetchCoverBytes(incomingUrl);
   }

--- a/src/lib/sources/tiktok/server/thumbnail-proxy.ts
+++ b/src/lib/sources/tiktok/server/thumbnail-proxy.ts
@@ -36,9 +36,47 @@ import { logger } from "$lib/server/logger.js";
 // normalizer reads video.dynamic_cover.url_list / video.cover.url_list, both on
 // `*.tiktokcdn-us.com` (10-SPIKE.md finding (e)); `.tiktokcdn.com` is the base
 // TikTok CDN domain that also serves covers in some regions. Suffix-matched
-// against the stored URL's host — defence-in-depth so a future provider change
-// can never turn this into a general-purpose fetch.
-const ALLOWED_HOST_SUFFIXES = [".tiktokcdn-us.com", ".tiktokcdn.com"];
+// against a URL's host — defence-in-depth so a future provider change can never
+// turn this into a general-purpose fetch. Single source: both the proxy and the
+// write-time byte-fetch (snapshots.ts) host-validate through isTikTokCdnHost.
+export const ALLOWED_HOST_SUFFIXES = [".tiktokcdn-us.com", ".tiktokcdn.com"];
+
+/** True when the URL's host is a known TikTok CDN (suffix-matched, dot-anchored
+ *  so `tiktokcdn.com.evil.com` fails). The SSRF guard shared by the proxy and the
+ *  write-time cover fetch. */
+export function isTikTokCdnHost(url: string): boolean {
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  return ALLOWED_HOST_SUFFIXES.some((suffix) => host.endsWith(suffix));
+}
+
+/**
+ * Best-effort server-side fetch of a TikTok CDN cover URL while it is still a
+ * fresh signed URL (poll time). Host-validated (SSRF), redirect:"manual" (a 3xx
+ * would re-open SSRF to the redirect target), timeout-bounded. Returns the image
+ * bytes + content-type, or null on a non-CDN host / non-ok / non-image / network
+ * error. NEVER throws — the caller treats null as "leave the cache empty, the
+ * proxy URL-fallback still applies". This is the only reusable seam IG could
+ * adopt later; it is applied to TikTok only in this PR.
+ */
+export async function fetchCoverBytes(
+  url: string,
+): Promise<{ bytes: Buffer; contentType: string } | null> {
+  if (!isTikTokCdnHost(url)) return null;
+  const res = await fetch(url, {
+    redirect: "manual",
+    signal: AbortSignal.timeout(8000),
+  }).catch(() => null);
+  if (res === null || !res.ok) return null;
+  const contentType = res.headers.get("content-type") ?? "";
+  if (!contentType.startsWith("image/")) return null;
+  const bytes = Buffer.from(await res.arrayBuffer().catch(() => new ArrayBuffer(0)));
+  return bytes.length === 0 ? null : { bytes, contentType };
+}
 
 /**
  * Resolve a post's stored thumbnail URL, host-validated. Returns null when the
@@ -53,13 +91,22 @@ export async function resolveTikTokThumbnailUrl(awemeId: string): Promise<string
     .limit(1);
   const url = row?.url ?? null;
   if (url === null) return null;
-  let host: string;
-  try {
-    host = new URL(url).hostname.toLowerCase();
-  } catch {
-    return null;
-  }
-  return ALLOWED_HOST_SUFFIXES.some((suffix) => host.endsWith(suffix)) ? url : null;
+  return isTikTokCdnHost(url) ? url : null;
+}
+
+/** The post's cached cover bytes (read ONLY here — never on the feed/DTO path,
+ *  which must not load blobs). Null when no row, no cached bytes yet (legacy /
+ *  re-poll pending), or no content-type. */
+async function resolveCachedCoverBytes(
+  awemeId: string,
+): Promise<{ bytes: Buffer; contentType: string } | null> {
+  const [row] = await db
+    .select({ bytes: tiktokPosts.thumbnailBytes, contentType: tiktokPosts.thumbnailContentType })
+    .from(tiktokPosts)
+    .where(eq(tiktokPosts.awemeId, awemeId))
+    .limit(1);
+  if (row?.bytes == null || row.contentType == null) return null;
+  return { bytes: row.bytes, contentType: row.contentType };
 }
 
 export const tiktokThumbnailRoutes = new Hono<{
@@ -67,7 +114,23 @@ export const tiktokThumbnailRoutes = new Hono<{
 }>();
 
 tiktokThumbnailRoutes.get("/tiktok/thumbnail/:postId", async (c) => {
-  const url = await resolveTikTokThumbnailUrl(c.req.param("postId"));
+  const postId = c.req.param("postId");
+
+  // Cached bytes win — expiry-proof, no upstream fetch (fixes the prod 502 from
+  // the signed-URL expiry). Populated at poll time while the URL was fresh.
+  const cached = await resolveCachedCoverBytes(postId);
+  if (cached !== null) {
+    // Blob wraps the bytes as a BodyInit the DOM Response type accepts (a raw
+    // Node Buffer / Uint8Array is valid at runtime but not in the lib.dom types).
+    const body = new Blob([new Uint8Array(cached.bytes)], { type: cached.contentType });
+    return new Response(body, {
+      status: 200,
+      headers: { "content-type": cached.contentType, "cache-control": "private, max-age=3600" },
+    });
+  }
+
+  // Legacy rows not yet re-polled (bytes null) → fall back to the URL fetch.
+  const url = await resolveTikTokThumbnailUrl(postId);
   if (url === null) return c.body(null, 404);
 
   // No Referer to the CDN (the original <img> used referrerpolicy=no-referrer).
@@ -98,7 +161,7 @@ tiktokThumbnailRoutes.get("/tiktok/thumbnail/:postId", async (c) => {
     // CDN block / opaque-redirect (3xx) without guessing.
     if (upstream !== null) {
       logger.warn(
-        { postId: c.req.param("postId"), status: upstream.status, hadBody: upstream.body !== null },
+        { postId, status: upstream.status, hadBody: upstream.body !== null },
         "tiktok thumbnail proxy: upstream non-ok",
       );
     }

--- a/src/lib/sources/tiktok/server/thumbnail-proxy.ts
+++ b/src/lib/sources/tiktok/server/thumbnail-proxy.ts
@@ -54,6 +54,21 @@ export function isTikTokCdnHost(url: string): boolean {
   return ALLOWED_HOST_SUFFIXES.some((suffix) => host.endsWith(suffix));
 }
 
+/** Stable identity of a cover URL = origin + path, WITHOUT the query. tiktokcdn
+ *  rotates the `x-signature`/`x-expires` query every poll while the cover (an
+ *  immutable per-post image) keeps the same path — so writeSnapshot compares this
+ *  key to re-fetch bytes only on a real cover change, not on every poll. Null in →
+ *  null; unparseable → the raw string (so two bad URLs still compare by value). */
+export function coverCacheKey(url: string | null): string | null {
+  if (url === null) return null;
+  try {
+    const u = new URL(url);
+    return `${u.origin}${u.pathname}`;
+  } catch {
+    return url;
+  }
+}
+
 /**
  * Best-effort server-side fetch of a TikTok CDN cover URL while it is still a
  * fresh signed URL (poll time). Host-validated (SSRF), redirect:"manual" (a 3xx
@@ -125,7 +140,13 @@ tiktokThumbnailRoutes.get("/tiktok/thumbnail/:postId", async (c) => {
     const body = new Blob([new Uint8Array(cached.bytes)], { type: cached.contentType });
     return new Response(body, {
       status: 200,
-      headers: { "content-type": cached.contentType, "cache-control": "private, max-age=3600" },
+      headers: {
+        "content-type": cached.contentType,
+        "cache-control": "private, max-age=3600",
+        // nosniff: the content-type is provider-derived; never let the browser
+        // sniff a stored blob into an executable type (e.g. svg navigated directly).
+        "x-content-type-options": "nosniff",
+      },
     });
   }
 
@@ -179,6 +200,7 @@ tiktokThumbnailRoutes.get("/tiktok/thumbnail/:postId", async (c) => {
     headers: {
       "content-type": upstream.headers.get("content-type") ?? "image/webp",
       "cache-control": "private, max-age=3600",
+      "x-content-type-options": "nosniff",
     },
   });
 });

--- a/tests/integration/tiktok-thumbnail-bytes-cache.test.ts
+++ b/tests/integration/tiktok-thumbnail-bytes-cache.test.ts
@@ -107,6 +107,31 @@ describe("tiktok cover byte-cache (writeSnapshot)", () => {
     expect(row!.thumbnailContentType).toBe("image/jpeg");
   });
 
+  it("does NOT re-fetch when only the signed query rotates (same cover path)", async () => {
+    // Prod reality: tiktokcdn rotates x-signature/x-expires every poll while the
+    // cover PATH is unchanged. coverCacheKey strips the query, so an immutable
+    // cover is fetched once, not re-downloaded on every poll.
+    const awemeId = `tk-cache-rotate-${uniq()}`;
+    const base = "https://p16-sign-va.tiktokcdn-us.com/obj/rotate.awebp";
+    scriptedCover = { bytes: Buffer.from([9]), contentType: "image/webp" };
+    await writeSnapshot({
+      awemeId,
+      thumbnailUrl: `${base}?x-expires=1&x-signature=AAA`,
+      status: "ok",
+      metrics: okMetrics,
+    });
+    expect(fetchCoverBytesMock).toHaveBeenCalledTimes(1);
+
+    fetchCoverBytesMock.mockClear();
+    await writeSnapshot({
+      awemeId,
+      thumbnailUrl: `${base}?x-expires=2&x-signature=BBB`,
+      status: "ok",
+      metrics: okMetrics,
+    });
+    expect(fetchCoverBytesMock).not.toHaveBeenCalled();
+  });
+
   it("leaves bytes null + keeps the URL when the cover fetch fails", async () => {
     const awemeId = `tk-cache-miss-${uniq()}`;
     scriptedCover = null; // fetch miss (non-ok / network / non-image)

--- a/tests/integration/tiktok-thumbnail-bytes-cache.test.ts
+++ b/tests/integration/tiktok-thumbnail-bytes-cache.test.ts
@@ -1,0 +1,231 @@
+// TikTok cover byte-cache (fixes the prod 502 on /api/tiktok/thumbnail).
+//
+// The proxy used to re-fetch tiktok_posts.thumbnail_url — a tiktokcdn signed URL
+// (x-expires) that expires in hours while the account poll is daily, so most
+// cover loads 502'd. The fix caches the cover BYTES at poll time (writeSnapshot,
+// while the URL is fresh) and serves them from the proxy expiry-proof.
+//
+// Real Postgres; the only mock is the cover fetch (fetchCoverBytes) — we never
+// hit the live TikTok CDN. Proves: a fresh URL caches bytes+content-type; an
+// unchanged URL on re-poll does NOT re-fetch; a fetch miss leaves bytes null +
+// keeps the URL; the proxy serves cached bytes WITHOUT an upstream fetch and
+// falls back to the URL-fetch when bytes are absent; the host guard still rejects
+// a non-tiktokcdn URL.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { eq } from "drizzle-orm";
+
+// Scripted cover-fetch result + a call counter so we can assert "did NOT re-fetch".
+let scriptedCover: { bytes: Buffer; contentType: string } | null = null;
+const fetchCoverBytesMock = vi.fn(async (_url: string) => scriptedCover);
+vi.mock("../../src/lib/sources/tiktok/server/thumbnail-proxy.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, fetchCoverBytes: fetchCoverBytesMock };
+});
+
+const { db } = await import("../../src/lib/server/db/client.js");
+const { tiktokPosts } = await import("../../src/lib/server/db/schema/index.js");
+const { writeSnapshot } = await import("../../src/lib/sources/tiktok/server/snapshots.js");
+const { resolveTikTokThumbnailUrl } =
+  await import("../../src/lib/sources/tiktok/server/thumbnail-proxy.js");
+
+const uniq = (): string => Math.random().toString(36).slice(2, 10);
+const cdnUrl = (v: string): string =>
+  `https://p16-sign-va.tiktokcdn-us.com/obj/${v}.awebp?x-expires=1&x-signature=abc`;
+
+async function readPost(awemeId: string) {
+  const [row] = await db
+    .select()
+    .from(tiktokPosts)
+    .where(eq(tiktokPosts.awemeId, awemeId))
+    .limit(1);
+  return row;
+}
+
+const okMetrics = { views: 10, likes: 2, comments: 1, shares: 3 };
+
+beforeEach(() => {
+  scriptedCover = null;
+  fetchCoverBytesMock.mockClear();
+});
+
+describe("tiktok cover byte-cache (writeSnapshot)", () => {
+  it("caches bytes + content_type when a fresh thumbnail_url is written", async () => {
+    const awemeId = `tk-cache-fresh-${uniq()}`;
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x01, 0x02]);
+    scriptedCover = { bytes, contentType: "image/webp" };
+
+    await writeSnapshot({
+      awemeId,
+      thumbnailUrl: cdnUrl("a"),
+      status: "ok",
+      metrics: okMetrics,
+    });
+
+    expect(fetchCoverBytesMock).toHaveBeenCalledTimes(1);
+    const row = await readPost(awemeId);
+    expect(row!.thumbnailBytes).toEqual(bytes);
+    expect(row!.thumbnailContentType).toBe("image/webp");
+    expect(row!.thumbnailUrl).toBe(cdnUrl("a"));
+  });
+
+  it("does NOT re-fetch when an unchanged thumbnail_url is re-polled", async () => {
+    const awemeId = `tk-cache-unchanged-${uniq()}`;
+    scriptedCover = { bytes: Buffer.from([1, 2, 3]), contentType: "image/webp" };
+    await writeSnapshot({
+      awemeId,
+      thumbnailUrl: cdnUrl("same"),
+      status: "ok",
+      metrics: okMetrics,
+    });
+    expect(fetchCoverBytesMock).toHaveBeenCalledTimes(1);
+
+    // Re-poll with the SAME URL (cache already populated) → no second fetch.
+    fetchCoverBytesMock.mockClear();
+    await writeSnapshot({
+      awemeId,
+      thumbnailUrl: cdnUrl("same"),
+      status: "ok",
+      metrics: okMetrics,
+    });
+    expect(fetchCoverBytesMock).not.toHaveBeenCalled();
+    const row = await readPost(awemeId);
+    expect(row!.thumbnailBytes).toEqual(Buffer.from([1, 2, 3]));
+  });
+
+  it("re-fetches when the thumbnail_url changes (new signed URL)", async () => {
+    const awemeId = `tk-cache-changed-${uniq()}`;
+    scriptedCover = { bytes: Buffer.from([1]), contentType: "image/webp" };
+    await writeSnapshot({ awemeId, thumbnailUrl: cdnUrl("v1"), status: "ok", metrics: okMetrics });
+
+    fetchCoverBytesMock.mockClear();
+    scriptedCover = { bytes: Buffer.from([2, 2]), contentType: "image/jpeg" };
+    await writeSnapshot({ awemeId, thumbnailUrl: cdnUrl("v2"), status: "ok", metrics: okMetrics });
+
+    expect(fetchCoverBytesMock).toHaveBeenCalledTimes(1);
+    const row = await readPost(awemeId);
+    expect(row!.thumbnailBytes).toEqual(Buffer.from([2, 2]));
+    expect(row!.thumbnailContentType).toBe("image/jpeg");
+  });
+
+  it("leaves bytes null + keeps the URL when the cover fetch fails", async () => {
+    const awemeId = `tk-cache-miss-${uniq()}`;
+    scriptedCover = null; // fetch miss (non-ok / network / non-image)
+
+    await writeSnapshot({
+      awemeId,
+      thumbnailUrl: cdnUrl("miss"),
+      status: "ok",
+      metrics: okMetrics,
+    });
+
+    expect(fetchCoverBytesMock).toHaveBeenCalledTimes(1);
+    const row = await readPost(awemeId);
+    expect(row!.thumbnailBytes).toBeNull();
+    expect(row!.thumbnailContentType).toBeNull();
+    // Graceful: the URL is still stored, so the proxy URL-fallback applies.
+    expect(row!.thumbnailUrl).toBe(cdnUrl("miss"));
+  });
+
+  it("preserves a working cached cover on a later fetch miss (COALESCE, not blank)", async () => {
+    const awemeId = `tk-cache-preserve-${uniq()}`;
+    scriptedCover = { bytes: Buffer.from([9, 9, 9]), contentType: "image/webp" };
+    await writeSnapshot({
+      awemeId,
+      thumbnailUrl: cdnUrl("good"),
+      status: "ok",
+      metrics: okMetrics,
+    });
+
+    // New URL, but the cover fetch now misses → must NOT blank the prior cache.
+    scriptedCover = null;
+    await writeSnapshot({ awemeId, thumbnailUrl: cdnUrl("new"), status: "ok", metrics: okMetrics });
+
+    const row = await readPost(awemeId);
+    expect(row!.thumbnailBytes).toEqual(Buffer.from([9, 9, 9]));
+    expect(row!.thumbnailContentType).toBe("image/webp");
+  });
+
+  it("does not fetch when the incoming thumbnail_url is null", async () => {
+    const awemeId = `tk-cache-nullurl-${uniq()}`;
+    await writeSnapshot({ awemeId, thumbnailUrl: null, status: "ok", metrics: okMetrics });
+    expect(fetchCoverBytesMock).not.toHaveBeenCalled();
+    const row = await readPost(awemeId);
+    expect(row!.thumbnailBytes).toBeNull();
+  });
+});
+
+// The proxy route: cached bytes win (no upstream fetch); fall back to the URL
+// fetch when bytes are absent. We mount the route on a Hono app and stub global
+// fetch so we can assert whether the upstream CDN was contacted.
+const { Hono } = await import("hono");
+const { tiktokThumbnailRoutes } =
+  await import("../../src/lib/sources/tiktok/server/thumbnail-proxy.js");
+
+function buildApp() {
+  const app = new Hono();
+  app.route("/api", tiktokThumbnailRoutes);
+  return app;
+}
+
+describe("tiktok thumbnail proxy — serves cached bytes", () => {
+  it("serves cached bytes WITHOUT an upstream fetch when bytes are present", async () => {
+    const awemeId = `tk-proxy-cached-${uniq()}`;
+    const bytes = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x10, 0x20]);
+    await db.insert(tiktokPosts).values({
+      awemeId,
+      thumbnailUrl: cdnUrl("c"),
+      thumbnailBytes: bytes,
+      thumbnailContentType: "image/jpeg",
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const res = await buildApp().request(`/api/tiktok/thumbnail/${awemeId}`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/jpeg");
+    expect(res.headers.get("cache-control")).toBe("private, max-age=3600");
+    expect(Buffer.from(await res.arrayBuffer())).toEqual(bytes);
+    // The whole point: expiry-proof, no upstream CDN contact.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it("falls back to the URL fetch when cached bytes are absent (legacy row)", async () => {
+    const awemeId = `tk-proxy-legacy-${uniq()}`;
+    await db
+      .insert(tiktokPosts)
+      .values({ awemeId, thumbnailUrl: cdnUrl("legacy"), thumbnailBytes: null });
+
+    const upstreamBytes = new Uint8Array([0x01, 0x02, 0x03]);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(upstreamBytes, { status: 200, headers: { "content-type": "image/webp" } }),
+      );
+    const res = await buildApp().request(`/api/tiktok/thumbnail/${awemeId}`);
+
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]![0]).toBe(cdnUrl("legacy"));
+    fetchSpy.mockRestore();
+  });
+
+  it("404s an unknown post (no bytes, no URL)", async () => {
+    const res = await buildApp().request(`/api/tiktok/thumbnail/tk-proxy-unknown-${uniq()}`);
+    expect(res.status).toBe(404);
+  });
+
+  it("host guard still rejects a non-tiktokcdn URL on the fallback path", async () => {
+    const awemeId = `tk-proxy-evil-${uniq()}`;
+    await db
+      .insert(tiktokPosts)
+      .values({ awemeId, thumbnailUrl: "https://evil.example.com/x.awebp", thumbnailBytes: null });
+    // No cached bytes → resolveTikTokThumbnailUrl rejects the host → 404, never fetched.
+    expect(await resolveTikTokThumbnailUrl(awemeId)).toBeNull();
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const res = await buildApp().request(`/api/tiktok/thumbnail/${awemeId}`);
+    expect(res.status).toBe(404);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- **Why:** `/api/tiktok/thumbnail/:postId` 502s in prod because the proxy re-fetches the stored `tiktok_posts.thumbnail_url` — a tiktokcdn **signed** URL (`x-expires`) that expires in hours, while the account poll is **daily**. So most cover loads hit a 403 from tiktokcdn → 502 (the diagnostic `tiktok thumbnail proxy: upstream non-ok status:403` WARN already confirmed this).
- **Fix:** cache the cover image **bytes** at poll time (while the signed URL is still fresh) and serve them from the proxy directly — expiry-proof, zero per-view provider cost (the byte-fetch hits the public tiktokcdn, no ScrapeCreators credit).
- **Scope:** TikTok only. The 2026-06-14 audit showed 502s on the TikTok route but **none** on `/api/instagram/thumbnail/:postId`, so IG's byte-identical proxy is not broken and is **not touched**. The byte-fetch is a small reusable helper (`fetchCoverBytes`) so IG could adopt it later.

## What changed

1. **Schema + migration `0069`:** two nullable columns on `tiktok_posts` — `thumbnail_bytes bytea` + `thumbnail_content_type text` (Drizzle `customType` bridge; generated, never hand-written). Journal `when=1781437055971` (> the prior max 0068=1781363235555). `pnpm db:check` clean.
2. **`fetchCoverBytes(url)`** (thumbnail-proxy.ts): host-validated against the shared `isTikTokCdnHost` allow-list, `redirect:"manual"`, `AbortSignal.timeout`, returns `null` on any non-ok / network / non-image — best-effort, never throws into the caller.
3. **`writeSnapshot`** caches the bytes only when the incoming `thumbnail_url` **changed** or the cache is empty (no needless re-download of an unchanged cover). The fetch is best-effort + **outside** the row tx (never hold a lock on a CDN fetch); a miss leaves bytes `null` + keeps the URL (graceful — the proxy URL-fallback still applies). `COALESCE` preserves a working cache on a later miss.
4. **Proxy** serves cached bytes first (status 200, stored content-type, `cache-control: private, max-age=3600`, **no upstream fetch**); falls back to the existing URL-fetch path (incl. the diagnostic WARN) for legacy rows not yet re-polled.
5. The bytea is read **only** by the proxy — feed-enrichment + DTO still select `thumbnail_url` only, never the blob (the write-path prior-row probe also uses `IS NOT NULL`, not the blob).

## Test plan

New `tests/integration/tiktok-thumbnail-bytes-cache.test.ts` (real Postgres, mocks only the cover fetch): fresh URL caches bytes+content_type; unchanged URL on re-poll does **not** re-fetch; changed URL re-fetches; a fetch miss leaves bytes null + keeps the URL; a later miss COALESCE-preserves the prior cache; the proxy serves cached bytes **without** an upstream fetch; falls back to the URL-fetch when bytes absent; the host guard rejects a non-tiktokcdn URL.

Local full CI gates (Windows; CI runs Linux):
- `pnpm typecheck` — 0 errors (pre-existing svelte `state_referenced_locally` warnings only).
- `pnpm exec eslint <touched>` / `pnpm exec prettier --check <touched>` — clean.
- `pnpm test:unit` — 965/965 (one cold-start 5000ms timeout in an unrelated `youtube-quota-tracker` test; passes 16/16 in isolation).
- `pnpm test:integration` (clean single run) — **1233 passed, 7 failed, 4 skipped**. All 7 failures are in `twitter-not-configured.test.ts` + `twitter-walker.test.ts` — the **known local-only artifact**: dev `.env` sets `TWITTER_PROVIDER`, so twitter is "configured" locally (CI runs without it → passes). **Every tiktok-* and instagram-* file passed**, proving the TikTok change works end-to-end and IG is untouched.
- `pnpm db:check` — clean.

## Self-review

- **No-denorm (AGENTS.md):** bytes/content-type are intrinsic to the post's own cover, not a renameable value owned by another table — no denormalization.
- **Validate at boundaries:** `fetchCoverBytes` host-validates + content-type-checks the external response; no defensive re-validation past that.
- **Zero-budget:** byte-fetch hits the public CDN (no provider credit); DB bytea store rides Postgres + backups (covers ~10-50KB, negligible for indie scale) — no object storage / new volume.
- **Hot read path untouched:** the bytea is loaded only by the proxy; feed-enrichment + DTO never select it.
- **Forward-only migration**, documented rollback in the migration header.

Closes the prod TikTok thumbnail 502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)