### PR TITLE
chore(observability): fix grafana-audit false positives in Loki counts and 5xx flag

### DIFF
--- a/.claude/commands/grafana-audit.md
+++ b/.claude/commands/grafana-audit.md
@@ -48,8 +48,10 @@ Default URL: `https://neotolis-diary.dev/grafana`. The browser opens for the use
 
 ### Loki
 - Auto-discovers available labels and their values (no hardcoded selectors)
-- Error logs count (level >= 50) over 24h
+- Error logs count (level >= 50, parse-error lines excluded via `__error__=""`) over 24h
+- `escapedHeadersSent24h` — raw `ERR_HTTP_HEADERS_SENT` lines (the known deferred bug prints raw, bypassing Pino, so `level >= 50` never sees it)
 - Total log volume over 1h
+- Retention is ~7 days — anything older is gone regardless of query window
 
 ### Alerts
 - Current firing/pending alert state from Grafana Alertmanager API
@@ -59,9 +61,9 @@ Default URL: `https://neotolis-diary.dev/grafana`. The browser opens for the use
 After the script finishes, read `scripts/grafana-audit-output/report.json` and the screenshots. Look for:
 
 ### Red flags (act now)
-- **5xx errors present** (`error_rate_5m` non-empty) — check `errors_by_route` for which routes
+- **5xx errors present** (`error_rate_5m` value > 0 — a zero-valued series just means a 5xx happened at some point since process start) — check `errors_by_route` for which routes
 - **Alerts firing** — check `alerts` array, look at `status.state` and `labels.alertname`
-- **Loki error logs** (`errorLogs24h.totalLines > 0`) — investigate via Grafana Explore
+- **Loki error logs** (`errorLogs24h > 0`, a matched-line count via `count_over_time`) — investigate via Grafana Explore
 - **Queue depth > 0 in `active`** for extended periods — jobs stuck
 
 ### Yellow flags (monitor)
@@ -71,7 +73,7 @@ After the script finishes, read `scripts/grafana-audit-output/report.json` and t
 - **Loki 0 lines** — Promtail may not be shipping logs; check `docker logs diary-promtail-1`
 
 ### Green (healthy)
-- `error_rate_5m` empty (no 5xx)
+- `error_rate_5m` zero (no current 5xx)
 - `latency_p95` < 200ms
 - All queues at 0
 - Memory trend < +10% per 24h

--- a/scripts/grafana-audit.mjs
+++ b/scripts/grafana-audit.mjs
@@ -44,17 +44,16 @@ async function lokiLabelValues(page, label) {
   return status === 200 ? body.data : [];
 }
 
-async function lokiQuery(page, expr, rangeSeconds = 86400, limit = 100) {
+// Counts MATCHED lines via count_over_time. Do not report the query stats'
+// totalLinesProcessed — that is how many lines the engine scanned, not how
+// many matched, and it inflates with every broad line filter.
+async function lokiCount(page, expr, rangeSeconds = 86400) {
   const now = Math.floor(Date.now() / 1000);
-  const start = now - rangeSeconds;
-  const url = `${GRAFANA_URL}/api/datasources/proxy/uid/loki/loki/api/v1/query_range?query=${encodeURIComponent(expr)}&start=${start}000000000&end=${now}000000000&limit=${limit}`;
+  const q = `sum(count_over_time(${expr} [${rangeSeconds}s]))`;
+  const url = `${GRAFANA_URL}/api/datasources/proxy/uid/loki/loki/api/v1/query?query=${encodeURIComponent(q)}&time=${now}`;
   const { status, body } = await fetchJson(page, url);
   if (status !== 200) return { error: status };
-  return {
-    entries: body.data?.result?.length ?? 0,
-    totalLines: body.data?.stats?.summary?.totalLinesProcessed ?? 0,
-    totalBytes: body.data?.stats?.summary?.totalBytesProcessed ?? 0,
-  };
+  return Number(body.data?.result?.[0]?.value?.[1] ?? 0);
 }
 
 function extractValue(result) {
@@ -145,18 +144,25 @@ async function main() {
     ? '{service=~"' + report.loki.labels.service.join("|") + '"}'
     : '{service=~".+"}';
 
-  report.loki.errorLogs24h = await lokiQuery(
+  // __error__="" must come AFTER the numeric comparison: LogQL keeps lines whose
+  // label failed to parse as a number (nginx logs level:"info"), so without the
+  // trailing filter every nginx access-log line counts as an "error".
+  report.loki.errorLogs24h = await lokiCount(
     page,
-    `${serviceSelector} |= "level" | json | level >= 50`,
+    `${serviceSelector} |= "level" | json | level >= 50 | __error__=""`,
   );
-  console.log(
-    `  error logs (24h): ${report.loki.errorLogs24h.totalLines} lines, ${report.loki.errorLogs24h.totalBytes} bytes`,
-  );
+  console.log(`  error logs (24h): ${report.loki.errorLogs24h} lines`);
 
-  report.loki.allLogs1h = await lokiQuery(page, `${serviceSelector}`, 3600, 5);
-  console.log(
-    `  all logs (1h): ${report.loki.allLogs1h.totalLines} lines, ${report.loki.allLogs1h.totalBytes} bytes`,
+  // ERR_HTTP_HEADERS_SENT is printed raw by @hono/node-server (bypasses Pino),
+  // so the level>=50 query never sees it — grep the raw line instead.
+  report.loki.escapedHeadersSent24h = await lokiCount(
+    page,
+    `${serviceSelector} |= "ERR_HTTP_HEADERS_SENT"`,
   );
+  console.log(`  ERR_HTTP_HEADERS_SENT (24h): ${report.loki.escapedHeadersSent24h} lines`);
+
+  report.loki.allLogs1h = await lokiCount(page, serviceSelector, 3600);
+  console.log(`  all logs (1h): ${report.loki.allLogs1h} lines`);
 
   // --- Alerts ---
   console.log("\n=== Alert State ===");
@@ -194,8 +200,10 @@ async function main() {
   const rssMB = rss?.[0]?.value ? (parseFloat(rss[0].value) / 1e6).toFixed(1) : "?";
   const p95 = report.prometheus.latency_p95;
   const p95ms = p95?.[0]?.value ? (parseFloat(p95[0].value) * 1000).toFixed(0) : "?";
+  // A zero-valued series still exists once any 5xx was ever counted — flag on
+  // the rate's value, not on the series' presence.
   const errRate = report.prometheus.error_rate_5m;
-  const hasErrors = Array.isArray(errRate) && errRate.length > 0;
+  const hasErrors = Array.isArray(errRate) && errRate.some((r) => parseFloat(r.value) > 0);
   const firingAlerts = Array.isArray(report.alerts)
     ? report.alerts.filter((a) => a.status?.state === "active").length
     : "?";
@@ -208,7 +216,7 @@ async function main() {
   console.log(`  Latency p95: ${p95ms} ms`);
   console.log(`  5xx errors:  ${hasErrors ? "YES" : "none"}`);
   console.log(`  Alerts:      ${firingAlerts} firing`);
-  console.log(`  Loki logs:   ${report.loki.allLogs1h.totalLines} lines (1h)`);
+  console.log(`  Loki logs:   ${report.loki.allLogs1h} lines (1h)`);
   if (report.memoryTrend.deltaMB) {
     console.log(
       `  Memory 24h:  ${report.memoryTrend.deltaMB > 0 ? "+" : ""}${report.memoryTrend.deltaMB} MB (${report.memoryTrend.deltaPercent}%)`,


### PR DESCRIPTION
## Summary
- The 2026-07-20 prod audit "found" 201 error lines and flagged 5xx — all three headline numbers were lies of the tooling, not prod problems:
  - **Error count matched nginx access logs.** LogQL keeps lines whose label fails a numeric parse (`level:"info"` vs `level >= 50`) — parse-error lines need an explicit `| __error__=""` AFTER the comparison.
  - **Counts reported `totalLinesProcessed`** — lines the engine *scanned*, not matches (a raw grep query reported 4734 "lines" when 4 matched). Replaced with `sum(count_over_time(...))`.
  - **"5xx errors: YES" fired on a zero-valued series** that exists because a 5xx ever happened since process start. Now flags on value > 0.
- Adds a separate raw `ERR_HTTP_HEADERS_SENT` counter — the known deferred bug prints raw via @hono/node-server (bypasses Pino), so the `level>=50` query structurally cannot see it.
- Skill doc (`.claude/commands/grafana-audit.md`) updated to the new field shapes + a Loki ~7d retention note.

## Test plan
- Verified live against prod Grafana: `error logs (24h): 0`, `ERR_HTTP_HEADERS_SENT (24h): 4`, `all logs (1h): 467`, `5xx errors: none` — each cross-checked with independent manual LogQL queries.
- `pnpm typecheck` — 0 errors; `pnpm lint` — clean; `pnpm test:unit` — 973 passed; `pnpm test:integration` — 1234 passed (7 known-local twitter env-artifact failures, green on CI).

## Self-review
- Principles/Don'ts walk: dev tooling only (`scripts/` + skill doc) — no app code, env reads, DB, or route surface. No drift.
- CI gate honesty: n/a (no CI assertions touched); the load-bearing check is the live prod verification above.
- Docs drift: skill doc updated in the same commit.

## Self-review (second pass)
- Separate fresh-context agent verified: commit scope (2 files), LogQL validity of `count_over_time` with pipeline + seconds range, instant-query URL shape vs the Loki proxy, `__error__=""` placement after the comparison, empty-vector → 0 mapping, 5xx flag crash-safety, doc consistency. Verdict: LGTM.
- Known P2 (pre-existing shape, left as-is): on a Loki outage `lokiCount` returns `{error: status}`, so report fields become objects; the console output makes this visible.

Closes the tooling half of the 2026-07-20 audit findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)